### PR TITLE
feat(composable-screen): add fontFamily prop to Text UIElement

### DIFF
--- a/example/app.json
+++ b/example/app.json
@@ -42,7 +42,12 @@
           }
         }
       ],
-      "expo-font",
+      [
+        "expo-font",
+        {
+          "fonts": ["./assets/fonts/Bangers_400Regular.ttf", "./assets/fonts/FuturaBold.otf"]
+        }
+      ],
       "expo-web-browser",
       "expo-image",
       "expo-video"

--- a/example/app/example/composable-screen.tsx
+++ b/example/app/example/composable-screen.tsx
@@ -113,6 +113,7 @@ export default function ComposableScreenExample() {
                 content: 'Built from the CMS',
                 fontSize: 28,
                 fontWeight: '700',
+                fontFamily: 'Bangers_400Regular',
                 textAlign: 'center',
               },
             },

--- a/example/package.json
+++ b/example/package.json
@@ -12,6 +12,7 @@
     "lint": "expo lint"
   },
   "dependencies": {
+    "@expo-google-fonts/bangers": "^0.4.1",
     "@expo/vector-icons": "^15.0.2",
     "@radix-ui/react-compose-refs": "^1.1.2",
     "@radix-ui/react-context": "^1.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13500,7 +13500,7 @@
     },
     "packages/onboarding": {
       "name": "@rocapine/react-native-onboarding",
-      "version": "1.6.0",
+      "version": "1.7.0",
       "license": "MIT",
       "dependencies": {
         "@react-native-async-storage/async-storage": "^2.1.0",
@@ -13520,7 +13520,7 @@
     },
     "packages/onboarding-ui": {
       "name": "@rocapine/react-native-onboarding-ui",
-      "version": "1.6.0",
+      "version": "1.7.0",
       "license": "MIT",
       "dependencies": {
         "lucide-react-native": "^0.545.0",
@@ -13545,7 +13545,7 @@
       },
       "peerDependencies": {
         "@react-native-picker/picker": "*",
-        "@rocapine/react-native-onboarding": "^1.6.0",
+        "@rocapine/react-native-onboarding": "^1.7.0",
         "@shopify/react-native-skia": ">=1.0.0",
         "@tanstack/react-query": ">=5.0.0",
         "@types/react": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
     "example": {
       "version": "1.0.0",
       "dependencies": {
+        "@expo-google-fonts/bangers": "^0.4.1",
         "@expo/vector-icons": "^15.0.2",
         "@radix-ui/react-compose-refs": "^1.1.2",
         "@radix-ui/react-context": "^1.1.2",
@@ -1650,6 +1651,12 @@
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
+    },
+    "node_modules/@expo-google-fonts/bangers": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@expo-google-fonts/bangers/-/bangers-0.4.1.tgz",
+      "integrity": "sha512-yc/iz6OOs3b6JW5KXZFhiwyAxsZHR3JQC854frmsOVWcOeZzCuwvFE/dIywHR+wy6Y7pv0eBwgMJqO7gkav2mQ==",
+      "license": "MIT AND OFL-1.1"
     },
     "node_modules/@expo-google-fonts/material-symbols": {
       "version": "0.4.32",
@@ -13493,7 +13500,7 @@
     },
     "packages/onboarding": {
       "name": "@rocapine/react-native-onboarding",
-      "version": "1.4.0",
+      "version": "1.6.0",
       "license": "MIT",
       "dependencies": {
         "@react-native-async-storage/async-storage": "^2.1.0",
@@ -13513,7 +13520,7 @@
     },
     "packages/onboarding-ui": {
       "name": "@rocapine/react-native-onboarding-ui",
-      "version": "1.4.0",
+      "version": "1.6.0",
       "license": "MIT",
       "dependencies": {
         "lucide-react-native": "^0.545.0",
@@ -13538,7 +13545,7 @@
       },
       "peerDependencies": {
         "@react-native-picker/picker": "*",
-        "@rocapine/react-native-onboarding": "^1.4.0",
+        "@rocapine/react-native-onboarding": "^1.6.0",
         "@shopify/react-native-skia": ">=1.0.0",
         "@tanstack/react-query": ">=5.0.0",
         "@types/react": "*",

--- a/packages/onboarding-ui/CHANGELOG.md
+++ b/packages/onboarding-ui/CHANGELOG.md
@@ -5,6 +5,17 @@ here.
 
 ---
 
+## [1.7.0] - 2026-04-21
+
+### Added
+
+- **`fontFamily` support on `Text` elements** — the `Text` renderer now passes
+  `fontFamily` from element props directly to the React Native `<Text>` style.
+  Any font family loaded by the host app (e.g. via `expo-font`) can be applied
+  to a text node by setting `fontFamily` in its props.
+
+---
+
 ## [1.6.0] - 2026-04-21
 
 ### Added

--- a/packages/onboarding-ui/package.json
+++ b/packages/onboarding-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocapine/react-native-onboarding-ui",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "UI components and renderers for Rocapine Onboarding Studio - Built on top of the headless SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -43,7 +43,7 @@
   },
   "peerDependencies": {
     "@react-native-picker/picker": "*",
-    "@rocapine/react-native-onboarding": "^1.6.0",
+    "@rocapine/react-native-onboarding": "^1.7.0",
     "@shopify/react-native-skia": ">=1.0.0",
     "@tanstack/react-query": ">=5.0.0",
     "@types/react": "*",

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/Renderer.tsx
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/Renderer.tsx
@@ -189,6 +189,7 @@ const renderElement = (element: UIElement, theme: Theme, variables: Record<strin
         style={{
           fontSize: element.props.fontSize,
           fontWeight: element.props.fontWeight as any,
+          fontFamily: element.props.fontFamily,
           color: element.props.color ?? theme.colors.text.primary,
           textAlign: element.props.textAlign,
           letterSpacing: element.props.letterSpacing,

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/types.ts
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/types.ts
@@ -58,6 +58,7 @@ export type UIElement =
         mode?: "plain" | "expression";
         fontSize?: number;
         fontWeight?: string;
+        fontFamily?: string;
         color?: string;
         textAlign?: "left" | "center" | "right";
         letterSpacing?: number;
@@ -204,6 +205,7 @@ const TextElementPropsSchema = z.object({
   mode: z.enum(["plain", "expression"]).optional(),
   fontSize: z.number().optional(),
   fontWeight: z.string().optional(),
+  fontFamily: z.string().optional(),
   color: z.string().optional(),
   textAlign: z.enum(["left", "center", "right"]).optional(),
   letterSpacing: z.number().optional(),

--- a/packages/onboarding/CHANGELOG.md
+++ b/packages/onboarding/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to `@rocapine/react-native-onboarding` are documented here.
 
 ---
 
+## [1.7.0] - 2026-04-21
+
+### Added
+
+- **`fontFamily` prop on `Text` UIElement** — optional `fontFamily?: string` added
+  to the `Text` variant of `UIElement` and to `TextElementPropsSchema` (Zod).
+  Pass any font family name loaded via `expo-font` (or a system font) to apply a
+  custom typeface to a text node.
+
+> **Backend note:** The `onboarding-studio` server should be updated to accept
+> and emit `fontFamily` on `Text` UIElement props, and to expose a font-family
+> input in the CMS text-element editor.
+
+---
+
 ## [1.6.0] - 2026-04-21
 
 ### Added

--- a/packages/onboarding/package.json
+++ b/packages/onboarding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocapine/react-native-onboarding",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "Headless React Native SDK for Rocapine Onboarding Studio - Data fetching, state management, and hooks",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/onboarding/src/onboarding-example.ts
+++ b/packages/onboarding/src/onboarding-example.ts
@@ -182,6 +182,7 @@ export const onboardingExample = {
                   content: "Built from the CMS",
                   fontSize: 28,
                   fontWeight: "700",
+                  fontFamily: "System",
                   textAlign: "center",
                 },
               },

--- a/packages/onboarding/src/steps/ComposableScreen/types.ts
+++ b/packages/onboarding/src/steps/ComposableScreen/types.ts
@@ -58,6 +58,7 @@ type UIElement =
         mode?: "plain" | "expression";
         fontSize?: number;
         fontWeight?: string;
+        fontFamily?: string;
         color?: string;
         textAlign?: "left" | "center" | "right";
         letterSpacing?: number;
@@ -204,6 +205,7 @@ const TextElementPropsSchema = z.object({
   mode: z.enum(["plain", "expression"]).optional(),
   fontSize: z.number().optional(),
   fontWeight: z.string().optional(),
+  fontFamily: z.string().optional(),
   color: z.string().optional(),
   textAlign: z.enum(["left", "center", "right"]).optional(),
   letterSpacing: z.number().optional(),

--- a/website/docs/page-types.mdx
+++ b/website/docs/page-types.mdx
@@ -464,6 +464,7 @@ Build arbitrary onboarding screens entirely from CMS data — no custom renderer
 | `content` | `string` | **Required** |
 | `mode` | `"plain" \| "expression"` | `"plain"` (default) renders content as-is; `"expression"` interpolates `{{variableName}}` patterns from the variable context |
 | `fontSize` / `fontWeight` / `letterSpacing` / `lineHeight` | `number \| string` | |
+| `fontFamily` | `string` | Font family name; must be loaded by the host app (e.g. via `expo-font`) |
 | `color` | `string` | Defaults to `theme.colors.text.primary` |
 | `textAlign` | `"left" \| "center" \| "right"` | |
 | `backgroundColor` / `borderColor` | `string` | |


### PR DESCRIPTION
## Summary

- Adds optional `fontFamily?: string` prop to the `Text` UIElement in both `ComposableScreen` types files (headless + UI packages)
- Renderer passes `fontFamily` through to the React Native `<Text>` style
- Bumps both packages to `v1.7.0` with changelog entries
- Updates website docs (`page-types.mdx`) to document the new prop

## Test plan

- [ ] Set `fontFamily` on a `Text` UIElement in `composable-screen.tsx` example — verify custom font renders (e.g. `Bangers_400Regular`)
- [ ] Omit `fontFamily` — verify default system font unchanged
- [ ] Type-check passes: `npm run type` in `example/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Text elements now support custom font families through the `fontFamily` property, allowing host-provided fonts to be applied in composable screens.

* **Documentation**
  * Added documentation describing the new `fontFamily` property for Text elements.

* **Chores**
  * Packages updated to version 1.7.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->