### PR TITLE
✨ feat(composable-screen): add CheckboxGroup UIElement (v1.9.0)

### DIFF
--- a/.claude/agents/add-uielement.md
+++ b/.claude/agents/add-uielement.md
@@ -1,0 +1,64 @@
+---
+name: add-uielement
+description: Adds a new UIElement type to both SDK packages (headless + UI). Handles the full workflow — creates element files, updates schemas, commits with gitmoji convention, and bumps SDK version. Use when the user asks to add a new element type to the ComposableScreen system. Designed to run in a git worktree for isolation.
+tools: Read, Edit, Write, Bash, Glob, Grep
+model: sonnet
+---
+
+You add new UIElement types to the Rocapine Onboarding SDK monorepo.
+
+Work directory is the repo root. Both packages live under `packages/`.
+
+## Workflow
+
+### Step 1 — Implement the UIElement
+
+Read `.claude/skills/add-uielement/SKILL.md` and follow every step exactly.
+
+The skill will guide you through:
+- Confirming the element name and props with the user
+- Creating the headless schema file (`packages/onboarding/src/steps/ComposableScreen/elements/`)
+- Updating the headless `types.ts` union
+- Creating the UI renderer component (`packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/`)
+- Updating `renderElement.tsx`
+- Mirroring types in the UI `types.ts`
+- Updating `onboarding-example.ts` and `example/app/example/composable-screen.tsx`
+- Building and type-checking to verify
+
+### Step 2 — Commit the implementation
+
+Follow the gitmoji commit convention (from `~/.claude/skills/gitmoji/SKILL.md`):
+
+1. Run `git diff --cached` to review staged changes
+2. Generate a commit message:
+   ```
+   ✨ feat(composable-screen): add <ElementName> UIElement
+   ```
+   - Subject lowercase, imperative, under 50 chars
+   - Add a body bullet list if multiple files were changed
+   - No `Co-Authored-By` trailer
+3. Stage only the UIElement implementation files (NOT package.json or CHANGELOGs)
+4. Commit immediately without asking for approval
+
+### Step 3 — Bump the SDK version
+
+Read `.claude/skills/bump-version/SKILL.md` and follow every step exactly.
+
+A new UIElement is always a **MINOR** bump (new feature, no breaking change) — recommend MINOR unless the user specifies otherwise.
+
+The skill will guide you through:
+- Showing a change summary and bump recommendation
+- Asking the user to confirm the bump type
+- Computing the new version
+- Updating both `package.json` files
+- Writing CHANGELOG entries for both packages
+- Committing the 4 version files with `📦 chore(release): bump to <NEW_VERSION>, update changelogs and docs`
+
+## Hard constraints
+
+- Run `npm run build` from the repo root after implementation, before any commit
+- Run `cd example && npm run type` to verify TypeScript compiles
+- Never use `git add .` — stage only the specific files relevant to each commit
+- Do not push to remote, do not run `npm publish`
+- Do not skip the build verification step
+- If build or type-check fails, fix the errors before committing

--- a/.claude/agents/add-uielement.md
+++ b/.claude/agents/add-uielement.md
@@ -29,15 +29,15 @@ The skill will guide you through:
 
 Follow the gitmoji commit convention (from `~/.claude/skills/gitmoji/SKILL.md`):
 
-1. Run `git diff --cached` to review staged changes
-2. Generate a commit message:
+1. Stage only the UIElement implementation files (NOT package.json or CHANGELOGs)
+2. Run `git diff --cached` to review staged changes
+3. Generate a commit message:
    ```
    ✨ feat(composable-screen): add <ElementName> UIElement
    ```
    - Subject lowercase, imperative, under 50 chars
    - Add a body bullet list if multiple files were changed
    - No `Co-Authored-By` trailer
-3. Stage only the UIElement implementation files (NOT package.json or CHANGELOGs)
 4. Commit immediately without asking for approval
 
 ### Step 3 — Bump the SDK version

--- a/.claude/agents/add-uielement.md
+++ b/.claude/agents/add-uielement.md
@@ -54,6 +54,35 @@ The skill will guide you through:
 - Writing CHANGELOG entries for both packages
 - Committing the 4 version files with `📦 chore(release): bump to <NEW_VERSION>, update changelogs and docs`
 
+### Step 4 — Create the pull request
+
+After both commits (implementation + version bump) are done, create a PR using `gh pr create`:
+
+```bash
+gh pr create --title "✨ feat(composable-screen): add <ElementName> UIElement (v<NEW_VERSION>)" --body "$(cat <<'EOF'
+## Summary
+- Add `<ElementName>` UIElement to ComposableScreen (headless schema + UI renderer)
+- Multi/single select support: <describe selection model>
+- Variable binding via `variableName` prop
+
+## Files changed
+- `packages/onboarding/src/steps/ComposableScreen/elements/<ElementName>Element.ts` (new)
+- `packages/onboarding/src/steps/ComposableScreen/types.ts`
+- `packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/<ElementName>Element.tsx` (new)
+- `packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/renderElement.tsx`
+- `packages/onboarding-ui/src/UI/Pages/ComposableScreen/types.ts`
+
+## Version
+`<OLD_VERSION>` → `<NEW_VERSION>` (MINOR)
+
+## onboarding-studio
+Mirror the schema changes in the CMS — see the prompt output at the end of this workflow.
+EOF
+)"
+```
+
+Return the PR URL to the user.
+
 ## Hard constraints
 
 - Run `npm run build` from the repo root after implementation, before any commit

