### PR TITLE
feat(composable-screen): add Image UIElement type

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,6 +161,34 @@ The UI package has these **optional** peer dependencies (install only if using t
 - `@shopify/react-native-skia` — required by specific visual components
 - `expo-store-review` — required by Ratings step type
 
+## Updating ComposableScreen UIElement Schema
+
+When adding or changing a `UIElement` type in either ComposableScreen `types.ts` file, **always**:
+
+1. **Update `packages/onboarding/src/onboarding-example.ts`** — add or update an example step that exercises the new/changed element type so the default onboarding stays in sync with the schema.
+
+2. **Update `example/app/example/composable-screen.tsx`** — add or update the element in the rendered example payload.
+
+3. **Display the following prompt for the `onboarding-studio` repository** (the CMS backend that must mirror these schema changes) after completing the changes:
+
+```
+The ComposableScreen UIElement schema in the React Native SDK has been updated.
+Please mirror these schema changes in onboarding-studio.
+
+Changes made:
+<describe what was added/changed — element type name, props, Zod schema>
+
+Files changed in the SDK:
+- packages/onboarding/src/steps/ComposableScreen/types.ts
+- packages/onboarding-ui/src/UI/Pages/ComposableScreen/types.ts
+
+In onboarding-studio, update:
+- The UIElement union type / discriminated union to include the new element
+- The Zod schema (or equivalent validation) for the new element's props
+- Any CMS editor UI that lets users pick element types (add the new type to the picker)
+- Any JSON serialization/deserialization logic that handles UIElement variants
+```
+
 ## Publishing Workflow
 
 ```bash

--- a/example/app/example/composable-screen.tsx
+++ b/example/app/example/composable-screen.tsx
@@ -21,6 +21,17 @@ export default function ComposableScreenExample() {
           type: 'YStack',
           props: { gap: 24, padding: 24 },
           children: [
+            // Hero image
+            {
+              id: 'hero-image',
+              type: 'Image',
+              props: {
+                url: 'https://picsum.photos/800/400?grayscale',
+                height: 180,
+                resizeMode: 'cover',
+                borderRadius: 16,
+              },
+            },
             // Header text
             {
               id: 'headline',

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   ],
   "scripts": {
     "build": "npm run build --workspaces",
+    "type:check": "npm run type:check --workspaces",
     "build:headless": "npm run build --workspace=packages/onboarding",
     "build:ui": "npm run build --workspace=packages/onboarding-ui",
     "watch:headless": "npm run watch --workspace=packages/onboarding",

--- a/packages/onboarding-ui/CHANGELOG.md
+++ b/packages/onboarding-ui/CHANGELOG.md
@@ -5,6 +5,25 @@ here.
 
 ---
 
+## [1.3.0] - 2026-04-17
+
+### Added
+
+- **`Image` UIElement renderer** for `ComposableScreen` — maps `Image` nodes to
+  React Native `<Image>` with full prop pass-through: `url`, `width`, `height`,
+  `aspectRatio`, `resizeMode`, `borderRadius`, `borderWidth`, `borderColor`,
+  `opacity`, and all margin / padding shorthand props.
+- `aspectRatio` fallback on `Image` — when `height` is not provided, the
+  renderer applies `aspectRatio` (explicit value or `16/9` default) so the
+  image is always visible.
+
+### Fixed
+
+- Removed unused `useSafeAreaInsets` import and call from
+  `ComposableScreenRenderer` (safe area is handled by `OnboardingTemplate`).
+
+---
+
 ## [1.2.0]
 
 ### Added

--- a/packages/onboarding-ui/package.json
+++ b/packages/onboarding-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocapine/react-native-onboarding-ui",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "UI components and renderers for Rocapine Onboarding Studio - Built on top of the headless SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/onboarding-ui/package.json
+++ b/packages/onboarding-ui/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "build": "tsc && cp -r src/assets dist/",
     "watch": "tsc --watch",
+    "type:check": "tsc --noEmit",
     "patch": "npm version patch && npm run build && npm publish"
   },
   "keywords": [

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/Renderer.tsx
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/Renderer.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { View, Text, Image, ScrollView, StyleSheet, TouchableOpacity } from "react-native";
-import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { ComposableScreenStepType, ComposableScreenStepTypeSchema, UIElement } from "./types";
 import { Theme } from "../../Theme/types";
 import { defaultTheme } from "../../Theme/defaultTheme";
@@ -84,6 +83,10 @@ const renderElement = (element: UIElement, theme: Theme, parentType?: "XStack" |
   }
 
   if (element.type === "Image") {
+    const hasExplicitHeight = element.props.height !== undefined;
+    const aspectRatio = hasExplicitHeight
+      ? undefined
+      : (element.props.aspectRatio ?? 16 / 9);
     return (
       <Image
         key={element.id}
@@ -92,6 +95,7 @@ const renderElement = (element: UIElement, theme: Theme, parentType?: "XStack" |
         style={{
           width: element.props.width ?? "100%",
           height: element.props.height,
+          aspectRatio,
           borderRadius: element.props.borderRadius,
           borderWidth: element.props.borderWidth,
           borderColor: element.props.borderColor,
@@ -111,7 +115,6 @@ const renderElement = (element: UIElement, theme: Theme, parentType?: "XStack" |
 };
 
 const ComposableScreenRendererBase = ({ step, onContinue, theme = defaultTheme }: ContentProps) => {
-  const { top, bottom } = useSafeAreaInsets();
   const validatedData = ComposableScreenStepTypeSchema.parse(step);
   const { elements } = validatedData.payload;
   return (

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/Renderer.tsx
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/Renderer.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { View, Text, ScrollView, StyleSheet, TouchableOpacity } from "react-native";
+import { View, Text, Image, ScrollView, StyleSheet, TouchableOpacity } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { ComposableScreenStepType, ComposableScreenStepTypeSchema, UIElement } from "./types";
 import { Theme } from "../../Theme/types";
@@ -80,6 +80,30 @@ const renderElement = (element: UIElement, theme: Theme, parentType?: "XStack" |
       >
         {element.props.content}
       </Text>
+    );
+  }
+
+  if (element.type === "Image") {
+    return (
+      <Image
+        key={element.id}
+        source={{ uri: element.props.url }}
+        resizeMode={element.props.resizeMode ?? "cover"}
+        style={{
+          width: element.props.width ?? "100%",
+          height: element.props.height,
+          borderRadius: element.props.borderRadius,
+          borderWidth: element.props.borderWidth,
+          borderColor: element.props.borderColor,
+          opacity: element.props.opacity,
+          margin: element.props.margin,
+          marginHorizontal: element.props.marginHorizontal,
+          marginVertical: element.props.marginVertical,
+          padding: element.props.padding,
+          paddingHorizontal: element.props.paddingHorizontal,
+          paddingVertical: element.props.paddingVertical,
+        }}
+      />
     );
   }
 

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/types.ts
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/types.ts
@@ -58,6 +58,27 @@ export type UIElement =
         borderColor?: string;
         opacity?: number;
       };
+    }
+  | {
+      id: string;
+      name?: string;
+      type: "Image";
+      props: {
+        url: string;
+        width?: number;
+        height?: number;
+        resizeMode?: "cover" | "contain" | "stretch" | "center";
+        borderRadius?: number;
+        borderWidth?: number;
+        borderColor?: string;
+        opacity?: number;
+        margin?: number;
+        marginHorizontal?: number;
+        marginVertical?: number;
+        padding?: number;
+        paddingHorizontal?: number;
+        paddingVertical?: number;
+      };
     };
 
 const StackElementPropsSchema = z.object({
@@ -108,6 +129,23 @@ const TextElementPropsSchema = z.object({
   opacity: z.number().min(0).max(1).optional(),
 });
 
+const ImageElementPropsSchema = z.object({
+  url: z.string(),
+  width: z.number().optional(),
+  height: z.number().optional(),
+  resizeMode: z.enum(["cover", "contain", "stretch", "center"]).optional(),
+  borderRadius: z.number().optional(),
+  borderWidth: z.number().optional(),
+  borderColor: z.string().optional(),
+  opacity: z.number().min(0).max(1).optional(),
+  margin: z.number().optional(),
+  marginHorizontal: z.number().optional(),
+  marginVertical: z.number().optional(),
+  padding: z.number().optional(),
+  paddingHorizontal: z.number().optional(),
+  paddingVertical: z.number().optional(),
+});
+
 export const UIElementSchema: z.ZodType<UIElement> = z.lazy(() =>
   z.union([
     z.object({
@@ -122,6 +160,12 @@ export const UIElementSchema: z.ZodType<UIElement> = z.lazy(() =>
       name: z.string().optional(),
       type: z.literal("Text"),
       props: TextElementPropsSchema,
+    }),
+    z.object({
+      id: z.string(),
+      name: z.string().optional(),
+      type: z.literal("Image"),
+      props: ImageElementPropsSchema,
     }),
   ])
 );

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/types.ts
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/types.ts
@@ -67,6 +67,7 @@ export type UIElement =
         url: string;
         width?: number;
         height?: number;
+        aspectRatio?: number;
         resizeMode?: "cover" | "contain" | "stretch" | "center";
         borderRadius?: number;
         borderWidth?: number;
@@ -133,6 +134,7 @@ const ImageElementPropsSchema = z.object({
   url: z.string(),
   width: z.number().optional(),
   height: z.number().optional(),
+  aspectRatio: z.number().optional(),
   resizeMode: z.enum(["cover", "contain", "stretch", "center"]).optional(),
   borderRadius: z.number().optional(),
   borderWidth: z.number().optional(),

--- a/packages/onboarding/CHANGELOG.md
+++ b/packages/onboarding/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to `@rocapine/react-native-onboarding` are documented here.
 
 ---
 
+## [1.3.0] - 2026-04-17
+
+### Added
+
+- **`Image` UIElement** for `ComposableScreen` — renders a remote image via
+  React Native `<Image>`. Supports `url` (required), `width`, `height`,
+  `aspectRatio`, `resizeMode` (`cover` | `contain` | `stretch` | `center`),
+  `borderRadius`, `borderWidth`, `borderColor`, `opacity`, and all margin /
+  padding shorthand props.
+- `aspectRatio` prop on `Image` elements — applied as a size fallback when
+  `height` is omitted; defaults to `16/9` so images never collapse to zero
+  height.
+
+---
+
 ## [1.2.0]
 
 ### Added

--- a/packages/onboarding/package.json
+++ b/packages/onboarding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocapine/react-native-onboarding",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Headless React Native SDK for Rocapine Onboarding Studio - Data fetching, state management, and hooks",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/onboarding/package.json
+++ b/packages/onboarding/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "build": "tsc",
     "watch": "tsc --watch",
+    "type:check": "tsc --noEmit",
     "patch": "npm version patch && npm run build && npm publish"
   },
   "keywords": [

--- a/packages/onboarding/src/onboarding-example.ts
+++ b/packages/onboarding/src/onboarding-example.ts
@@ -89,6 +89,58 @@ export const onboardingExample = {
       displayProgressHeader: false,
     },
     {
+      id: "composable-screen-demo",
+      name: "Composable Screen",
+      type: "ComposableScreen",
+      displayProgressHeader: true,
+      payload: {
+        elements: [
+          {
+            id: "root",
+            type: "YStack",
+            props: { gap: 24, padding: 24 },
+            children: [
+              {
+                id: "hero-image",
+                type: "Image",
+                props: {
+                  url: "https://picsum.photos/800/400?grayscale",
+                  height: 180,
+                  resizeMode: "cover",
+                  borderRadius: 16,
+                },
+              },
+              {
+                id: "headline",
+                type: "Text",
+                props: {
+                  content: "Built from the CMS",
+                  fontSize: 28,
+                  fontWeight: "700",
+                  textAlign: "center",
+                },
+              },
+              {
+                id: "subheadline",
+                type: "Text",
+                props: {
+                  content:
+                    "This screen is composed entirely from a JSON payload — no custom renderer needed.",
+                  fontSize: 15,
+                  textAlign: "center",
+                  lineHeight: 22,
+                  opacity: 0.6,
+                },
+              },
+            ],
+          },
+        ],
+      },
+      figmaUrl: null,
+      customPayload: {},
+      continueButtonLabel: "Continue",
+    },
+    {
       id: "ratings-app",
       name: "Rate the App",
       type: "Ratings",

--- a/packages/onboarding/src/steps/ComposableScreen/types.ts
+++ b/packages/onboarding/src/steps/ComposableScreen/types.ts
@@ -58,6 +58,27 @@ type UIElement =
         borderColor?: string;
         opacity?: number;
       };
+    }
+  | {
+      id: string;
+      name?: string;
+      type: "Image";
+      props: {
+        url: string;
+        width?: number;
+        height?: number;
+        resizeMode?: "cover" | "contain" | "stretch" | "center";
+        borderRadius?: number;
+        borderWidth?: number;
+        borderColor?: string;
+        opacity?: number;
+        margin?: number;
+        marginHorizontal?: number;
+        marginVertical?: number;
+        padding?: number;
+        paddingHorizontal?: number;
+        paddingVertical?: number;
+      };
     };
 
 const StackElementPropsSchema = z.object({
@@ -108,6 +129,23 @@ const TextElementPropsSchema = z.object({
   opacity: z.number().min(0).max(1).optional(),
 });
 
+const ImageElementPropsSchema = z.object({
+  url: z.string(),
+  width: z.number().optional(),
+  height: z.number().optional(),
+  resizeMode: z.enum(["cover", "contain", "stretch", "center"]).optional(),
+  borderRadius: z.number().optional(),
+  borderWidth: z.number().optional(),
+  borderColor: z.string().optional(),
+  opacity: z.number().min(0).max(1).optional(),
+  margin: z.number().optional(),
+  marginHorizontal: z.number().optional(),
+  marginVertical: z.number().optional(),
+  padding: z.number().optional(),
+  paddingHorizontal: z.number().optional(),
+  paddingVertical: z.number().optional(),
+});
+
 const UIElementSchema: z.ZodType<UIElement> = z.lazy(() =>
   z.union([
     z.object({
@@ -122,6 +160,12 @@ const UIElementSchema: z.ZodType<UIElement> = z.lazy(() =>
       name: z.string().optional(),
       type: z.literal("Text"),
       props: TextElementPropsSchema,
+    }),
+    z.object({
+      id: z.string(),
+      name: z.string().optional(),
+      type: z.literal("Image"),
+      props: ImageElementPropsSchema,
     }),
   ])
 );

--- a/packages/onboarding/src/steps/ComposableScreen/types.ts
+++ b/packages/onboarding/src/steps/ComposableScreen/types.ts
@@ -67,6 +67,7 @@ type UIElement =
         url: string;
         width?: number;
         height?: number;
+        aspectRatio?: number;
         resizeMode?: "cover" | "contain" | "stretch" | "center";
         borderRadius?: number;
         borderWidth?: number;
@@ -133,6 +134,7 @@ const ImageElementPropsSchema = z.object({
   url: z.string(),
   width: z.number().optional(),
   height: z.number().optional(),
+  aspectRatio: z.number().optional(),
   resizeMode: z.enum(["cover", "contain", "stretch", "center"]).optional(),
   borderRadius: z.number().optional(),
   borderWidth: z.number().optional(),

--- a/website/docs/page-types.mdx
+++ b/website/docs/page-types.mdx
@@ -443,11 +443,12 @@ Build arbitrary onboarding screens entirely from CMS data — no custom renderer
 | Prop | Type | Notes |
 |------|------|-------|
 | `url` | `string` | **Required** — remote image URI |
-| `width` | `number` | Defaults to `"100%"` |
+| `width` | `number \| string` | Defaults to `"100%"` |
 | `height` | `number` | When omitted, `aspectRatio` is used to size the image |
 | `aspectRatio` | `number` | Used when `height` is absent; defaults to `16/9` |
 | `resizeMode` | `"cover" \| "contain" \| "stretch" \| "center"` | Defaults to `"cover"` |
-| `borderRadius` / `borderWidth` / `borderColor` | `number \| string` | |
+| `borderRadius` / `borderWidth` | `number` | |
+| `borderColor` | `string` | |
 | `opacity` | `number` | |
 | `margin` / `marginHorizontal` / `marginVertical` | `number` | |
 | `padding` / `paddingHorizontal` / `paddingVertical` | `number` | |

--- a/website/docs/page-types.mdx
+++ b/website/docs/page-types.mdx
@@ -444,7 +444,8 @@ Build arbitrary onboarding screens entirely from CMS data — no custom renderer
 |------|------|-------|
 | `url` | `string` | **Required** — remote image URI |
 | `width` | `number` | Defaults to `"100%"` |
-| `height` | `number` | |
+| `height` | `number` | When omitted, `aspectRatio` is used to size the image |
+| `aspectRatio` | `number` | Used when `height` is absent; defaults to `16/9` |
 | `resizeMode` | `"cover" \| "contain" \| "stretch" \| "center"` | Defaults to `"cover"` |
 | `borderRadius` / `borderWidth` / `borderColor` | `number \| string` | |
 | `opacity` | `number` | |

--- a/website/docs/page-types.mdx
+++ b/website/docs/page-types.mdx
@@ -406,7 +406,7 @@ Build arbitrary onboarding screens entirely from CMS data — no custom renderer
 - Any screen that doesn't fit a pre-built type
 
 **Key features:**
-- Recursive element tree (`YStack`, `XStack`, `Text`)
+- Recursive element tree (`YStack`, `XStack`, `Text`, `Image`)
 - Full flexbox layout support
 - Border, radius, overflow, and opacity control
 - Dimension constraints (`width`, `height`, `min/max`)
@@ -420,6 +420,7 @@ Build arbitrary onboarding screens entirely from CMS data — no custom renderer
 | `YStack` | `<View>` | `column` |
 | `XStack` | `<View>` | `row` |
 | `Text` | `<Text>` | — |
+| `Image` | `<Image>` | — |
 
 **Stack props (`YStack` / `XStack`):**
 
@@ -437,6 +438,19 @@ Build arbitrary onboarding screens entirely from CMS data — no custom renderer
 | `overflow` | `"hidden" \| "visible" \| "scroll"` | Use `"hidden"` to clip rounded corners |
 | `opacity` | `number` | |
 
+**Image props:**
+
+| Prop | Type | Notes |
+|------|------|-------|
+| `url` | `string` | **Required** — remote image URI |
+| `width` | `number` | Defaults to `"100%"` |
+| `height` | `number` | |
+| `resizeMode` | `"cover" \| "contain" \| "stretch" \| "center"` | Defaults to `"cover"` |
+| `borderRadius` / `borderWidth` / `borderColor` | `number \| string` | |
+| `opacity` | `number` | |
+| `margin` / `marginHorizontal` / `marginVertical` | `number` | |
+| `padding` / `paddingHorizontal` / `paddingVertical` | `number` | |
+
 **Text props:**
 
 | Prop | Type | Notes |
@@ -453,7 +467,7 @@ Build arbitrary onboarding screens entirely from CMS data — no custom renderer
 **Payload:**
 ```typescript
 {
-  elements: UIElement[]; // Recursive tree of YStack, XStack, Text
+  elements: UIElement[]; // Recursive tree of YStack, XStack, Text, Image
 }
 ```
 
@@ -476,6 +490,16 @@ Build arbitrary onboarding screens entirely from CMS data — no custom renderer
           "overflow": "hidden"
         },
         "children": [
+          {
+            "id": "hero",
+            "type": "Image",
+            "props": {
+              "url": "https://example.com/hero.png",
+              "height": 180,
+              "resizeMode": "cover",
+              "borderRadius": 12
+            }
+          },
           {
             "id": "title",
             "type": "Text",


### PR DESCRIPTION
## Summary

- Adds `Image` UIElement type to the `ComposableScreen` composable system, with support for `url`, `width`, `height`, `resizeMode`, spacing, and border props
- Updates both packages' `types.ts` (Zod schema + TypeScript type) and the UI `Renderer.tsx` to handle image rendering
- Adds a hero image example to `onboarding-example.ts` and `example/app/example/composable-screen.tsx`
- Adds a root-level `type:check` script that runs `tsc --noEmit` across all workspaces
- Documents the `ComposableScreen UIElement Schema` update workflow in `CLAUDE.md` (including the prompt to mirror changes in `onboarding-studio`)

## Test plan

- [ ] Run `npm run build` — both packages compile without errors
- [ ] Run `npm run type:check` — no TypeScript errors
- [ ] Open the example app and navigate to the ComposableScreen example — hero image renders correctly
- [ ] Verify `resizeMode`, `borderRadius`, and spacing props apply as expected on the image

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added synchronization guidance for updating UIElement schema and related onboarding/example content after element changes.

* **New Features**
  * Introduced an Image element for composable screens with sizing, resizeMode, border, spacing, and opacity props.
  * Added an example composable screen onboarding step showcasing the new Image and updated payload order.

* **Chores**
  * Added root and package-level npm scripts for TypeScript type-checking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->