### PR TITLE
✨ feat(composable-screen): add DatePicker UIElement (v1.10.0)

### DIFF
--- a/example/app/example/composable-screen.tsx
+++ b/example/app/example/composable-screen.tsx
@@ -255,6 +255,32 @@ export default function ComposableScreenExample() {
                 marginVertical: 4,
               },
             },
+            // Date picker element
+            {
+              id: 'hero-date-picker',
+              type: 'DatePicker' as const,
+              props: {
+                variableName: 'birthdate',
+                defaultValue: '1990-01-01T00:00:00.000Z',
+                mode: 'date' as const,
+                display: 'spinner' as const,
+                maximumDate: new Date().toISOString(),
+                marginVertical: 8,
+              },
+            },
+            // Expression text — shows selected date
+            {
+              id: 'birthdate-display',
+              type: 'Text' as const,
+              props: {
+                content: 'Birth date: {{birthdate}}',
+                mode: 'expression' as const,
+                fontSize: 14,
+                textAlign: 'center' as const,
+                opacity: 0.7,
+                marginVertical: 4,
+              },
+            },
             // Button element
             {
               id: 'hero-button',

--- a/package-lock.json
+++ b/package-lock.json
@@ -3427,6 +3427,30 @@
         "react-native": "^0.0.0-0 || >=0.65 <1.0"
       }
     },