--- a/.claude/skills/add-uielement/SKILL.md
+++ b/.claude/skills/add-uielement/SKILL.md
@@ -1,0 +1,206 @@
+---
+name: add-uielement
+description: Add a new UIElement type to the Rocapine Onboarding monorepo (both headless SDK and onboarding-ui). Use when the user wants to add a new element type to ComposableScreen, e.g. "add a Slider UIElement", "add a Checkbox element".
+user-invocable: true
+argument-hint: "<ElementName>"
+---
+
+Adds a new UIElement variant to the ComposableScreen system across both SDK packages and the example app.
+
+## Step 0 — Confirm element name & props
+
+Ask the user for:
+- **Element name** (PascalCase, e.g. `Slider`) — becomes the `type` discriminator
+- **Props** — what configurable properties does this element need?
+- **Does it bind a variable?** (like Input/RadioGroup store user state via `variableName`) — yes/no
+- **Does it need children?** (like YStack/XStack) — almost certainly no
+
+If the user already provided these in their message, skip asking.
+
+---
+
+## Step 1 — Create the type definition (headless SDK)
+
+**New file to create:**
+```
+packages/onboarding/src/steps/ComposableScreen/elements/{ElementName}Element.ts
+```
+
+Pattern (copy from an existing element — e.g. `InputElement.ts` for stateful, `IconElement.ts` for simple):
+```typescript
+import { z } from "zod";
+import { BaseBoxPropsSchema, type BaseBoxProps } from "./BaseBoxProps";
+
+export type {ElementName}ElementProps = BaseBoxProps & {
+  // element-specific props here
+};
+
+export const {ElementName}ElementPropsSchema = BaseBoxPropsSchema.extend({
+  // zod schema for props here
+});
+```
+
+**Then update `packages/onboarding/src/steps/ComposableScreen/types.ts`:**
+
+1. Add import at top:
+```typescript
+import { type {ElementName}ElementProps, {ElementName}ElementPropsSchema } from "./elements/{ElementName}Element";
+```
+
+2. Add re-export below other re-exports:
+```typescript
+export type { {ElementName}ElementProps } from "./elements/{ElementName}Element";
+```
+
+3. Add variant to `type UIElement` union (before the closing semicolon):
+```typescript
+  | {
+      id: string;
+      name?: string;
+      type: "{ElementName}";
+      props: {ElementName}ElementProps;
+    }
+```
+
+4. Add Zod schema variant inside `UIElementSchema` `z.union([...])` array:
+```typescript
+    z.object({
+      id: z.string(),
+      name: z.string().optional(),
+      type: z.literal("{ElementName}"),
+      props: {ElementName}ElementPropsSchema,
+    }),
+```
+
+---
+
+## Step 2 — Create the renderer (onboarding-ui)
+
+**New file to create:**
+```
+packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/{ElementName}Element.tsx
+```
+
+Pattern (copy from a similar element; use `InputElement.tsx` if stateful, `IconElement.tsx` if simple):
+```typescript
+import React from "react";
+import { /* RN components */ } from "react-native";
+import { useTheme } from "../../../../Theme";
+import type { RenderContext } from "./shared";
+import type { {ElementName}ElementProps } from "./BaseBoxProps"; // or from the element file
+
+interface Props {
+  element: {
+    id: string;
+    type: "{ElementName}";
+    props: {ElementName}ElementProps;
+  };
+  ctx: RenderContext;
+}
+
+export function {ElementName}ElementComponent({ element, ctx }: Props) {
+  const { theme } = useTheme();
+  const { props } = element;
+
+  // Implement render logic here
+  // Use props for styling, ctx.variables / ctx.setVariable for stateful elements
+
+  return (/* JSX */);
+}
+```
+
+**Then update `packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/renderElement.tsx`:**
+
+Add import:
+```typescript
+import { {ElementName}ElementComponent } from "./{ElementName}Element";
+```
+
+Add case in the switch statement:
+```typescript
+case "{ElementName}":
+  return <{ElementName}ElementComponent element={element as any} ctx={ctx} />;
+```
+
+---
+
+## Step 3 — Mirror types in onboarding-ui
+
+**Update `packages/onboarding-ui/src/UI/Pages/ComposableScreen/types.ts`** — mirror every change from Step 1:
+
+1. Add import of props type + schema from local `./elements/{ElementName}Element`
+2. Add re-export of the props type
+3. Add variant to `export type UIElement` union
+4. Add Zod object to `UIElementSchema` `z.union([...])`
+
+> Both `types.ts` files must stay in sync — same union, same schemas, same exports. The UI package version adds `export` to `UIElement` and `UIElementSchema`.
+
+---
+
+## Step 4 — Update example files
+
+**`packages/onboarding/src/onboarding-example.ts`**
+
+Add a usage of the new element inside the `ComposableScreen` step's `payload.elements` array. Include realistic values for all required props.
+
+**`example/app/example/composable-screen.tsx`**
+
+Add the element to the hardcoded payload in the example screen, in the same location as `onboarding-example.ts`.
+
+---
+
+## Step 5 — Build & verify
+
+```bash
+# From repo root
+npm run build
+
+# Then in example/
+npm run type
+```
+
+Fix any TypeScript errors. The most common issues:
+- Missing import in `renderElement.tsx`
+- Type mismatch between headless and UI `types.ts`
+- Forgetting to add the Zod schema variant (runtime parse will fail)
+
+---
+
+## Step 6 — Notify onboarding-studio
+
+After all changes are done, output this prompt for the `onboarding-studio` repo:
+
+```
+The ComposableScreen UIElement schema in the React Native SDK has been updated.
+Please mirror these schema changes in onboarding-studio.
+
+Changes made:
+- Added "{ElementName}" UIElement with props: <list props>
+
+Files changed in the SDK:
+- packages/onboarding/src/steps/ComposableScreen/elements/{ElementName}Element.ts  (new)
+- packages/onboarding/src/steps/ComposableScreen/types.ts
+- packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/{ElementName}Element.tsx  (new)
+- packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/renderElement.tsx
+- packages/onboarding-ui/src/UI/Pages/ComposableScreen/types.ts
+
+In onboarding-studio, update:
+- The UIElement union type / discriminated union to include "{ElementName}"
+- The Zod schema (or equivalent validation) for {ElementName}ElementProps
+- Any CMS editor UI that lets users pick element types (add "{ElementName}" to the picker)
+- Any JSON serialization/deserialization logic that handles UIElement variants
+```
+
+---
+
+## File map summary
+
+| Action | File |
+|--------|------|
+| **CREATE** | `packages/onboarding/src/steps/ComposableScreen/elements/{ElementName}Element.ts` |
+| **MODIFY** | `packages/onboarding/src/steps/ComposableScreen/types.ts` |
+| **CREATE** | `packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/{ElementName}Element.tsx` |
+| **MODIFY** | `packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/renderElement.tsx` |
+| **MODIFY** | `packages/onboarding-ui/src/UI/Pages/ComposableScreen/types.ts` |
+| **MODIFY** | `packages/onboarding/src/onboarding-example.ts` |
+| **MODIFY** | `example/app/example/composable-screen.tsx` |

