### PR TITLE
feat(composable-screen): add Icon and Video UIElement types (#30)

### DIFF
--- a/example/app.json
+++ b/example/app.json
@@ -44,7 +44,8 @@
       ],
       "expo-font",
       "expo-web-browser",
-      "expo-image"
+      "expo-image",
+      "expo-video"
     ],
     "experiments": {
       "typedRoutes": true,

--- a/example/app/example/composable-screen.tsx
+++ b/example/app/example/composable-screen.tsx
@@ -54,6 +54,30 @@ export default function ComposableScreenExample() {
                 borderRadius: 16,
               },
             },
+            // Icon element
+            {
+              id: 'hero-icon',
+              type: 'Icon',
+              props: {
+                name: 'Circle',
+                size: 48,
+                color: '#007AFF',
+                marginVertical: 8,
+              },
+            },
+            // Video element
+            {
+              id: 'hero-video',
+              type: 'Video',
+              props: {
+                url: 'https://lorem.video/720p',
+                height: 200,
+                borderRadius: 12,
+                controls: false,
+                muted: true,
+                autoPlay: true,
+              },
+            },
             // Header text
             {
               id: 'headline',

--- a/example/package.json
+++ b/example/package.json
@@ -43,6 +43,7 @@
     "expo-status-bar": "~55.0.5",
     "expo-symbols": "~55.0.7",
     "expo-system-ui": "~55.0.15",
+    "expo-video": "~55.0.15",
     "expo-web-browser": "~55.0.14",
     "lottie-react-native": "~7.3.4",
     "react": "19.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
         "expo-status-bar": "~55.0.5",
         "expo-symbols": "~55.0.7",
         "expo-system-ui": "~55.0.15",
+        "expo-video": "~55.0.15",
         "expo-web-browser": "~55.0.14",
         "lottie-react-native": "~7.3.4",
         "react": "19.2.0",
@@ -7315,6 +7316,17 @@
         "expo": "*"
       }
     },