+    "node_modules/@react-native-community/datetimepicker": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/datetimepicker/-/datetimepicker-8.6.0.tgz",
+      "integrity": "sha512-yxPSqNfxgpGaqHQIpatqe6ykeBdU/1pdsk/G3x01mY2bpTflLpmVTLqFSJYd3MiZzxNZcMs/j1dQakUczSjcYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "invariant": "^2.2.4"
+      },
+      "peerDependencies": {
+        "expo": ">=52.0.0",
+        "react": "*",
+        "react-native": "*",
+        "react-native-windows": "*"
+      },
+      "peerDependenciesMeta": {
+        "expo": {
+          "optional": true
+        },
+        "react-native-windows": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@react-native-picker/picker": {
       "version": "2.11.4",
       "resolved": "https://registry.npmjs.org/@react-native-picker/picker/-/picker-2.11.4.tgz",
@@ -13500,7 +13524,7 @@
     },
     "packages/onboarding": {
       "name": "@rocapine/react-native-onboarding",
-      "version": "1.8.0",
+      "version": "1.9.0",
       "license": "MIT",
       "dependencies": {
         "@react-native-async-storage/async-storage": "^2.1.0",
@@ -13520,7 +13544,7 @@
     },
     "packages/onboarding-ui": {
       "name": "@rocapine/react-native-onboarding-ui",
-      "version": "1.8.0",
+      "version": "1.9.0",
       "license": "MIT",
       "dependencies": {
         "lucide-react-native": "^0.545.0",
@@ -13530,6 +13554,7 @@
         "zod": "^4.1.11"
       },
       "devDependencies": {
+        "@react-native-community/datetimepicker": "^8.2.0",
         "@react-native-picker/picker": "^2.11.2",
         "@shopify/react-native-skia": "2.4.18",
         "@types/react": "^19.0.0",
@@ -13544,8 +13569,9 @@
         "typescript": "^5.0.0"
       },
       "peerDependencies": {
+        "@react-native-community/datetimepicker": "*",
         "@react-native-picker/picker": "*",
-        "@rocapine/react-native-onboarding": "^1.8.0",
+        "@rocapine/react-native-onboarding": "^1.9.0",
         "@shopify/react-native-skia": ">=1.0.0",
         "@tanstack/react-query": ">=5.0.0",
         "@types/react": "*",
@@ -13559,6 +13585,9 @@
         "rive-react-native": "*"
       },
       "peerDependenciesMeta": {
+        "@react-native-community/datetimepicker": {
+          "optional": true
+        },
         "@react-native-picker/picker": {
           "optional": true
         },

--- a/packages/onboarding-ui/CHANGELOG.md
+++ b/packages/onboarding-ui/CHANGELOG.md
@@ -5,6 +5,22 @@ here.
 
 ---
 
+## [1.10.0] - 2026-04-23
+
+### Added
+
+- **`DatePicker` element renderer** — renders `DatePicker` UIElements using
+  `@react-native-community/datetimepicker` (new optional peer dependency). On mount,
+  initialises the variable from `defaultValue` (or today if omitted) as
+  `{ value: ISO string, label: locale-formatted string }`. On change, updates the
+  same variable; the `label` is human-readable (e.g. `"Apr 23, 2026"` for `mode: "date"`).
+  Supports `minimumDate`, `maximumDate`, `mode` (`date` / `time` / `datetime`),
+  `display` (platform-specific — iOS defaults to `"spinner"`, Android to `"default"`),
+  `textColor`, `accentColor`, `locale`, and all `BaseBoxProps` for the wrapping
+  container.
+
+---
+
 ## [1.9.0] - 2026-04-22
 
 ### Added

--- a/packages/onboarding-ui/package.json
+++ b/packages/onboarding-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocapine/react-native-onboarding-ui",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "description": "UI components and renderers for Rocapine Onboarding Studio - Built on top of the headless SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -45,7 +45,7 @@
   "peerDependencies": {
     "@react-native-community/datetimepicker": "*",
     "@react-native-picker/picker": "*",
-    "@rocapine/react-native-onboarding": "^1.9.0",
+    "@rocapine/react-native-onboarding": "^1.10.0",
     "@shopify/react-native-skia": ">=1.0.0",
     "@tanstack/react-query": ">=5.0.0",
     "@types/react": "*",

--- a/packages/onboarding-ui/package.json
+++ b/packages/onboarding-ui/package.json
@@ -28,6 +28,7 @@
     "zod": "^4.1.11"
   },
   "devDependencies": {
+    "@react-native-community/datetimepicker": "^8.2.0",
     "@react-native-picker/picker": "^2.11.2",
     "@shopify/react-native-skia": "2.4.18",
     "@types/react": "^19.0.0",
@@ -42,6 +43,7 @@
     "typescript": "^5.0.0"
   },
   "peerDependencies": {
+    "@react-native-community/datetimepicker": "*",
     "@react-native-picker/picker": "*",
     "@rocapine/react-native-onboarding": "^1.9.0",
     "@shopify/react-native-skia": ">=1.0.0",
@@ -57,6 +59,9 @@
     "expo-video": "*"
   },
   "peerDependenciesMeta": {
+    "@react-native-community/datetimepicker": {
+      "optional": true
+    },
     "@react-native-picker/picker": {
       "optional": true
     },

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/DatePickerElement.tsx
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/DatePickerElement.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect, useState } from "react";
-import { View, Platform } from "react-native";
+import React, { useEffect, useRef, useState } from "react";
+import { Pressable, Text, View, Platform } from "react-native";
 import DateTimePicker, { DateTimePickerEvent } from "@react-native-community/datetimepicker";
 import { BaseBoxProps, BaseBoxPropsSchema } from "./BaseBoxProps";
 import { z } from "zod";
@@ -20,9 +20,9 @@ export type DatePickerElementProps = BaseBoxProps & {
 
 export const DatePickerElementPropsSchema = BaseBoxPropsSchema.extend({
   variableName: z.string().min(1).optional(),
-  defaultValue: z.string().optional(),
-  minimumDate: z.string().optional(),
-  maximumDate: z.string().optional(),
+  defaultValue: z.string().refine((s) => !isNaN(Date.parse(s)), { message: "Invalid date string" }).optional(),
+  minimumDate: z.string().refine((s) => !isNaN(Date.parse(s)), { message: "Invalid date string" }).optional(),
+  maximumDate: z.string().refine((s) => !isNaN(Date.parse(s)), { message: "Invalid date string" }).optional(),
   mode: z.enum(["date", "time", "datetime"]).optional().default("date"),
   display: z.enum(["default", "spinner", "calendar", "clock", "compact", "inline"]).optional(),
   textColor: z.string().optional(),
@@ -48,7 +48,7 @@ function formatDate(date: Date, mode: "date" | "time" | "datetime"): string {
 }
 
 export const DatePickerElementComponent = ({ element, ctx }: Props): React.ReactElement => {
-  const { variables, setVariable } = ctx;
+  const { theme, variables, setVariable } = ctx;
   const { props } = element;
 
   const persistedValue = props.variableName ? variables[props.variableName]?.value : undefined;
@@ -59,16 +59,26 @@ export const DatePickerElementComponent = ({ element, ctx }: Props): React.React
     : new Date();
 
   const [date, setDate] = useState<Date>(initialDate);
+  const [isPickerVisible, setPickerVisible] = useState(false);
   const mode = props.mode ?? "date";
 
+  // Tracks which variableName has been seeded so re-renders don't clobber a
+  // persisted value that arrived after the first render.
+  const seededVariableRef = useRef<string | undefined>(undefined);
+
   useEffect(() => {
-    if (props.variableName && persistedValue === undefined) {
+    if (
+      props.variableName &&
+      persistedValue === undefined &&
+      seededVariableRef.current !== props.variableName
+    ) {
+      seededVariableRef.current = props.variableName;
       setVariable(props.variableName, {
         value: initialDate.toISOString(),
         label: formatDate(initialDate, mode),
       });
     }
-  }, []);
+  }, [props.variableName, persistedValue, initialDate, mode, setVariable]);
 
   const handleChange = (_event: DateTimePickerEvent, selected?: Date) => {
     if (!selected) return;
@@ -81,35 +91,81 @@ export const DatePickerElementComponent = ({ element, ctx }: Props): React.React
     }
   };
 
+  const containerStyle = {
+    alignSelf: props.alignSelf,
+    width: props.width,
+    height: props.height,
+    margin: props.margin,
+    marginHorizontal: props.marginHorizontal,
+    marginVertical: props.marginVertical,
+    padding: props.padding,
+    paddingHorizontal: props.paddingHorizontal,
+    paddingVertical: props.paddingVertical,
+    opacity: props.opacity,
+    borderWidth: props.borderWidth,
+    borderRadius: props.borderRadius,
+    borderColor: props.borderColor,
+    overflow: "hidden" as const,
+  };
+
+  const pickerProps = {
+    value: date,
+    mode,
+    onChange: handleChange,
+    minimumDate: props.minimumDate ? new Date(props.minimumDate) : undefined,
+    maximumDate: props.maximumDate ? new Date(props.maximumDate) : undefined,
+    // Fall back to theme tokens when CMS props are not provided.
+    textColor: props.textColor ?? theme.colors.text.primary,
+    accentColor: props.accentColor ?? theme.colors.primary,
+    locale: props.locale,
+  };
+
+  if (Platform.OS === "android") {
+    return (
+      <View style={containerStyle}>
+        <Pressable
+          onPress={() => setPickerVisible(true)}
+          style={{
+            flexDirection: "row",
+            alignItems: "center",
+            justifyContent: "space-between",
+            paddingVertical: 12,
+            paddingHorizontal: 16,
+            borderRadius: props.borderRadius ?? 8,
+            borderWidth: props.borderWidth ?? 1,
+            borderColor: props.borderColor ?? theme.colors.neutral.low,
+            backgroundColor: theme.colors.neutral.lowest,
+          }}
+        >
+          <Text
+            style={{
+              color: props.textColor ?? theme.colors.text.primary,
+              fontSize: theme.typography.textStyles.body.fontSize,
+            }}
+          >
+            {formatDate(date, mode)}
+          </Text>
+          <Text style={{ color: theme.colors.text.tertiary, fontSize: 16 }}>›</Text>
+        </Pressable>
+        {isPickerVisible && (
+          <DateTimePicker
+            {...pickerProps}
+            display={(props.display ?? "default") as any}
+            onChange={(event, selected) => {
+              setPickerVisible(false);
+              handleChange(event, selected);
+            }}
+          />
+        )}
+      </View>
+    );
+  }
+
   return (
-    <View
-      style={{
-        alignSelf: props.alignSelf,
-        width: props.width,
-        height: props.height,
-        margin: props.margin,
-        marginHorizontal: props.marginHorizontal,
-        marginVertical: props.marginVertical,
-        padding: props.padding,
-        paddingHorizontal: props.paddingHorizontal,
-        paddingVertical: props.paddingVertical,
-        opacity: props.opacity,
-        borderWidth: props.borderWidth,
-        borderRadius: props.borderRadius,
-        borderColor: props.borderColor,
-        overflow: "hidden",
-      }}
-    >
+    <View style={containerStyle}>
       <DateTimePicker
-        value={date}
-        mode={mode}
-        display={(props.display ?? (Platform.OS === "ios" ? "spinner" : "default")) as any}
-        onChange={handleChange}
-        minimumDate={props.minimumDate ? new Date(props.minimumDate) : undefined}
-        maximumDate={props.maximumDate ? new Date(props.maximumDate) : undefined}
-        textColor={props.textColor}
-        accentColor={props.accentColor}
-        locale={props.locale}
+        {...pickerProps}
+        display={(props.display ?? "spinner") as any}
       />
     </View>
   );

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/DatePickerElement.tsx
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/DatePickerElement.tsx
@@ -1,0 +1,116 @@
+import React, { useEffect, useState } from "react";
+import { View, Platform } from "react-native";
+import DateTimePicker, { DateTimePickerEvent } from "@react-native-community/datetimepicker";
+import { BaseBoxProps, BaseBoxPropsSchema } from "./BaseBoxProps";
+import { z } from "zod";
+import type { UIElement } from "../types";
+import type { RenderContext } from "./shared";
+
+export type DatePickerElementProps = BaseBoxProps & {
+  variableName?: string;
+  defaultValue?: string;
+  minimumDate?: string;
+  maximumDate?: string;
+  mode?: "date" | "time" | "datetime";
+  display?: "default" | "spinner" | "calendar" | "clock" | "compact" | "inline";
+  textColor?: string;
+  accentColor?: string;
+  locale?: string;
+};
+
+export const DatePickerElementPropsSchema = BaseBoxPropsSchema.extend({
+  variableName: z.string().min(1).optional(),
+  defaultValue: z.string().optional(),
+  minimumDate: z.string().optional(),
+  maximumDate: z.string().optional(),
+  mode: z.enum(["date", "time", "datetime"]).optional().default("date"),
+  display: z.enum(["default", "spinner", "calendar", "clock", "compact", "inline"]).optional(),
+  textColor: z.string().optional(),
+  accentColor: z.string().optional(),
+  locale: z.string().optional(),
+});
+
+type DatePickerUIElement = Extract<UIElement, { type: "DatePicker" }>;
+
+type Props = {
+  element: DatePickerUIElement;
+  ctx: RenderContext;
+};
+
+function formatDate(date: Date, mode: "date" | "time" | "datetime"): string {
+  if (mode === "time") {
+    return date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+  }
+  if (mode === "datetime") {
+    return date.toLocaleString([], { dateStyle: "medium", timeStyle: "short" });
+  }
+  return date.toLocaleDateString([], { dateStyle: "medium" });
+}
+
+export const DatePickerElementComponent = ({ element, ctx }: Props): React.ReactElement => {
+  const { variables, setVariable } = ctx;
+  const { props } = element;
+
+  const persistedValue = props.variableName ? variables[props.variableName]?.value : undefined;
+  const initialDate = persistedValue
+    ? new Date(persistedValue)
+    : props.defaultValue
+    ? new Date(props.defaultValue)
+    : new Date();
+
+  const [date, setDate] = useState<Date>(initialDate);
+  const mode = props.mode ?? "date";
+
+  useEffect(() => {
+    if (props.variableName && persistedValue === undefined) {
+      setVariable(props.variableName, {
+        value: initialDate.toISOString(),
+        label: formatDate(initialDate, mode),
+      });
+    }
+  }, []);
+
+  const handleChange = (_event: DateTimePickerEvent, selected?: Date) => {
+    if (!selected) return;
+    setDate(selected);
+    if (props.variableName) {
+      setVariable(props.variableName, {
+        value: selected.toISOString(),
+        label: formatDate(selected, mode),
+      });
+    }
+  };
+
+  return (
+    <View
+      style={{
+        alignSelf: props.alignSelf,
+        width: props.width,
+        height: props.height,
+        margin: props.margin,
+        marginHorizontal: props.marginHorizontal,
+        marginVertical: props.marginVertical,
+        padding: props.padding,
+        paddingHorizontal: props.paddingHorizontal,
+        paddingVertical: props.paddingVertical,
+        opacity: props.opacity,
+        borderWidth: props.borderWidth,
+        borderRadius: props.borderRadius,
+        borderColor: props.borderColor,
+        overflow: "hidden",
+      }}
+    >
+      <DateTimePicker
+        value={date}
+        mode={mode}
+        display={(props.display ?? (Platform.OS === "ios" ? "spinner" : "default")) as any}
+        onChange={handleChange}
+        minimumDate={props.minimumDate ? new Date(props.minimumDate) : undefined}
+        maximumDate={props.maximumDate ? new Date(props.maximumDate) : undefined}
+        textColor={props.textColor}
+        accentColor={props.accentColor}
+        locale={props.locale}
+      />
+    </View>
+  );
+};

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/renderElement.tsx
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/renderElement.tsx
@@ -12,6 +12,7 @@ import { InputElementComponent } from "./InputElement";
 import { RadioGroupComponent } from "./RadioGroupElement";
 import { CheckboxGroupComponent } from "./CheckboxGroupElement";
 import { ButtonElementComponent } from "./ButtonElement";
+import { DatePickerElementComponent } from "./DatePickerElement";
 
 export const renderElement = (
   element: UIElement,
@@ -60,6 +61,10 @@ export const renderElement = (
 
   if (element.type === "Button") {
     return <ButtonElementComponent key={element.id} element={element} ctx={ctx} />;
+  }
+
+  if (element.type === "DatePicker") {
+    return <DatePickerElementComponent key={element.id} element={element} ctx={ctx} />;
   }
 
   return null;

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/types.ts
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/types.ts
@@ -11,6 +11,7 @@ import { type InputElementProps, InputElementPropsSchema } from "./elements/Inpu
 import { type ButtonElementProps, ButtonElementPropsSchema } from "./elements/ButtonElement";
 import { type RadioGroupElementProps, RadioGroupElementPropsSchema } from "./elements/RadioGroupElement";
 import { type CheckboxGroupElementProps, CheckboxGroupElementPropsSchema } from "./elements/CheckboxGroupElement";
+import { type DatePickerElementProps, DatePickerElementPropsSchema } from "./elements/DatePickerElement";
 
 export type { BaseBoxProps } from "./elements/BaseBoxProps";
 export { BaseBoxPropsSchema } from "./elements/BaseBoxProps";
@@ -25,6 +26,7 @@ export type { InputElementProps } from "./elements/InputElement";
 export type { ButtonElementProps } from "./elements/ButtonElement";
 export type { RadioGroupElementProps } from "./elements/RadioGroupElement";
 export type { CheckboxGroupElementProps } from "./elements/CheckboxGroupElement";
+export type { DatePickerElementProps } from "./elements/DatePickerElement";
 
 // UIElement union — must live here (not in elements/) to avoid circular deps
 // because the Stack variant's children: UIElement[] references itself.
@@ -95,6 +97,12 @@ export type UIElement =
       name?: string;
       type: "CheckboxGroup";
       props: CheckboxGroupElementProps;
+    }
+  | {
+      id: string;
+      name?: string;
+      type: "DatePicker";
+      props: DatePickerElementProps;
     };
 
 export const UIElementSchema: z.ZodType<UIElement> = z.lazy(() =>
@@ -165,6 +173,12 @@ export const UIElementSchema: z.ZodType<UIElement> = z.lazy(() =>
       name: z.string().optional(),
       type: z.literal("CheckboxGroup"),
       props: CheckboxGroupElementPropsSchema,
+    }),
+    z.object({
+      id: z.string(),
+      name: z.string().optional(),
+      type: z.literal("DatePicker"),
+      props: DatePickerElementPropsSchema,
     }),
   ])
 );

--- a/packages/onboarding/CHANGELOG.md
+++ b/packages/onboarding/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to `@rocapine/react-native-onboarding` are documented here.
 
 ---
 
+## [1.10.0] - 2026-04-23
+
+### Added
+
+- **`DatePicker` UIElement schema** for `ComposableScreen` — new discriminated-union
+  variant with `type: "DatePicker"`. Props: `variableName` (string, optional — context
+  key; selected date written as ISO 8601 string), `defaultValue` (ISO string, optional),
+  `minimumDate` / `maximumDate` (ISO strings, optional), `mode`
+  (`"date"` | `"time"` | `"datetime"`, default `"date"`), `display`
+  (`"default"` | `"spinner"` | `"calendar"` | `"clock"` | `"compact"` | `"inline"`,
+  optional — platform-specific), `textColor`, `accentColor`, `locale` (strings,
+  optional), plus all `BaseBoxProps`. Validated by `DatePickerElementPropsSchema` (Zod).
+
+> **Backend note:** The `onboarding-studio` server must be updated to accept and
+> emit the `DatePicker` `UIElement` variant in `ComposableScreen` payloads. Mirror
+> `DatePickerElementPropsSchema` in the backend validation layer and add `DatePicker`
+> to the CMS element-type picker.
+
+---
+
 ## [1.9.0] - 2026-04-22
 
 ### Added

--- a/packages/onboarding/package.json
+++ b/packages/onboarding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocapine/react-native-onboarding",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "description": "Headless React Native SDK for Rocapine Onboarding Studio - Data fetching, state management, and hooks",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/onboarding/src/onboarding-example.ts
+++ b/packages/onboarding/src/onboarding-example.ts
@@ -254,6 +254,30 @@ export const onboardingExample = {
                 },
               },
               {
+                id: "hero-date-picker",
+                type: "DatePicker",
+                props: {
+                  variableName: "birthdate",
+                  defaultValue: "1990-01-01T00:00:00.000Z",
+                  mode: "date",
+                  display: "spinner",
+                  maximumDate: new Date().toISOString(),
+                  marginVertical: 8,
+                },
+              },
+              {
+                id: "birthdate-display",
+                type: "Text",
+                props: {
+                  content: "Birth date: {{birthdate}}",
+                  mode: "expression",
+                  fontSize: 14,
+                  textAlign: "center",
+                  opacity: 0.6,
+                  marginVertical: 4,
+                },
+              },
+              {
                 id: "hero-button",
                 type: "Button",
                 props: {

--- a/packages/onboarding/src/onboarding-example.ts
+++ b/packages/onboarding/src/onboarding-example.ts
@@ -261,7 +261,7 @@ export const onboardingExample = {
                   defaultValue: "1990-01-01T00:00:00.000Z",
                   mode: "date",
                   display: "spinner",
-                  maximumDate: new Date().toISOString(),
+                  maximumDate: new Date().toISOString(), // static at module load time — suitable for demo; use a runtime value in production
                   marginVertical: 8,
                 },
               },

--- a/packages/onboarding/src/steps/ComposableScreen/elements/DatePickerElement.ts
+++ b/packages/onboarding/src/steps/ComposableScreen/elements/DatePickerElement.ts
@@ -1,0 +1,26 @@
+import { z } from "zod";
+import { BaseBoxProps, BaseBoxPropsSchema } from "./BaseBoxProps";
+
+export type DatePickerElementProps = BaseBoxProps & {
+  variableName?: string;
+  defaultValue?: string;
+  minimumDate?: string;
+  maximumDate?: string;
+  mode?: "date" | "time" | "datetime";
+  display?: "default" | "spinner" | "calendar" | "clock" | "compact" | "inline";
+  textColor?: string;
+  accentColor?: string;
+  locale?: string;
+};
+
+export const DatePickerElementPropsSchema = BaseBoxPropsSchema.extend({
+  variableName: z.string().min(1).optional(),
+  defaultValue: z.string().optional(),
+  minimumDate: z.string().optional(),
+  maximumDate: z.string().optional(),
+  mode: z.enum(["date", "time", "datetime"]).optional().default("date"),
+  display: z.enum(["default", "spinner", "calendar", "clock", "compact", "inline"]).optional(),
+  textColor: z.string().optional(),
+  accentColor: z.string().optional(),
+  locale: z.string().optional(),
+});

--- a/packages/onboarding/src/steps/ComposableScreen/elements/DatePickerElement.ts
+++ b/packages/onboarding/src/steps/ComposableScreen/elements/DatePickerElement.ts
@@ -15,9 +15,9 @@ export type DatePickerElementProps = BaseBoxProps & {
 
 export const DatePickerElementPropsSchema = BaseBoxPropsSchema.extend({
   variableName: z.string().min(1).optional(),
-  defaultValue: z.string().optional(),
-  minimumDate: z.string().optional(),
-  maximumDate: z.string().optional(),
+  defaultValue: z.string().refine((s) => !isNaN(Date.parse(s)), { message: "Invalid date string" }).optional(),
+  minimumDate: z.string().refine((s) => !isNaN(Date.parse(s)), { message: "Invalid date string" }).optional(),
+  maximumDate: z.string().refine((s) => !isNaN(Date.parse(s)), { message: "Invalid date string" }).optional(),
   mode: z.enum(["date", "time", "datetime"]).optional().default("date"),
   display: z.enum(["default", "spinner", "calendar", "clock", "compact", "inline"]).optional(),
   textColor: z.string().optional(),

--- a/packages/onboarding/src/steps/ComposableScreen/types.ts
+++ b/packages/onboarding/src/steps/ComposableScreen/types.ts
@@ -11,6 +11,7 @@ import { type InputElementProps, InputElementPropsSchema } from "./elements/Inpu
 import { type ButtonElementProps, ButtonElementPropsSchema } from "./elements/ButtonElement";
 import { type RadioGroupElementProps, RadioGroupElementPropsSchema } from "./elements/RadioGroupElement";
 import { type CheckboxGroupElementProps, CheckboxGroupElementPropsSchema } from "./elements/CheckboxGroupElement";
+import { type DatePickerElementProps, DatePickerElementPropsSchema } from "./elements/DatePickerElement";
 
 export type { BaseBoxProps } from "./elements/BaseBoxProps";
 export { BaseBoxPropsSchema } from "./elements/BaseBoxProps";
@@ -25,6 +26,7 @@ export type { InputElementProps } from "./elements/InputElement";
 export type { ButtonElementProps } from "./elements/ButtonElement";
 export type { RadioGroupElementProps } from "./elements/RadioGroupElement";
 export type { CheckboxGroupElementProps } from "./elements/CheckboxGroupElement";
+export type { DatePickerElementProps } from "./elements/DatePickerElement";
 
 // UIElement union — must live here (not in elements/) to avoid circular deps
 // because the Stack variant's children: UIElement[] references itself.
@@ -95,6 +97,12 @@ type UIElement =
       name?: string;
       type: "CheckboxGroup";
       props: CheckboxGroupElementProps;
+    }
+  | {
+      id: string;
+      name?: string;
+      type: "DatePicker";
+      props: DatePickerElementProps;
     };
 
 const UIElementSchema: z.ZodType<UIElement> = z.lazy(() =>
@@ -165,6 +173,12 @@ const UIElementSchema: z.ZodType<UIElement> = z.lazy(() =>
       name: z.string().optional(),
       type: z.literal("CheckboxGroup"),
       props: CheckboxGroupElementPropsSchema,
+    }),
+    z.object({
+      id: z.string(),
+      name: z.string().optional(),
+      type: z.literal("DatePicker"),
+      props: DatePickerElementPropsSchema,
     }),
   ])
 );

--- a/website/docs/changelog/_category_.json
+++ b/website/docs/changelog/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "Changelog",
+  "position": 8,
+  "link": {
+    "type": "generated-index",
+    "description": "Release history for both SDK packages."
+  }
+}

--- a/website/docs/changelog/headless.mdx
+++ b/website/docs/changelog/headless.mdx
@@ -1,0 +1,8 @@
+---
+sidebar_position: 1
+title: "@rocapine/react-native-onboarding"
+---
+
+import Content from '../../../packages/onboarding/CHANGELOG.md';
+
+<Content />

--- a/website/docs/changelog/ui.mdx
+++ b/website/docs/changelog/ui.mdx
@@ -1,0 +1,8 @@
+---
+sidebar_position: 2
+title: "@rocapine/react-native-onboarding-ui"
+---
+
+import Content from '../../../packages/onboarding-ui/CHANGELOG.md';
+
+<Content />

--- a/website/docs/page-types.mdx
+++ b/website/docs/page-types.mdx
@@ -403,14 +403,14 @@ Build arbitrary onboarding screens entirely from CMS data — no custom renderer
 - Any screen that doesn't fit a pre-built type
 
 **Key features:**
-- Recursive element tree (`YStack`, `XStack`, `Text`, `Image`, `Lottie`, `Rive`, `Icon`, `Video`, `Input`, `RadioGroup`)
+- Recursive element tree (`YStack`, `XStack`, `Text`, `Image`, `Lottie`, `Rive`, `Icon`, `Video`, `Input`, `RadioGroup`, `CheckboxGroup`, `Button`, `DatePicker`)
 - Full flexbox layout support
 - Border, radius, overflow, and opacity control
 - Dimension constraints (`width`, `height`, `min/max`)
 - Spacing with both `padding` and `margin`
 - Text color defaults to `theme.colors.text.primary`
-- Lottie, Rive, and Video as optional peer deps — graceful fallback if not installed
-- **Variable context** — `Input` and `RadioGroup` elements write into shared state; `Text` elements interpolate those values with `{{variableName}}` expressions — radio groups expose both a raw `value` and a human-readable `label` (e.g. `{{plan}}` renders `"Monthly"` not `"monthly"`)
+- Lottie, Rive, Video, and DatePicker as optional peer deps — graceful fallback if not installed
+- **Variable context** — `Input`, `RadioGroup`, `CheckboxGroup`, and `DatePicker` elements write into shared state; `Text` elements interpolate those values with `{{variableName}}` expressions
 
 **Element types:**
 
@@ -423,6 +423,9 @@ Build arbitrary onboarding screens entirely from CMS data — no custom renderer
 | `Icon` | Lucide icon | — | — (bundled) |
 | `Input` | `<TextInput>` | — | — |
 | `RadioGroup` | Radio item list | — | — |
+| `CheckboxGroup` | Checkbox item list | — | — |
+| `Button` | `<TouchableOpacity>` | — | — |
+| `DatePicker` | Native date/time picker | — | `@react-native-community/datetimepicker` |
 | `Lottie` | `LottieView` | — | `lottie-react-native` |
 | `Rive` | `<Rive>` | — | `rive-react-native` |
 | `Video` | `<VideoView>` | — | `expo-video` |
@@ -532,13 +535,99 @@ Build arbitrary onboarding screens entirely from CMS data — no custom renderer
 | `borderWidth` / `borderRadius` / `borderColor` | `number \| string` | Container border |
 | `opacity` | `number` | |
 
+**CheckboxGroup props:**
+
+| Prop | Type | Notes |
+|------|------|-------|
+| `items` | `Array<{ label: string; value: string }>` | **Required** — list of options; values must be unique |
+| `variableName` | `string` | Context key — selected values stored as `JSON.stringify(string[])`, label as comma-joined display names |
+| `defaultValues` | `string[]` | Pre-selects matching items on mount; must reference valid item values |
+| `direction` | `"vertical" \| "horizontal"` | Layout direction; defaults to `"vertical"` |
+| `gap` | `number` | Space between items; defaults to `8` |
+| `itemBackgroundColor` | `string` | Unselected item background; defaults to `"transparent"` |
+| `itemSelectedBackgroundColor` | `string` | Selected item background; defaults to `primary + 10% opacity` |
+| `itemBorderColor` | `string` | Unselected item border; defaults to `theme.colors.neutral.low` |
+| `itemSelectedBorderColor` | `string` | Selected item border; defaults to `theme.colors.primary` |
+| `itemBorderRadius` | `number` | Defaults to `8` |
+| `itemBorderWidth` | `number` | Defaults to `1` |
+| `itemColor` | `string` | Unselected label color; defaults to `theme.colors.text.primary` |
+| `itemSelectedColor` | `string` | Selected label color; defaults to `theme.colors.primary` |
+| `itemFontSize` | `number` | |
+| `itemFontWeight` | `string` | |
+| `itemFontFamily` | `string` | |
+| `itemPadding` | `number` | Defaults to `12` when no `itemPaddingHorizontal`/`Vertical` is set |
+| `itemPaddingHorizontal` / `itemPaddingVertical` | `number` | |
+| `alignSelf` | `"auto" \| "flex-start" \| "flex-end" \| "center" \| "stretch" \| "baseline"` | |
+| `width` / `height` | `number` | Container dimensions |
+| `margin` / `marginHorizontal` / `marginVertical` | `number` | |
+| `padding` / `paddingHorizontal` / `paddingVertical` | `number` | |
+| `borderWidth` / `borderRadius` / `borderColor` | `number \| string` | Container border |
+| `opacity` | `number` | |
+
+**Button props:**
+
+| Prop | Type | Notes |
+|------|------|-------|
+| `label` | `string` | **Required** — button text |
+| `variant` | `"filled" \| "outlined" \| "ghost"` | Visual style; `filled` = solid primary background, `outlined` = border only, `ghost` = no background or border |
+| `action` | `"continue"` | Calls `onContinue` when tapped; defaults to `"continue"` |
+| `backgroundColor` | `string` | Overrides variant background color |
+| `color` | `string` | Label text color |
+| `fontSize` | `number` | |
+| `fontWeight` | `string` | |
+| `fontFamily` | `string` | |
+| `textAlign` | `"left" \| "center" \| "right"` | |
+| `alignSelf` | `"auto" \| "flex-start" \| "center" \| "flex-end" \| "stretch"` | |
+| `width` / `height` | `number` | |
+| `margin` / `marginHorizontal` / `marginVertical` | `number` | |
+| `padding` / `paddingHorizontal` / `paddingVertical` | `number` | |
+| `borderWidth` / `borderRadius` / `borderColor` | `number \| string` | |
+| `opacity` | `number` | |
+
+**DatePicker props:**
+
+| Prop | Type | Notes |
+|------|------|-------|
+| `variableName` | `string` | Context key — selected date stored as ISO 8601 string (`value`) and locale-formatted string (`label`, e.g. `"Apr 23, 2026"`) |
+| `defaultValue` | `string` | ISO date string; used as initial value if no persisted value exists |
+| `minimumDate` | `string` | ISO date string — earliest selectable date |
+| `maximumDate` | `string` | ISO date string — latest selectable date |
+| `mode` | `"date" \| "time" \| "datetime"` | Defaults to `"date"` |
+| `display` | `"default" \| "spinner" \| "calendar" \| "clock" \| "compact" \| "inline"` | Platform-specific display style; iOS defaults to `"spinner"`, Android defaults to `"default"` |
+| `textColor` | `string` | Picker text color; defaults to `theme.colors.text.primary` |
+| `accentColor` | `string` | Picker accent/highlight color; defaults to `theme.colors.primary` |
+| `locale` | `string` | BCP 47 locale tag (e.g. `"fr-FR"`) |
+| `alignSelf` | `"auto" \| "flex-start" \| "flex-end" \| "center" \| "stretch" \| "baseline"` | |
+| `width` / `height` | `number` | Container dimensions |
+| `margin` / `marginHorizontal` / `marginVertical` | `number` | |
+| `padding` / `paddingHorizontal` / `paddingVertical` | `number` | |
+| `borderWidth` / `borderRadius` / `borderColor` | `number \| string` | Container border |
+| `opacity` | `number` | |
+
+:::note Android
+On Android, `DatePicker` renders as a `Pressable` showing the current value. Tapping opens the native modal picker. On iOS it renders inline.
+:::
+
+**Dependencies:** `@react-native-community/datetimepicker`
+
+```bash
+npx expo install @react-native-community/datetimepicker
+```
+
 **Variable context**
 
-`Input` and `RadioGroup` elements write into a shared `composableVariables` map stored in `OnboardingProgressContext`. This state persists across navigation between `ComposableScreen` steps, so values entered on an early screen are available on later screens.
+`Input`, `RadioGroup`, `CheckboxGroup`, and `DatePicker` elements write into a shared `composableVariables` map stored in `OnboardingProgressContext`. This state persists across navigation between `ComposableScreen` steps, so values collected on an early screen are available on later screens.
 
-Each entry is a structured object `{ value: string; label?: string }`. `Input` stores only `value`; `RadioGroup` stores both `value` (the raw option value, e.g. `"monthly"`) and `label` (the human-readable display text, e.g. `"Monthly"`).
+Each entry is a structured object `{ value: string; label?: string }`:
 
-`Text` elements with `mode: "expression"` interpolate `{{variableName}}` patterns in their `content` string from that map. The renderer prefers `label` over `value` when both are present — so a radio-backed `{{plan}}` renders `"Monthly"` instead of `"monthly"`. If a key has no value yet, the pattern is replaced with an empty string.
+| Element | `value` | `label` |
+|---------|---------|---------|
+| `Input` | Raw text string | — |
+| `RadioGroup` | Selected item value (e.g. `"monthly"`) | Selected item label (e.g. `"Monthly"`) |
+| `CheckboxGroup` | `JSON.stringify(string[])` of selected values | Comma-joined display labels (e.g. `"Health, Fitness"`) |
+| `DatePicker` | ISO 8601 string (e.g. `"1990-01-01T00:00:00.000Z"`) | Locale-formatted date (e.g. `"Jan 1, 1990"`) |
+
+`Text` elements with `mode: "expression"` interpolate `{{variableName}}` patterns in their `content` string from that map. The renderer prefers `label` over `value` when both are present. If a key has no value yet, the pattern is replaced with an empty string.
 
 ```json
 [
@@ -762,7 +851,7 @@ If `expo-video` is not installed, the element renders a placeholder view with an
 }
 ```
 
-**Dependencies:** None (for `YStack`, `XStack`, `Text`, `Image`, `Icon`, `Input`, `RadioGroup`). See Lottie, Rive, and Video sections above for elements with optional peer deps.
+**Dependencies:** None for `YStack`, `XStack`, `Text`, `Image`, `Icon`, `Input`, `RadioGroup`, `CheckboxGroup`, `Button`. See the Lottie, Rive, Video, and DatePicker sections above for elements with optional peer deps.
 
 ---
 


### PR DESCRIPTION
## Summary

- New `DatePicker` UIElement for ComposableScreen — renders `@react-native-community/datetimepicker` natively
- Saves selected date as ISO string (`value`) + locale-formatted label to a named variable, same pattern as Input/RadioGroup/CheckboxGroup
- Supports `mode` (date/time/datetime), `display` style, `minimumDate`/`maximumDate`, `textColor`, `accentColor`, `locale`, and all BaseBoxProps

## Files changed

| Action | File |
|--------|------|
| new | `packages/onboarding/src/steps/ComposableScreen/elements/DatePickerElement.ts` |
| new | `packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/DatePickerElement.tsx` |
| modified | both `ComposableScreen/types.ts` — union + Zod schema entry |
| modified | `elements/renderElement.tsx` — new `DatePicker` case |
| modified | `packages/onboarding-ui/package.json` — datetimepicker as optional peer dep |
| modified | `onboarding-example.ts` + `composable-screen.tsx` — birthdate picker demo |

## Test plan

- [ ] Run example app, navigate to ComposableScreen demo
- [ ] Verify date picker renders and spins/selects dates
- [ ] Verify `{{birthdate}}` expression text updates live as date changes
- [ ] Test on both iOS (spinner) and Android (default)
- [ ] Verify `minimumDate`/`maximumDate` constraints apply

## onboarding-studio

Mirror required — see schema prompt in PR description or previous commit message for full details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a DatePicker element for composable screens with modes (date/time/datetime), display styles, min/max constraints, and variable binding for expression interpolation.
  * Example updated to demonstrate birthdate selection and live display.

* **Documentation**
  * Docs and changelogs updated with DatePicker usage, props, install note, and variable-context details.

* **Chores**
  * Package version bumped to 1.10.0 and datetimepicker declared as an optional peer dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->