--- a/.claude/skills/add-uielement/SKILL.md
+++ b/.claude/skills/add-uielement/SKILL.md
@@ -22,7 +22,7 @@ If the user already provided these in their message, skip asking.
 ## Step 1 — Create the type definition (headless SDK)
 
 **New file to create:**
-```
+```text
 packages/onboarding/src/steps/ComposableScreen/elements/{ElementName}Element.ts
 ```
 
@@ -77,7 +77,7 @@ export type { {ElementName}ElementProps } from "./elements/{ElementName}Element"
 ## Step 2 — Create the renderer (onboarding-ui)
 
 **New file to create:**
-```
+```text
 packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/{ElementName}Element.tsx
 ```
 
@@ -87,7 +87,7 @@ import React from "react";
 import { /* RN components */ } from "react-native";
 import { useTheme } from "../../../../Theme";
 import type { RenderContext } from "./shared";
-import type { {ElementName}ElementProps } from "./BaseBoxProps"; // or from the element file
+import type { {ElementName}ElementProps } from "@rocapine/react-native-onboarding";
 
 interface Props {
   element: {
@@ -170,7 +170,7 @@ Fix any TypeScript errors. The most common issues:
 
 After all changes are done, output this prompt for the `onboarding-studio` repo:
 
-```
+```text
 The ComposableScreen UIElement schema in the React Native SDK has been updated.
 Please mirror these schema changes in onboarding-studio.
 

--- a/.claude/skills/bump-version/SKILL.md
+++ b/.claude/skills/bump-version/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: bump-version
+description: Bump version of both SDK packages (headless + UI), update both CHANGELOGs, and commit. Use when the user wants to release a new version, bump the SDK, or cut a release.
+user-invocable: true
+argument-hint: "[patch|minor|major]"
+---
+
+Bump both `@rocapine/react-native-onboarding` and `@rocapine/react-native-onboarding-ui` to a new version, write changelog entries for both, and create a commit.
+
+Both packages always share the same version number.
+
+---
+
+## Step 1 — Analyze the diff
+
+Run:
+```bash
+git diff main...HEAD -- packages/
+```
+
+Also run:
+```bash
+git log main...HEAD --oneline
+```
+
+Read the diff carefully. Classify each change:
+
+| Signal | Bump |
+|--------|------|
+| Breaking API change, removed export, type narrowing that breaks callers | **MAJOR** |
+| New feature, new UIElement, new prop, new hook, new export | **MINOR** |
+| Bug fix, style tweak, internal refactor, doc update, example update only | **PATCH** |
+
+Use the highest applicable level across all changes.
+
+---
+
+## Step 2 — Ask the user
+
+Show a compact summary:
+
+```
+Changes on this branch:
+• <bullet per logical change>
+
+Recommendation: MINOR — new feature added (no breaking changes)
+
+Bump type? [PATCH / MINOR / MAJOR]
+```
+
+If the user passed an argument (`/bump-version patch`), skip asking and use that directly.
+
+Wait for confirmation before proceeding.
+
+---
+
+## Step 3 — Compute new version
+
+Read current version from `packages/onboarding/package.json` (field `"version"`).
+
+Apply the bump:
+- PATCH: `x.y.Z+1`
+- MINOR: `x.Y+1.0`
+- MAJOR: `X+1.0.0`
+
+Call this `NEW_VERSION`.
+
+---
+
+## Step 4 — Update package.json files
+
+Edit **both** files — only the `"version"` field:
+- `packages/onboarding/package.json`
+- `packages/onboarding-ui/package.json`
+
+Set `"version": "<NEW_VERSION>"` in each.
+
+---
+
+## Step 5 — Write changelog entries
+
+Read the diff again (already done in Step 1). Write a changelog entry for **each package separately** — the headless SDK entry describes schema/type/hook changes; the UI entry describes renderer/component/theme changes. Be specific and useful; follow the existing entry style in each file.
+
+**Format to prepend** (insert after the `---` separator line at the top, before the previous `## [x.y.z]` entry):
+
+```markdown
+## [NEW_VERSION] - YYYY-MM-DD
+
+### Added
+- **X** — description.
+
+### Changed
+- **Y** — description.
+
+### Fixed
+- **Z** — description.
+
+---
+```
+
+Only include sections that apply. Today's date: read from the environment or use the date in the conversation context.
+
+Files to update:
+- `packages/onboarding/CHANGELOG.md`
+- `packages/onboarding-ui/CHANGELOG.md`
+
+---
+
+## Step 6 — Commit
+
+Stage only the four files:
+```bash
+git add packages/onboarding/package.json packages/onboarding-ui/package.json packages/onboarding/CHANGELOG.md packages/onboarding-ui/CHANGELOG.md
+```
+
+Commit message format (gitmoji conventional):
+```
+📦 chore(release): bump to <NEW_VERSION>, update changelogs and docs
+```
+
+Show the user the proposed commit message before running — confirm then commit.
+
+Do **not** push. Do **not** run `npm publish`. The user handles publishing separately.
+
+---
+
+## Step 7 — Summary
+
+Print:
+
+```
+Bumped: x.y.z → NEW_VERSION (BUMP_TYPE)
+Commit: <sha or "done">
+Next: npm run publish:all  (when ready to publish)
+```

--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,14 @@
+# Symlink these paths into every git worktree instead of copying them.
+# Format: one path per line (relative to repo root).
+
+# Root dependencies
+node_modules
+
+# Package dependencies
+packages/onboarding/node_modules
+packages/onboarding-ui/node_modules
+
+# Example app dependencies and env
+example/node_modules
+example/.env
+example/.env.local

--- a/example/app/example/composable-screen.tsx
+++ b/example/app/example/composable-screen.tsx
@@ -225,6 +225,36 @@ export default function ComposableScreenExample() {
                 marginVertical: 4,
               },
             },
+            // Checkbox group element
+            {
+              id: 'hero-checkbox',
+              type: 'CheckboxGroup' as const,
+              props: {
+                variableName: 'goals',
+                defaultValues: ['health', 'fitness'],
+                gap: 8,
+                marginVertical: 8,
+                items: [
+                  { label: 'Improve health', value: 'health' },
+                  { label: 'Build fitness', value: 'fitness' },
+                  { label: 'Lose weight', value: 'weight' },
+                  { label: 'Gain muscle', value: 'muscle' },
+                ],
+              },
+            },
+            // Expression text — shows selected goals
+            {
+              id: 'goals-display',
+              type: 'Text' as const,
+              props: {
+                content: 'Goals: {{goals}}',
+                mode: 'expression' as const,
+                fontSize: 14,
+                textAlign: 'center' as const,
+                opacity: 0.7,
+                marginVertical: 4,
+              },
+            },
             // Button element
             {
               id: 'hero-button',

--- a/packages/onboarding-ui/CHANGELOG.md
+++ b/packages/onboarding-ui/CHANGELOG.md
@@ -5,6 +5,20 @@ here.
 
 ---
 
+## [1.9.0] - 2026-04-22
+
+### Added
+
+- **`Checkbox` element renderer** — renders `Checkbox` UIElements as a tappable
+  checkbox with an optional text label. The box toggles between checked and unchecked
+  state; tapping writes `{ value: "true" | "false" }` into `composableVariables`
+  via `variableName`. Supports `defaultValue` (boolean), `checkedColor`,
+  `uncheckedColor`, `checkmarkColor`, `size`, `borderRadius`, `labelColor`,
+  `labelFontSize`, `labelFontWeight`, `labelFontFamily`, `gap`, and all
+  `BaseBoxProps` for the outer container.
+
+---
+
 ## [1.8.1] - 2026-04-22
 
 ### Added

--- a/packages/onboarding-ui/CHANGELOG.md
+++ b/packages/onboarding-ui/CHANGELOG.md
@@ -9,13 +9,17 @@ here.
 
 ### Added
 
-- **`Checkbox` element renderer** — renders `Checkbox` UIElements as a tappable
-  checkbox with an optional text label. The box toggles between checked and unchecked
-  state; tapping writes `{ value: "true" | "false" }` into `composableVariables`
-  via `variableName`. Supports `defaultValue` (boolean), `checkedColor`,
-  `uncheckedColor`, `checkmarkColor`, `size`, `borderRadius`, `labelColor`,
-  `labelFontSize`, `labelFontWeight`, `labelFontFamily`, `gap`, and all
-  `BaseBoxProps` for the outer container.
+- **`CheckboxGroup` element renderer** — renders `CheckboxGroup` UIElements as a
+  vertical (default) or horizontal list of tappable checkbox items. Each item shows
+  a square checkbox indicator and a label; tapping toggles the item's value in/out
+  of the selected set. On mount, sets `defaultValues` into `composableVariables` (keyed
+  by `variableName`) as `{ value: JSON.stringify(string[]), label: string }`.
+  Subsequent toggles update the same entry. Supports all per-item style props
+  (`itemBackgroundColor`, `itemSelectedBackgroundColor`, `itemBorderColor`,
+  `itemSelectedBorderColor`, `itemBorderRadius`, `itemBorderWidth`, `itemColor`,
+  `itemSelectedColor`, `itemFontSize`, `itemFontWeight`, `itemFontFamily`,
+  `itemPadding`, `itemPaddingHorizontal`, `itemPaddingVertical`), `gap`,
+  `direction`, and all `BaseBoxProps` for the group container.
 
 ---
 

--- a/packages/onboarding-ui/package.json
+++ b/packages/onboarding-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocapine/react-native-onboarding-ui",
-  "version": "1.8.1",
+  "version": "1.9.0",
   "description": "UI components and renderers for Rocapine Onboarding Studio - Built on top of the headless SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -43,7 +43,7 @@
   },
   "peerDependencies": {
     "@react-native-picker/picker": "*",
-    "@rocapine/react-native-onboarding": "^1.8.0",
+    "@rocapine/react-native-onboarding": "^1.9.0",
     "@shopify/react-native-skia": ">=1.0.0",
     "@tanstack/react-query": ">=5.0.0",
     "@types/react": "*",

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/CheckboxGroupElement.tsx
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/CheckboxGroupElement.tsx
@@ -2,8 +2,8 @@ import React, { useEffect } from "react";
 import { z } from "zod";
 import { View, Text, TouchableOpacity } from "react-native";
 import { BaseBoxProps, BaseBoxPropsSchema } from "./BaseBoxProps";
-import { UIElement } from "../types";
-import { RenderContext } from "./shared";
+import type { UIElement } from "../types";
+import type { RenderContext } from "./shared";
 
 export type CheckboxGroupElementProps = BaseBoxProps & {
   variableName?: string;
@@ -54,11 +54,11 @@ export const CheckboxGroupElementPropsSchema = BaseBoxPropsSchema.extend({
     ctx.addIssue({ code: z.ZodIssueCode.custom, message: "item values must be unique", path: ["items"] });
   }
   if (data.defaultValues !== undefined) {
-    for (const dv of data.defaultValues) {
+    data.defaultValues.forEach((dv, i) => {
       if (!unique.has(dv)) {
-        ctx.addIssue({ code: z.ZodIssueCode.custom, message: `defaultValues entry "${dv}" must match one of the item values`, path: ["defaultValues"] });
+        ctx.addIssue({ code: z.ZodIssueCode.custom, message: `defaultValues entry "${dv}" must match one of the item values`, path: ["defaultValues", i] });
       }
-    }
+    });
   }
 });
 
@@ -73,7 +73,10 @@ export const CheckboxGroupComponent = ({ element, ctx }: Props): React.ReactElem
   const { theme, variables, setVariable } = ctx;
   // The variable stores a JSON-serialised string[] to stay compatible with the string-based variable system.
   const rawValue = element.props.variableName ? variables[element.props.variableName]?.value : undefined;
-  const selectedValues: string[] = rawValue ? JSON.parse(rawValue) : undefined;
+  const selectedValues: string[] | undefined = (() => {
+    if (typeof rawValue !== "string") return undefined;
+    try { return JSON.parse(rawValue) as string[]; } catch { return undefined; }
+  })();
 
   useEffect(() => {
     if (element.props.variableName && element.props.defaultValues && selectedValues === undefined) {
@@ -122,9 +125,8 @@ export const CheckboxGroupComponent = ({ element, ctx }: Props): React.ReactElem
     >
       {element.props.items.map((item) => {
         const isSelected = (selectedValues ?? []).includes(item.value);
-        // Note: "+ "15"" appends hex alpha (≈8% opacity) assuming a 6-digit hex primary color.
         const bgColor = isSelected
-          ? (element.props.itemSelectedBackgroundColor ?? theme.colors.primary + "15")
+          ? (element.props.itemSelectedBackgroundColor ?? (theme.colors.primary.startsWith("#") ? theme.colors.primary + "1A" : theme.colors.primary))
           : (element.props.itemBackgroundColor ?? "transparent");
         const textColor = isSelected
           ? (element.props.itemSelectedColor ?? theme.colors.primary)

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/CheckboxGroupElement.tsx
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/CheckboxGroupElement.tsx
@@ -1,0 +1,198 @@
+import React, { useEffect } from "react";
+import { z } from "zod";
+import { View, Text, TouchableOpacity } from "react-native";
+import { BaseBoxProps, BaseBoxPropsSchema } from "./BaseBoxProps";
+import { UIElement } from "../types";
+import { RenderContext } from "./shared";
+
+export type CheckboxGroupElementProps = BaseBoxProps & {
+  variableName?: string;
+  defaultValues?: string[];
+  gap?: number;
+  direction?: "vertical" | "horizontal";
+  items: Array<{ label: string; value: string }>;
+  itemBackgroundColor?: string;
+  itemSelectedBackgroundColor?: string;
+  itemBorderColor?: string;
+  itemSelectedBorderColor?: string;
+  itemBorderRadius?: number;
+  itemBorderWidth?: number;
+  itemColor?: string;
+  itemSelectedColor?: string;
+  itemFontSize?: number;
+  itemFontWeight?: string;
+  itemFontFamily?: string;
+  itemPadding?: number;
+  itemPaddingHorizontal?: number;
+  itemPaddingVertical?: number;
+};
+
+export const CheckboxGroupElementPropsSchema = BaseBoxPropsSchema.extend({
+  variableName: z.string().optional(),
+  defaultValues: z.array(z.string()).optional(),
+  gap: z.number().optional(),
+  direction: z.enum(["vertical", "horizontal"]).optional(),
+  items: z.array(z.object({ label: z.string().trim().min(1, "item label must not be empty"), value: z.string().trim().min(1, "item value must not be empty") })).min(1, "items must not be empty"),
+  itemBackgroundColor: z.string().optional(),
+  itemSelectedBackgroundColor: z.string().optional(),
+  itemBorderColor: z.string().optional(),
+  itemSelectedBorderColor: z.string().optional(),
+  itemBorderRadius: z.number().optional(),
+  itemBorderWidth: z.number().optional(),
+  itemColor: z.string().optional(),
+  itemSelectedColor: z.string().optional(),
+  itemFontSize: z.number().optional(),
+  itemFontWeight: z.string().optional(),
+  itemFontFamily: z.string().optional(),
+  itemPadding: z.number().optional(),
+  itemPaddingHorizontal: z.number().optional(),
+  itemPaddingVertical: z.number().optional(),
+}).superRefine((data, ctx) => {
+  const values = data.items.map((i) => i.value);
+  const unique = new Set(values);
+  if (unique.size !== values.length) {
+    ctx.addIssue({ code: z.ZodIssueCode.custom, message: "item values must be unique", path: ["items"] });
+  }
+  if (data.defaultValues !== undefined) {
+    for (const dv of data.defaultValues) {
+      if (!unique.has(dv)) {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, message: `defaultValues entry "${dv}" must match one of the item values`, path: ["defaultValues"] });
+      }
+    }
+  }
+});
+
+type CheckboxGroupUIElement = Extract<UIElement, { type: "CheckboxGroup" }>;
+
+type Props = {
+  element: CheckboxGroupUIElement;
+  ctx: RenderContext;
+};
+
+export const CheckboxGroupComponent = ({ element, ctx }: Props): React.ReactElement => {
+  const { theme, variables, setVariable } = ctx;
+  // The variable stores a JSON-serialised string[] to stay compatible with the string-based variable system.
+  const rawValue = element.props.variableName ? variables[element.props.variableName]?.value : undefined;
+  const selectedValues: string[] = rawValue ? JSON.parse(rawValue) : undefined;
+
+  useEffect(() => {
+    if (element.props.variableName && element.props.defaultValues && selectedValues === undefined) {
+      const defaultLabels = element.props.defaultValues.map((dv) => element.props.items.find((i) => i.value === dv)?.label ?? dv);
+      setVariable(element.props.variableName, {
+        value: JSON.stringify(element.props.defaultValues),
+        label: defaultLabels.join(", "),
+      });
+    }
+  }, [element.props.variableName, element.props.defaultValues, element.props.items, selectedValues]);
+
+  const handleToggle = (value: string, label: string) => {
+    if (!element.props.variableName) return;
+    const current: string[] = selectedValues ?? [];
+    const next = current.includes(value) ? current.filter((v) => v !== value) : [...current, value];
+    const nextLabels = next.map((v) => element.props.items.find((i) => i.value === v)?.label ?? v);
+    setVariable(element.props.variableName, {
+      value: JSON.stringify(next),
+      label: nextLabels.join(", "),
+    });
+  };
+
+  const isHorizontal = element.props.direction === "horizontal";
+
+  return (
+    <View
+      accessibilityRole="list"
+      style={{
+        flexDirection: isHorizontal ? "row" : "column",
+        flexWrap: isHorizontal ? "wrap" : undefined,
+        alignSelf: element.props.alignSelf,
+        gap: element.props.gap ?? 8,
+        width: element.props.width,
+        height: element.props.height,
+        margin: element.props.margin,
+        marginHorizontal: element.props.marginHorizontal,
+        marginVertical: element.props.marginVertical,
+        padding: element.props.padding,
+        paddingHorizontal: element.props.paddingHorizontal,
+        paddingVertical: element.props.paddingVertical,
+        borderWidth: element.props.borderWidth,
+        borderRadius: element.props.borderRadius,
+        borderColor: element.props.borderColor,
+        opacity: element.props.opacity,
+      }}
+    >
+      {element.props.items.map((item) => {
+        const isSelected = (selectedValues ?? []).includes(item.value);
+        // Note: "+ "15"" appends hex alpha (≈8% opacity) assuming a 6-digit hex primary color.
+        const bgColor = isSelected
+          ? (element.props.itemSelectedBackgroundColor ?? theme.colors.primary + "15")
+          : (element.props.itemBackgroundColor ?? "transparent");
+        const textColor = isSelected
+          ? (element.props.itemSelectedColor ?? theme.colors.primary)
+          : (element.props.itemColor ?? theme.colors.text.primary);
+        const borderColor = isSelected
+          ? (element.props.itemSelectedBorderColor ?? theme.colors.primary)
+          : (element.props.itemBorderColor ?? theme.colors.neutral.low);
+
+        return (
+          <TouchableOpacity
+            key={item.value}
+            activeOpacity={0.7}
+            onPress={() => handleToggle(item.value, item.label)}
+            accessibilityRole="checkbox"
+            accessibilityState={{ checked: isSelected }}
+            accessibilityLabel={item.label}
+            style={{
+              flexDirection: "row",
+              alignItems: "center",
+              gap: 12,
+              backgroundColor: bgColor,
+              borderRadius: element.props.itemBorderRadius ?? 8,
+              borderWidth: element.props.itemBorderWidth ?? 1,
+              borderColor: borderColor,
+              padding: element.props.itemPadding ?? (element.props.itemPaddingHorizontal === undefined && element.props.itemPaddingVertical === undefined ? 12 : undefined),
+              paddingHorizontal: element.props.itemPaddingHorizontal,
+              paddingVertical: element.props.itemPaddingVertical,
+            }}
+          >
+            <View
+              style={{
+                width: 20,
+                height: 20,
+                borderRadius: 4,
+                borderWidth: 2,
+                borderColor: isSelected ? theme.colors.primary : theme.colors.neutral.medium,
+                alignItems: "center",
+                justifyContent: "center",
+                backgroundColor: isSelected ? theme.colors.primary : "transparent",
+              }}
+            >
+              {isSelected && (
+                <Text
+                  style={{
+                    color: "#fff",
+                    fontSize: 12,
+                    fontWeight: "700",
+                    lineHeight: 14,
+                  }}
+                >
+                  ✓
+                </Text>
+              )}
+            </View>
+            <Text
+              style={{
+                flexShrink: 1,
+                color: textColor,
+                fontSize: element.props.itemFontSize ?? theme.typography.textStyles.body.fontSize,
+                fontWeight: (element.props.itemFontWeight as any) ?? theme.typography.textStyles.body.fontWeight,
+                fontFamily: element.props.itemFontFamily,
+              }}
+            >
+              {item.label}
+            </Text>
+          </TouchableOpacity>
+        );
+      })}
+    </View>
+  );
+};

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/renderElement.tsx
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/renderElement.tsx
@@ -10,6 +10,7 @@ import { IconElementComponent } from "./IconElement";
 import { VideoElementRenderer } from "./VideoElement";
 import { InputElementComponent } from "./InputElement";
 import { RadioGroupComponent } from "./RadioGroupElement";
+import { CheckboxGroupComponent } from "./CheckboxGroupElement";
 import { ButtonElementComponent } from "./ButtonElement";
 
 export const renderElement = (
@@ -51,6 +52,10 @@ export const renderElement = (
 
   if (element.type === "RadioGroup") {
     return <RadioGroupComponent key={element.id} element={element} ctx={ctx} />;
+  }
+
+  if (element.type === "CheckboxGroup") {
+    return <CheckboxGroupComponent key={element.id} element={element} ctx={ctx} />;
   }
 
   if (element.type === "Button") {

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/types.ts
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/types.ts
@@ -10,6 +10,7 @@ import { type VideoElementProps, VideoElementPropsSchema } from "./elements/Vide
 import { type InputElementProps, InputElementPropsSchema } from "./elements/InputElement";
 import { type ButtonElementProps, ButtonElementPropsSchema } from "./elements/ButtonElement";
 import { type RadioGroupElementProps, RadioGroupElementPropsSchema } from "./elements/RadioGroupElement";
+import { type CheckboxGroupElementProps, CheckboxGroupElementPropsSchema } from "./elements/CheckboxGroupElement";
 
 export type { BaseBoxProps } from "./elements/BaseBoxProps";
 export { BaseBoxPropsSchema } from "./elements/BaseBoxProps";
@@ -23,6 +24,7 @@ export type { VideoElementProps } from "./elements/VideoElement";
 export type { InputElementProps } from "./elements/InputElement";
 export type { ButtonElementProps } from "./elements/ButtonElement";
 export type { RadioGroupElementProps } from "./elements/RadioGroupElement";
+export type { CheckboxGroupElementProps } from "./elements/CheckboxGroupElement";
 
 // UIElement union — must live here (not in elements/) to avoid circular deps
 // because the Stack variant's children: UIElement[] references itself.
@@ -87,6 +89,12 @@ export type UIElement =
       name?: string;
       type: "RadioGroup";
       props: RadioGroupElementProps;
+    }
+  | {
+      id: string;
+      name?: string;
+      type: "CheckboxGroup";
+      props: CheckboxGroupElementProps;
     };
 
 export const UIElementSchema: z.ZodType<UIElement> = z.lazy(() =>
@@ -151,6 +159,12 @@ export const UIElementSchema: z.ZodType<UIElement> = z.lazy(() =>
       name: z.string().optional(),
       type: z.literal("RadioGroup"),
       props: RadioGroupElementPropsSchema,
+    }),
+    z.object({
+      id: z.string(),
+      name: z.string().optional(),
+      type: z.literal("CheckboxGroup"),
+      props: CheckboxGroupElementPropsSchema,
     }),
   ])
 );

--- a/packages/onboarding/CHANGELOG.md
+++ b/packages/onboarding/CHANGELOG.md
@@ -8,17 +8,23 @@ All notable changes to `@rocapine/react-native-onboarding` are documented here.
 
 ### Added
 
-- **`Checkbox` UIElement schema** for `ComposableScreen` — new discriminated-union
-  variant with `type: "Checkbox"`. Props: `variableName` (string, optional — context
-  key), `defaultValue` (boolean), `label` (string, optional — displayed beside the
-  checkbox), `checkedColor`, `uncheckedColor`, `checkmarkColor`, `size` (number),
-  `borderRadius` (number), `labelColor`, `labelFontSize`, `labelFontWeight`,
-  `labelFontFamily`, `gap` (space between box and label), plus all `BaseBoxProps`.
-  Validated by `CheckboxElementPropsSchema` (Zod).
+- **`CheckboxGroup` UIElement schema** for `ComposableScreen` — new discriminated-union
+  variant with `type: "CheckboxGroup"`. Props: `variableName` (string, optional —
+  context key; selected values written as a JSON `string[]`), `items`
+  (`Array<{ label: string; value: string }>`, required, min 1), `defaultValues`
+  (`string[]`, optional — must reference valid item values), `gap` (number),
+  `direction` (`"vertical"` | `"horizontal"`), per-item styling
+  (`itemBackgroundColor`, `itemSelectedBackgroundColor`, `itemBorderColor`,
+  `itemSelectedBorderColor`, `itemBorderRadius`, `itemBorderWidth`, `itemColor`,
+  `itemSelectedColor`, `itemFontSize`, `itemFontWeight`, `itemFontFamily`,
+  `itemPadding`, `itemPaddingHorizontal`, `itemPaddingVertical`), plus all
+  `BaseBoxProps`. Validated by `CheckboxGroupElementPropsSchema` (Zod); includes
+  `superRefine` checks for unique item values and valid `defaultValues` entries
+  (per-index error paths).
 
 > **Backend note:** The `onboarding-studio` server must be updated to accept and
-> emit the `Checkbox` `UIElement` variant in `ComposableScreen` payloads. Mirror
-> `CheckboxElementPropsSchema` in the backend validation layer and add `Checkbox`
+> emit the `CheckboxGroup` `UIElement` variant in `ComposableScreen` payloads. Mirror
+> `CheckboxGroupElementPropsSchema` in the backend validation layer and add `CheckboxGroup`
 > to the CMS element-type picker.
 
 ---

--- a/packages/onboarding/CHANGELOG.md
+++ b/packages/onboarding/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to `@rocapine/react-native-onboarding` are documented here.
 
 ---
 
+## [1.9.0] - 2026-04-22
+
+### Added
+
+- **`Checkbox` UIElement schema** for `ComposableScreen` — new discriminated-union
+  variant with `type: "Checkbox"`. Props: `variableName` (string, optional — context
+  key), `defaultValue` (boolean), `label` (string, optional — displayed beside the
+  checkbox), `checkedColor`, `uncheckedColor`, `checkmarkColor`, `size` (number),
+  `borderRadius` (number), `labelColor`, `labelFontSize`, `labelFontWeight`,
+  `labelFontFamily`, `gap` (space between box and label), plus all `BaseBoxProps`.
+  Validated by `CheckboxElementPropsSchema` (Zod).
+
+> **Backend note:** The `onboarding-studio` server must be updated to accept and
+> emit the `Checkbox` `UIElement` variant in `ComposableScreen` payloads. Mirror
+> `CheckboxElementPropsSchema` in the backend validation layer and add `Checkbox`
+> to the CMS element-type picker.
+
+---
+
 ## [1.8.1] - 2026-04-22
 
 ### Added

--- a/packages/onboarding/package.json
+++ b/packages/onboarding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocapine/react-native-onboarding",
-  "version": "1.8.1",
+  "version": "1.9.0",
   "description": "Headless React Native SDK for Rocapine Onboarding Studio - Data fetching, state management, and hooks",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/onboarding/src/onboarding-example.ts
+++ b/packages/onboarding/src/onboarding-example.ts
@@ -226,6 +226,34 @@ export const onboardingExample = {
                 },
               },
               {
+                id: "hero-checkbox",
+                type: "CheckboxGroup",
+                props: {
+                  variableName: "goals",
+                  defaultValues: ["health", "fitness"],
+                  gap: 8,
+                  marginVertical: 8,
+                  items: [
+                    { label: "Improve health", value: "health" },
+                    { label: "Build fitness", value: "fitness" },
+                    { label: "Lose weight", value: "weight" },
+                    { label: "Gain muscle", value: "muscle" },
+                  ],
+                },
+              },
+              {
+                id: "goals-display",
+                type: "Text",
+                props: {
+                  content: "Goals: {{goals}}",
+                  mode: "expression",
+                  fontSize: 14,
+                  textAlign: "center",
+                  opacity: 0.6,
+                  marginVertical: 4,
+                },
+              },
+              {
                 id: "hero-button",
                 type: "Button",
                 props: {

--- a/packages/onboarding/src/steps/ComposableScreen/elements/CheckboxGroupElement.ts
+++ b/packages/onboarding/src/steps/ComposableScreen/elements/CheckboxGroupElement.ts
@@ -50,10 +50,10 @@ export const CheckboxGroupElementPropsSchema = BaseBoxPropsSchema.extend({
     ctx.addIssue({ code: z.ZodIssueCode.custom, message: "item values must be unique", path: ["items"] });
   }
   if (data.defaultValues !== undefined) {
-    for (const dv of data.defaultValues) {
+    data.defaultValues.forEach((dv, i) => {
       if (!unique.has(dv)) {
-        ctx.addIssue({ code: z.ZodIssueCode.custom, message: `defaultValues entry "${dv}" must match one of the item values`, path: ["defaultValues"] });
+        ctx.addIssue({ code: z.ZodIssueCode.custom, message: `defaultValues entry "${dv}" must match one of the item values`, path: ["defaultValues", i] });
       }
-    }
+    });
   }
 });

--- a/packages/onboarding/src/steps/ComposableScreen/elements/CheckboxGroupElement.ts
+++ b/packages/onboarding/src/steps/ComposableScreen/elements/CheckboxGroupElement.ts
@@ -1,0 +1,59 @@
+import { z } from "zod";
+import { BaseBoxProps, BaseBoxPropsSchema } from "./BaseBoxProps";
+
+export type CheckboxGroupElementProps = BaseBoxProps & {
+  variableName?: string;
+  defaultValues?: string[];
+  gap?: number;
+  direction?: "vertical" | "horizontal";
+  items: Array<{ label: string; value: string }>;
+  itemBackgroundColor?: string;
+  itemSelectedBackgroundColor?: string;
+  itemBorderColor?: string;
+  itemSelectedBorderColor?: string;
+  itemBorderRadius?: number;
+  itemBorderWidth?: number;
+  itemColor?: string;
+  itemSelectedColor?: string;
+  itemFontSize?: number;
+  itemFontWeight?: string;
+  itemFontFamily?: string;
+  itemPadding?: number;
+  itemPaddingHorizontal?: number;
+  itemPaddingVertical?: number;
+};
+
+export const CheckboxGroupElementPropsSchema = BaseBoxPropsSchema.extend({
+  variableName: z.string().optional(),
+  defaultValues: z.array(z.string()).optional(),
+  gap: z.number().optional(),
+  direction: z.enum(["vertical", "horizontal"]).optional(),
+  items: z.array(z.object({ label: z.string().trim().min(1, "item label must not be empty"), value: z.string().trim().min(1, "item value must not be empty") })).min(1, "items must not be empty"),
+  itemBackgroundColor: z.string().optional(),
+  itemSelectedBackgroundColor: z.string().optional(),
+  itemBorderColor: z.string().optional(),
+  itemSelectedBorderColor: z.string().optional(),
+  itemBorderRadius: z.number().optional(),
+  itemBorderWidth: z.number().optional(),
+  itemColor: z.string().optional(),
+  itemSelectedColor: z.string().optional(),
+  itemFontSize: z.number().optional(),
+  itemFontWeight: z.string().optional(),
+  itemFontFamily: z.string().optional(),
+  itemPadding: z.number().optional(),
+  itemPaddingHorizontal: z.number().optional(),
+  itemPaddingVertical: z.number().optional(),
+}).superRefine((data, ctx) => {
+  const values = data.items.map((i) => i.value);
+  const unique = new Set(values);
+  if (unique.size !== values.length) {
+    ctx.addIssue({ code: z.ZodIssueCode.custom, message: "item values must be unique", path: ["items"] });
+  }
+  if (data.defaultValues !== undefined) {
+    for (const dv of data.defaultValues) {
+      if (!unique.has(dv)) {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, message: `defaultValues entry "${dv}" must match one of the item values`, path: ["defaultValues"] });
+      }
+    }
+  }
+});

--- a/packages/onboarding/src/steps/ComposableScreen/types.ts
+++ b/packages/onboarding/src/steps/ComposableScreen/types.ts
@@ -10,6 +10,7 @@ import { type VideoElementProps, VideoElementPropsSchema } from "./elements/Vide
 import { type InputElementProps, InputElementPropsSchema } from "./elements/InputElement";
 import { type ButtonElementProps, ButtonElementPropsSchema } from "./elements/ButtonElement";
 import { type RadioGroupElementProps, RadioGroupElementPropsSchema } from "./elements/RadioGroupElement";
+import { type CheckboxGroupElementProps, CheckboxGroupElementPropsSchema } from "./elements/CheckboxGroupElement";
 
 export type { BaseBoxProps } from "./elements/BaseBoxProps";
 export { BaseBoxPropsSchema } from "./elements/BaseBoxProps";
@@ -23,6 +24,7 @@ export type { VideoElementProps } from "./elements/VideoElement";
 export type { InputElementProps } from "./elements/InputElement";
 export type { ButtonElementProps } from "./elements/ButtonElement";
 export type { RadioGroupElementProps } from "./elements/RadioGroupElement";
+export type { CheckboxGroupElementProps } from "./elements/CheckboxGroupElement";
 
 // UIElement union — must live here (not in elements/) to avoid circular deps
 // because the Stack variant's children: UIElement[] references itself.
@@ -87,6 +89,12 @@ type UIElement =
       name?: string;
       type: "RadioGroup";
       props: RadioGroupElementProps;
+    }
+  | {
+      id: string;
+      name?: string;
+      type: "CheckboxGroup";
+      props: CheckboxGroupElementProps;
     };
 
 const UIElementSchema: z.ZodType<UIElement> = z.lazy(() =>
@@ -151,6 +159,12 @@ const UIElementSchema: z.ZodType<UIElement> = z.lazy(() =>
       name: z.string().optional(),
       type: z.literal("RadioGroup"),
       props: RadioGroupElementPropsSchema,
+    }),
+    z.object({
+      id: z.string(),
+      name: z.string().optional(),
+      type: z.literal("CheckboxGroup"),
+      props: CheckboxGroupElementPropsSchema,
     }),
   ])
 );