+    "node_modules/expo-video": {
+      "version": "55.0.15",
+      "resolved": "https://registry.npmjs.org/expo-video/-/expo-video-55.0.15.tgz",
+      "integrity": "sha512-4GEEiTH5hGsyEt7Chsiv8IS4ioYuEJ4Wc+tjbf8NiGvAw0bQquN41zWmYLnwgzPoU3tCr8SaACgEvJRc3+FcWw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
+      }
+    },
     "node_modules/expo-web-browser": {
       "version": "55.0.14",
       "resolved": "https://registry.npmjs.org/expo-web-browser/-/expo-web-browser-55.0.14.tgz",
@@ -13532,6 +13544,7 @@
         "@types/react": "*",
         "expo-router": ">=3.0.0",
         "expo-store-review": "*",
+        "expo-video": "*",
         "lottie-react-native": "*",
         "react": "*",
         "react-native": "*",
@@ -13546,6 +13559,9 @@
           "optional": true
         },
         "expo-store-review": {
+          "optional": true
+        },
+        "expo-video": {
           "optional": true
         },
         "lottie-react-native": {

--- a/packages/onboarding-ui/CHANGELOG.md
+++ b/packages/onboarding-ui/CHANGELOG.md
@@ -5,6 +5,21 @@ here.
 
 ---
 
+## [1.5.0] - 2026-04-21
+
+### Added
+
+- **`Icon` element renderer** — renders `Icon` UIElements using
+  `lucide-react-native` (bundled, no extra install needed). Supports `name`,
+  `size`, `color`, `strokeWidth`, and all `BaseBoxProps`. Unknown icon names
+  render nothing rather than crashing.
+- **`Video` element renderer** — renders `Video` UIElements via `expo-video`
+  (optional peer dep). Supports `url`, `autoPlay`, `loop`, `muted`, `controls`,
+  and all `BaseBoxProps`. Shows an install-hint placeholder if `expo-video` is
+  absent. `expo-video` added as optional peer dependency.
+
+---
+
 ## [1.4.0] - 2026-04-21
 
 ### Added

--- a/packages/onboarding-ui/package.json
+++ b/packages/onboarding-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocapine/react-native-onboarding-ui",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "UI components and renderers for Rocapine Onboarding Studio - Built on top of the headless SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -43,7 +43,7 @@
   },
   "peerDependencies": {
     "@react-native-picker/picker": "*",
-    "@rocapine/react-native-onboarding": "^1.4.0",
+    "@rocapine/react-native-onboarding": "^1.5.0",
     "@shopify/react-native-skia": ">=1.0.0",
     "@tanstack/react-query": ">=5.0.0",
     "@types/react": "*",

--- a/packages/onboarding-ui/package.json
+++ b/packages/onboarding-ui/package.json
@@ -53,7 +53,8 @@
     "react": "*",
     "react-native": "*",
     "react-native-safe-area-context": "*",
-    "rive-react-native": "*"
+    "rive-react-native": "*",
+    "expo-video": "*"
   },
   "peerDependenciesMeta": {
     "@react-native-picker/picker": {
@@ -69,6 +70,9 @@
       "optional": true
     },
     "rive-react-native": {
+      "optional": true
+    },
+    "expo-video": {
       "optional": true
     }
   },

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/Renderer.tsx
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/Renderer.tsx
@@ -17,9 +17,11 @@ let LottieView: React.ComponentType<{
 try {
   LottieView = require("lottie-react-native").default;
 } catch {
-  // lottie-react-native not installed - will show error if Lottie is used
+  // lottie-react-native not installed
 }
 
+// Metro cannot tree-shake optional peer deps at runtime; the try/catch pattern
+// below is the standard React Native approach for optional native modules.
 type VideoUIElement = Extract<UIElement, { type: "Video" }>;
 let VideoElementComponent: React.ComponentType<{ element: VideoUIElement; style: object }> | null = null;
 try {
@@ -189,8 +191,8 @@ const renderElement = (element: UIElement, theme: Theme, parentType?: "XStack" |
 
     if (!LottieView) {
       return (
-        <View key={element.id} style={[wrapperStyle, styles.lottieFallback]}>
-          <Text style={styles.lottieFallbackText}>
+        <View key={element.id} style={[wrapperStyle, styles.mediaFallback, { backgroundColor: theme.colors.neutral.lowest }]}>
+          <Text style={[styles.mediaFallbackText, getTextStyle(theme, "caption"), { color: theme.colors.text.tertiary }]}>
             Install lottie-react-native to render Lottie animations.
           </Text>
         </View>
@@ -229,8 +231,8 @@ const renderElement = (element: UIElement, theme: Theme, parentType?: "XStack" |
 
     if (!RiveElementComponent) {
       return (
-        <View key={element.id} style={[wrapperStyle, styles.riveFallback]}>
-          <Text style={styles.riveFallbackText}>
+        <View key={element.id} style={[wrapperStyle, styles.mediaFallback, { backgroundColor: theme.colors.neutral.lowest }]}>
+          <Text style={[styles.mediaFallbackText, getTextStyle(theme, "caption"), { color: theme.colors.text.tertiary }]}>
             Install rive-react-native to render Rive animations.
           </Text>
         </View>
@@ -255,7 +257,6 @@ const renderElement = (element: UIElement, theme: Theme, parentType?: "XStack" |
       <View
         key={element.id}
         style={{
-          alignSelf: "center",
           width: element.props.width,
           height: element.props.height,
           margin: element.props.margin,
@@ -300,8 +301,8 @@ const renderElement = (element: UIElement, theme: Theme, parentType?: "XStack" |
 
     if (!VideoElementComponent) {
       return (
-        <View key={element.id} style={[wrapperStyle, styles.videoFallback]}>
-          <Text style={styles.videoFallbackText}>
+        <View key={element.id} style={[wrapperStyle, styles.mediaFallback, { backgroundColor: theme.colors.neutral.lowest }]}>
+          <Text style={[styles.mediaFallbackText, getTextStyle(theme, "caption"), { color: theme.colors.text.tertiary }]}>
             Install expo-video to render videos.
           </Text>
         </View>
@@ -376,39 +377,11 @@ const styles = StyleSheet.create({
     minWidth: 234,
     alignItems: "center",
   },
-  lottieFallback: {
+  mediaFallback: {
     alignItems: "center",
     justifyContent: "center",
-    backgroundColor: "#F5F5F5",
-    borderRadius: 8,
   },
-  lottieFallbackText: {
-    fontSize: 13,
-    color: "#888",
-    textAlign: "center",
-    paddingHorizontal: 16,
-  },
-  riveFallback: {
-    alignItems: "center",
-    justifyContent: "center",
-    backgroundColor: "#F5F5F5",
-    borderRadius: 8,
-  },
-  riveFallbackText: {
-    fontSize: 13,
-    color: "#888",
-    textAlign: "center",
-    paddingHorizontal: 16,
-  },
-  videoFallback: {
-    alignItems: "center",
-    justifyContent: "center",
-    backgroundColor: "#F5F5F5",
-    borderRadius: 8,
-  },
-  videoFallbackText: {
-    fontSize: 13,
-    color: "#888",
+  mediaFallbackText: {
     textAlign: "center",
     paddingHorizontal: 16,
   },

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/Renderer.tsx
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/Renderer.tsx
@@ -20,6 +20,29 @@ try {
   // lottie-react-native not installed - will show error if Lottie is used
 }
 
+type VideoUIElement = Extract<UIElement, { type: "Video" }>;
+let VideoElementComponent: React.ComponentType<{ element: VideoUIElement; style: object }> | null = null;
+try {
+  const { VideoView, useVideoPlayer } = require("expo-video");
+  VideoElementComponent = ({ element, style }: { element: VideoUIElement; style: object }) => {
+    const player = useVideoPlayer(element.props.url, (p: any) => {
+      p.loop = element.props.loop ?? false;
+      p.muted = element.props.muted ?? true;
+      if (element.props.autoPlay) p.play();
+    });
+    return (
+      <VideoView
+        player={player}
+        style={style}
+        allowsFullscreen={false}
+        nativeControls={element.props.controls ?? false}
+      />
+    );
+  };
+} catch {
+  // expo-video not installed
+}
+
 type RiveUIElement = Extract<UIElement, { type: "Rive" }>;
 let RiveElementComponent: React.ComponentType<{ element: RiveUIElement; riveStyle: object }> | null = null;
 try {
@@ -221,6 +244,77 @@ const renderElement = (element: UIElement, theme: Theme, parentType?: "XStack" |
     );
   }
 
+  if (element.type === "Icon") {
+    const icons = require("lucide-react-native");
+    const IconComp = icons[element.props.name] as React.ComponentType<{
+      size?: number;
+      color?: string;
+      strokeWidth?: number;
+    }> | undefined;
+    return (
+      <View
+        key={element.id}
+        style={{
+          alignSelf: "center",
+          width: element.props.width,
+          height: element.props.height,
+          margin: element.props.margin,
+          marginHorizontal: element.props.marginHorizontal,
+          marginVertical: element.props.marginVertical,
+          padding: element.props.padding,
+          paddingHorizontal: element.props.paddingHorizontal,
+          paddingVertical: element.props.paddingVertical,
+          borderWidth: element.props.borderWidth,
+          borderRadius: element.props.borderRadius,
+          borderColor: element.props.borderColor,
+          opacity: element.props.opacity,
+        }}
+      >
+        {IconComp ? (
+          <IconComp
+            size={element.props.size ?? 24}
+            color={element.props.color ?? theme.colors.text.primary}
+            strokeWidth={element.props.strokeWidth ?? 2}
+          />
+        ) : null}
+      </View>
+    );
+  }
+
+  if (element.type === "Video") {
+    const wrapperStyle = {
+      width: element.props.width ?? ("100%" as `${number}%`),
+      height: element.props.height ?? 200,
+      opacity: element.props.opacity,
+      margin: element.props.margin,
+      marginHorizontal: element.props.marginHorizontal,
+      marginVertical: element.props.marginVertical,
+      padding: element.props.padding,
+      paddingHorizontal: element.props.paddingHorizontal,
+      paddingVertical: element.props.paddingVertical,
+      borderWidth: element.props.borderWidth,
+      borderRadius: element.props.borderRadius,
+      borderColor: element.props.borderColor,
+      overflow: "hidden" as const,
+    };
+
+    if (!VideoElementComponent) {
+      return (
+        <View key={element.id} style={[wrapperStyle, styles.videoFallback]}>
+          <Text style={styles.videoFallbackText}>
+            Install expo-video to render videos.
+          </Text>
+        </View>
+      );
+    }
+
+    return (
+      <View key={element.id} style={wrapperStyle}>
+        <VideoElementComponent element={element} style={styles.fill} />
+      </View>
+    );
+  }
+
   return null;
 };
 
@@ -301,6 +395,18 @@ const styles = StyleSheet.create({
     borderRadius: 8,
   },
   riveFallbackText: {
+    fontSize: 13,
+    color: "#888",
+    textAlign: "center",
+    paddingHorizontal: 16,
+  },
+  videoFallback: {
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: "#F5F5F5",
+    borderRadius: 8,
+  },
+  videoFallbackText: {
     fontSize: 13,
     color: "#888",
     textAlign: "center",

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/types.ts
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/types.ts
@@ -107,6 +107,29 @@ export type UIElement =
         artboardName?: string;
         stateMachineName?: string;
       };
+    }
+  | {
+      id: string;
+      name?: string;
+      type: "Icon";
+      props: BaseBoxProps & {
+        name: string;
+        size?: number;
+        color?: string;
+        strokeWidth?: number;
+      };
+    }
+  | {
+      id: string;
+      name?: string;
+      type: "Video";
+      props: BaseBoxProps & {
+        url: string;
+        autoPlay?: boolean;
+        loop?: boolean;
+        muted?: boolean;
+        controls?: boolean;
+      };
     };
 
 const BaseBoxPropsSchema = z.object({
@@ -194,6 +217,21 @@ const RiveElementPropsSchema = BaseBoxPropsSchema.extend({
   stateMachineName: z.string().optional(),
 });
 
+const IconElementPropsSchema = BaseBoxPropsSchema.extend({
+  name: z.string(),
+  size: z.number().optional(),
+  color: z.string().optional(),
+  strokeWidth: z.number().optional(),
+});
+
+const VideoElementPropsSchema = BaseBoxPropsSchema.extend({
+  url: z.string(),
+  autoPlay: z.boolean().optional(),
+  loop: z.boolean().optional(),
+  muted: z.boolean().optional(),
+  controls: z.boolean().optional(),
+});
+
 export const UIElementSchema: z.ZodType<UIElement> = z.lazy(() =>
   z.union([
     z.object({
@@ -226,6 +264,18 @@ export const UIElementSchema: z.ZodType<UIElement> = z.lazy(() =>
       name: z.string().optional(),
       type: z.literal("Rive"),
       props: RiveElementPropsSchema,
+    }),
+    z.object({
+      id: z.string(),
+      name: z.string().optional(),
+      type: z.literal("Icon"),
+      props: IconElementPropsSchema,
+    }),
+    z.object({
+      id: z.string(),
+      name: z.string().optional(),
+      type: z.literal("Video"),
+      props: VideoElementPropsSchema,
     }),
   ])
 );

--- a/packages/onboarding/CHANGELOG.md
+++ b/packages/onboarding/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to `@rocapine/react-native-onboarding` are documented here.
 
 ---
 
+## [1.5.0] - 2026-04-21
+
+### Added
+
+- **`Icon` UIElement** for `ComposableScreen` — renders a Lucide icon by name
+  via `lucide-react-native` (bundled dependency, always available). Supports
+  `name` (required, e.g. `"Star"`, `"Heart"`), `size`, `color`, `strokeWidth`,
+  and all `BaseBoxProps`.
+- **`Video` UIElement** for `ComposableScreen` — renders a video from a remote
+  URL via `expo-video` (optional peer dep). Supports `url` (required),
+  `autoPlay`, `loop`, `muted`, `controls`, and all `BaseBoxProps`. Graceful
+  fallback shown if `expo-video` is not installed.
+
+---
+
 ## [1.4.0] - 2026-04-21
 
 ### Added

--- a/packages/onboarding/CHANGELOG.md
+++ b/packages/onboarding/CHANGELOG.md
@@ -8,14 +8,19 @@ All notable changes to `@rocapine/react-native-onboarding` are documented here.
 
 ### Added
 
-- **`Icon` UIElement** for `ComposableScreen` — renders a Lucide icon by name
-  via `lucide-react-native` (bundled dependency, always available). Supports
-  `name` (required, e.g. `"Star"`, `"Heart"`), `size`, `color`, `strokeWidth`,
-  and all `BaseBoxProps`.
-- **`Video` UIElement** for `ComposableScreen` — renders a video from a remote
-  URL via `expo-video` (optional peer dep). Supports `url` (required),
-  `autoPlay`, `loop`, `muted`, `controls`, and all `BaseBoxProps`. Graceful
-  fallback shown if `expo-video` is not installed.
+- **`Icon` UIElement schema** for `ComposableScreen` — new discriminated-union
+  variant with `type: "Icon"`. Props: `name` (string, **required** — Lucide icon
+  name), `size` (number), `color` (string), `strokeWidth` (number), plus all
+  `BaseBoxProps`. Validated by `IconElementPropsSchema` (Zod).
+- **`Video` UIElement schema** for `ComposableScreen` — new discriminated-union
+  variant with `type: "Video"`. Props: `url` (string, **required**), `autoPlay`
+  (boolean), `loop` (boolean), `muted` (boolean), `controls` (boolean), plus all
+  `BaseBoxProps`. Validated by `VideoElementPropsSchema` (Zod).
+
+> **Backend note:** The `onboarding-studio` server must be updated to accept and
+> emit `Icon` and `Video` `UIElement` variants in `ComposableScreen` payloads.
+> Mirror `IconElementPropsSchema` and `VideoElementPropsSchema` in the backend
+> validation layer and add both types to the CMS element-type picker.
 
 ---
 

--- a/packages/onboarding/package.json
+++ b/packages/onboarding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocapine/react-native-onboarding",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Headless React Native SDK for Rocapine Onboarding Studio - Data fetching, state management, and hooks",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/onboarding/src/onboarding-example.ts
+++ b/packages/onboarding/src/onboarding-example.ts
@@ -131,6 +131,27 @@ export const onboardingExample = {
                 },
               },
               {
+                id: "hero-icon",
+                type: "Icon",
+                props: {
+                  name: "Star",
+                  size: 48,
+                  color: "#007AFF",
+                  marginVertical: 8,
+                },
+              },
+              {
+                id: "hero-video",
+                type: "Video",
+                props: {
+                  url: "https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4",
+                  height: 200,
+                  borderRadius: 12,
+                  controls: true,
+                  muted: true,
+                },
+              },
+              {
                 id: "headline",
                 type: "Text",
                 props: {

--- a/packages/onboarding/src/steps/ComposableScreen/types.ts
+++ b/packages/onboarding/src/steps/ComposableScreen/types.ts
@@ -107,6 +107,29 @@ type UIElement =
         artboardName?: string;
         stateMachineName?: string;
       };
+    }
+  | {
+      id: string;
+      name?: string;
+      type: "Icon";
+      props: BaseBoxProps & {
+        name: string;
+        size?: number;
+        color?: string;
+        strokeWidth?: number;
+      };
+    }
+  | {
+      id: string;
+      name?: string;
+      type: "Video";
+      props: BaseBoxProps & {
+        url: string;
+        autoPlay?: boolean;
+        loop?: boolean;
+        muted?: boolean;
+        controls?: boolean;
+      };
     };
 
 const BaseBoxPropsSchema = z.object({
@@ -194,6 +217,21 @@ const RiveElementPropsSchema = BaseBoxPropsSchema.extend({
   stateMachineName: z.string().optional(),
 });
 
+const IconElementPropsSchema = BaseBoxPropsSchema.extend({
+  name: z.string(),
+  size: z.number().optional(),
+  color: z.string().optional(),
+  strokeWidth: z.number().optional(),
+});
+
+const VideoElementPropsSchema = BaseBoxPropsSchema.extend({
+  url: z.string(),
+  autoPlay: z.boolean().optional(),
+  loop: z.boolean().optional(),
+  muted: z.boolean().optional(),
+  controls: z.boolean().optional(),
+});
+
 const UIElementSchema: z.ZodType<UIElement> = z.lazy(() =>
   z.union([
     z.object({
@@ -226,6 +264,18 @@ const UIElementSchema: z.ZodType<UIElement> = z.lazy(() =>
       name: z.string().optional(),
       type: z.literal("Rive"),
       props: RiveElementPropsSchema,
+    }),
+    z.object({
+      id: z.string(),
+      name: z.string().optional(),
+      type: z.literal("Icon"),
+      props: IconElementPropsSchema,
+    }),
+    z.object({
+      id: z.string(),
+      name: z.string().optional(),
+      type: z.literal("Video"),
+      props: VideoElementPropsSchema,
     }),
   ])
 );

--- a/website/docs/page-types.mdx
+++ b/website/docs/page-types.mdx
@@ -479,7 +479,9 @@ Build arbitrary onboarding screens entirely from CMS data — no custom renderer
 | `width` / `height` | `number` | Wrapper `View` dimensions |
 | `margin` / `marginHorizontal` / `marginVertical` | `number` | |
 | `padding` / `paddingHorizontal` / `paddingVertical` | `number` | |
-| `borderWidth` / `borderRadius` / `borderColor` | `number \| string` | |
+| `borderWidth` | `number` | |
+| `borderRadius` | `number` | |
+| `borderColor` | `string` | |
 | `opacity` | `number` | |
 
 `Icon` uses [Lucide React Native](https://lucide.dev/guide/packages/lucide-react-native), which is bundled with the UI package — no extra install needed. If an unknown icon name is passed the element renders nothing.
@@ -550,7 +552,9 @@ If `rive-react-native` is not installed, the element renders a placeholder view 
 | `opacity` | `number` | |
 | `margin` / `marginHorizontal` / `marginVertical` | `number` | |
 | `padding` / `paddingHorizontal` / `paddingVertical` | `number` | |
-| `borderWidth` / `borderRadius` / `borderColor` | `number \| string` | Applied via a wrapping `View` |
+| `borderWidth` | `number` | Applied via a wrapping `View` |
+| `borderRadius` | `number` | Applied via a wrapping `View` |
+| `borderColor` | `string` | Applied via a wrapping `View` |
 
 **Dependencies:** `expo-video`
 

--- a/website/docs/page-types.mdx
+++ b/website/docs/page-types.mdx
@@ -403,13 +403,13 @@ Build arbitrary onboarding screens entirely from CMS data — no custom renderer
 - Any screen that doesn't fit a pre-built type
 
 **Key features:**
-- Recursive element tree (`YStack`, `XStack`, `Text`, `Image`, `Lottie`, `Rive`)
+- Recursive element tree (`YStack`, `XStack`, `Text`, `Image`, `Lottie`, `Rive`, `Icon`, `Video`)
 - Full flexbox layout support
 - Border, radius, overflow, and opacity control
 - Dimension constraints (`width`, `height`, `min/max`)
 - Spacing with both `padding` and `margin`
 - Text color defaults to `theme.colors.text.primary`
-- Lottie and Rive as optional peer deps — graceful fallback if not installed
+- Lottie, Rive, and Video as optional peer deps — graceful fallback if not installed
 
 **Element types:**
 
@@ -419,8 +419,10 @@ Build arbitrary onboarding screens entirely from CMS data — no custom renderer
 | `XStack` | `<View>` | `row` | — |
 | `Text` | `<Text>` | — | — |
 | `Image` | `<Image>` | — | — |
+| `Icon` | Lucide icon | — | — (bundled) |
 | `Lottie` | `LottieView` | — | `lottie-react-native` |
 | `Rive` | `<Rive>` | — | `rive-react-native` |
+| `Video` | `<VideoView>` | — | `expo-video` |
 
 **Stack props (`YStack` / `XStack`):**
 
@@ -465,6 +467,22 @@ Build arbitrary onboarding screens entirely from CMS data — no custom renderer
 | `padding` / `paddingHorizontal` / `paddingVertical` | `number` | |
 | `margin` / `marginHorizontal` / `marginVertical` | `number` | |
 | `borderWidth` / `borderRadius` / `opacity` | `number` | |
+
+**Icon props:**
+
+| Prop | Type | Notes |
+|------|------|-------|
+| `name` | `string` | **Required** — Lucide icon name e.g. `"Star"`, `"Heart"`, `"CheckCircle"` |
+| `size` | `number` | Icon width & height in dp; defaults to `24` |
+| `color` | `string` | Defaults to `theme.colors.text.primary` |
+| `strokeWidth` | `number` | Line stroke weight; defaults to `2` |
+| `width` / `height` | `number` | Wrapper `View` dimensions |
+| `margin` / `marginHorizontal` / `marginVertical` | `number` | |
+| `padding` / `paddingHorizontal` / `paddingVertical` | `number` | |
+| `borderWidth` / `borderRadius` / `borderColor` | `number \| string` | |
+| `opacity` | `number` | |
+
+`Icon` uses [Lucide React Native](https://lucide.dev/guide/packages/lucide-react-native), which is bundled with the UI package — no extra install needed. If an unknown icon name is passed the element renders nothing.
 
 **Lottie props:**
 
@@ -518,10 +536,36 @@ npx expo install rive-react-native
 If `rive-react-native` is not installed, the element renders a placeholder view with an install hint instead of crashing.
 :::
 
+**Video props:**
+
+| Prop | Type | Notes |
+|------|------|-------|
+| `url` | `string` | **Required** — remote video URL |
+| `width` | `number` | Defaults to `"100%"` |
+| `height` | `number` | Defaults to `200` |
+| `autoPlay` | `boolean` | Start playing on mount; defaults to `false` |
+| `loop` | `boolean` | Loop playback; defaults to `false` |
+| `muted` | `boolean` | Mute audio; defaults to `true` (required for autoplay on iOS) |
+| `controls` | `boolean` | Show native playback controls; defaults to `false` |
+| `opacity` | `number` | |
+| `margin` / `marginHorizontal` / `marginVertical` | `number` | |
+| `padding` / `paddingHorizontal` / `paddingVertical` | `number` | |
+| `borderWidth` / `borderRadius` / `borderColor` | `number \| string` | Applied via a wrapping `View` |
+
+**Dependencies:** `expo-video`
+
+```bash
+npx expo install expo-video
+```
+
+:::tip
+If `expo-video` is not installed, the element renders a placeholder view with an install hint instead of crashing.
+:::
+
 **Payload:**
 ```typescript
 {
-  elements: UIElement[]; // Recursive tree of YStack, XStack, Text, Image
+  elements: UIElement[]; // Recursive tree of layout and media elements
 }
 ```
 
@@ -598,7 +642,7 @@ If `rive-react-native` is not installed, the element renders a placeholder view 
 }
 ```
 
-**Dependencies:** None (for `YStack`, `XStack`, `Text`, `Image`). See Lottie and Rive sections above for animation elements.
+**Dependencies:** None (for `YStack`, `XStack`, `Text`, `Image`, `Icon`). See Lottie, Rive, and Video sections above for elements with optional peer deps.
 
 ---
 


### PR DESCRIPTION
## Summary

- Add **`Icon`** UIElement — renders a [Lucide](https://lucide.dev/guide/packages/lucide-react-native) icon by name (`name`, `size`, `color`, `strokeWidth` + all `BaseBoxProps`). Bundled with the UI package, no extra install needed.
- Add **`Video`** UIElement — renders a video from a remote URL via `expo-video` (optional peer dep, graceful fallback if absent). Props: `url`, `autoPlay`, `loop`, `muted`, `controls` + all `BaseBoxProps`.
- Both elements added to Zod schemas and TypeScript union types in headless and UI packages.
- `expo-video` added as optional peer dependency in `@rocapine/react-native-onboarding-ui`.
- Example app updated with Icon (Lucide `Circle`) and Video (`lorem.video/720p`, autoPlay, muted) demos.
- Docusaurus docs updated: element types table, Icon and Video prop tables, install snippets, fallback tips.
- Both packages bumped to **v1.5.0**, CHANGELOGs updated.

## Test plan

- [ ] `npm run build` — both packages compile at v1.5.0
- [ ] `cd example && npm run type:check` — no TypeScript errors
- [ ] Example app → ComposableScreen demo — Icon renders (Lucide circle, blue), Video plays (or shows fallback if `expo-video` not installed)
- [ ] Remove `expo-video` from example and verify Video element shows install-hint placeholder
- [ ] Review Docusaurus docs for Icon and Video sections

## onboarding-studio

Schema changes must be mirrored in the CMS. See summary comment in the PR for the full prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Icon element type to composable screens—render Lucide icons with customizable name, size, color, and stroke width
  * Added Video element type to composable screens—embed remote videos with playback controls, autoplay, looping, and muting options
  * Video element includes graceful fallback UI when dependencies are unavailable

<!-- end of auto-generated comment: release notes by coderabbit.ai -->