### PR DESCRIPTION
## Summary
- Add `CheckboxGroup` UIElement to ComposableScreen (headless schema + UI renderer)
- Multi-select: selected values stored as `string[]` in variable context under element `id`
- Variable binding via `id` prop (same pattern as RadioGroup)
- Add Claude skills: `add-uielement`, `bump-version`, and `add-uielement` agent

## Files changed
- `packages/onboarding/src/steps/ComposableScreen/elements/CheckboxGroupElement.ts` (new)
- `packages/onboarding/src/steps/ComposableScreen/types.ts`
- `packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/CheckboxGroupElement.tsx` (new)
- `packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/renderElement.tsx`
- `packages/onboarding-ui/src/UI/Pages/ComposableScreen/types.ts`
- `packages/onboarding/src/onboarding-example.ts`
- `example/app/example/composable-screen.tsx`

## Version
`1.8.1` → `1.9.0` (MINOR)

## onboarding-studio
Mirror the schema changes in the CMS — add `CheckboxGroup` to the UIElement union with props: `id`, `options: Array<{ label, value }>`, `defaultValues?: string[]`, `alignSelf?`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CheckboxGroup UI element supporting multiple checkbox selections with customizable styling, layout options, and variable binding.

* **Documentation**
  * Updated changelogs documenting the new CheckboxGroup element and its supported properties for styling and configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->