### PR TITLE
✨ feat(composable-screen): add ZStack UIElement (v1.14.0)

### DIFF
--- a/example/app/example/composable-screen-media.tsx
+++ b/example/app/example/composable-screen-media.tsx
@@ -97,6 +97,7 @@ export default function ComposableScreenMediaExample() {
                 controls: false,
                 muted: true,
                 autoPlay: true,
+                contentFit: 'cover',
               },
             },
             {

--- a/example/app/example/composable-screen-zstack.tsx
+++ b/example/app/example/composable-screen-zstack.tsx
@@ -1,0 +1,260 @@
+import * as OnboardingUi from '@rocapine/react-native-onboarding-ui';
+import { View, Pressable, Text, StyleSheet } from 'react-native';
+import { useRouter } from 'expo-router';
+
+export const unstable_settings = {
+  anchor: '(tabs)',
+};
+
+export default function ComposableScreenZStackExample() {
+  const router = useRouter();
+
+  const step = {
+    id: 'composable-screen-zstack',
+    type: 'ComposableScreen',
+    name: 'ComposableScreen — ZStack',
+    displayProgressHeader: true,
+    payload: {
+      elements: [
+        {
+          id: 'root',
+          type: 'YStack',
+          props: { gap: 20, padding: 24 },
+          children: [
+            {
+              id: 'section-title',
+              type: 'Text',
+              props: { content: 'ZStack', fontSize: 22, fontWeight: '700', textAlign: 'center' },
+            },
+            {
+              id: 'section-subtitle',
+              type: 'Text',
+              props: {
+                content: 'Children stack in Z-axis. First child = bottom layer.',
+                fontSize: 14,
+                textAlign: 'center',
+                opacity: 0.55,
+              },
+            },
+            // Full-bleed hero: image + gradient scrim + text overlay
+            {
+              id: 'hero-zstack',
+              type: 'ZStack',
+              props: {
+                height: 260,
+                borderRadius: 20,
+                overflow: 'hidden',
+                marginVertical: 4,
+              },
+              children: [
+                {
+                  id: 'hero-bg',
+                  type: 'Image',
+                  props: {
+                    url: 'https://picsum.photos/800/520?random=42',
+                    height: 260,
+                    resizeMode: 'cover',
+                  },
+                },
+                {
+                  id: 'hero-scrim',
+                  type: 'YStack',
+                  props: {
+                    backgroundGradient: {
+                      type: 'linear',
+                      from: 'bottom',
+                      to: 'top',
+                      stops: [
+                        { color: 'rgba(0,0,0,0.72)', position: 0 },
+                        { color: 'rgba(0,0,0,0)', position: 1 },
+                      ],
+                    },
+                    padding: 24,
+                    paddingVertical: 24,
+                    justifyContent: 'flex-end',
+                  },
+                  children: [
+                    {
+                      id: 'hero-tag',
+                      type: 'YStack',
+                      props: {
+                        backgroundColor: '#007AFF',
+                        borderRadius: 6,
+                        paddingHorizontal: 10,
+                        paddingVertical: 4,
+                        alignSelf: 'flex-start',
+                        marginVertical: 8,
+                      },
+                      children: [
+                        {
+                          id: 'hero-tag-text',
+                          type: 'Text',
+                          props: { content: 'FEATURED', fontSize: 11, fontWeight: '700', color: '#fff', letterSpacing: 1 },
+                        },
+                      ],
+                    },
+                    {
+                      id: 'hero-title',
+                      type: 'Text',
+                      props: { content: 'Image with gradient overlay', fontSize: 22, fontWeight: '700', color: '#fff' },
+                    },
+                    {
+                      id: 'hero-body',
+                      type: 'Text',
+                      props: {
+                        content: 'The gradient scrim lives in the second layer of the ZStack.',
+                        fontSize: 14,
+                        color: 'rgba(255,255,255,0.8)',
+                        lineHeight: 20,
+                        marginVertical: 6,
+                      },
+                    },
+                  ],
+                },
+              ],
+            },
+            // Badge overlay: image + corner badge
+            {
+              id: 'badge-label',
+              type: 'Text',
+              props: { content: 'Corner badge overlay', fontSize: 15, fontWeight: '600' },
+            },
+            {
+              id: 'badge-zstack',
+              type: 'ZStack',
+              props: {
+                height: 160,
+                borderRadius: 16,
+                overflow: 'hidden',
+              },
+              children: [
+                {
+                  id: 'badge-bg',
+                  type: 'Image',
+                  props: {
+                    url: 'https://picsum.photos/800/320?random=7',
+                    height: 160,
+                    resizeMode: 'cover',
+                  },
+                },
+                {
+                  id: 'badge-container',
+                  type: 'YStack',
+                  props: {
+                    padding: 12,
+                    alignItems: 'flex-end',
+                    justifyContent: 'flex-start',
+                  },
+                  children: [
+                    {
+                      id: 'badge-pill',
+                      type: 'YStack',
+                      props: {
+                        backgroundColor: '#FF3B30',
+                        borderRadius: 20,
+                        paddingHorizontal: 12,
+                        paddingVertical: 6,
+                      },
+                      children: [
+                        {
+                          id: 'badge-text',
+                          type: 'Text',
+                          props: { content: 'NEW', fontSize: 12, fontWeight: '800', color: '#fff' },
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+            // Solid color background + centered content
+            {
+              id: 'solid-label',
+              type: 'Text',
+              props: { content: 'Solid background + centered text', fontSize: 15, fontWeight: '600' },
+            },
+            {
+              id: 'solid-zstack',
+              type: 'ZStack',
+              props: {
+                height: 120,
+                borderRadius: 16,
+                overflow: 'hidden',
+                backgroundGradient: {
+                  type: 'linear',
+                  from: 'topLeft',
+                  to: 'bottomRight',
+                  stops: [
+                    { color: '#6C63FF' },
+                    { color: '#FF6584' },
+                  ],
+                },
+              },
+              children: [
+                {
+                  id: 'solid-content',
+                  type: 'YStack',
+                  props: {
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    gap: 4,
+                  },
+                  children: [
+                    {
+                      id: 'solid-title',
+                      type: 'Text',
+                      props: { content: 'Gradient background', fontSize: 18, fontWeight: '700', color: '#fff', textAlign: 'center' },
+                    },
+                    {
+                      id: 'solid-sub',
+                      type: 'Text',
+                      props: { content: 'via backgroundGradient on ZStack', fontSize: 13, color: 'rgba(255,255,255,0.8)', textAlign: 'center' },
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    customPayload: null,
+    continueButtonLabel: 'Continue',
+    figmaUrl: null,
+  } satisfies OnboardingUi.ComposableScreenStepType;
+
+  return (
+    <View style={{ flex: 1 }}>
+      <OnboardingUi.ComposableScreenRenderer step={step} onContinue={() => router.back()} />
+      <Pressable style={styles.backButton} onPress={() => router.back()}>
+        <Text style={styles.backButtonText}>‹</Text>
+      </Pressable>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  backButton: {
+    position: 'absolute',
+    top: 50,
+    left: 20,
+    width: 32,
+    height: 32,
+    backgroundColor: 'rgba(255, 255, 255, 0.9)',
+    borderRadius: 16,
+    alignItems: 'center',
+    justifyContent: 'center',
+    zIndex: 1000,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.1,
+    shadowRadius: 4,
+    elevation: 3,
+  },
+  backButtonText: {
+    color: '#007AFF',
+    fontSize: 32,
+    fontWeight: '400',
+    lineHeight: 32,
+  },
+});

--- a/example/app/example/composable-screen.tsx
+++ b/example/app/example/composable-screen.tsx
@@ -76,6 +76,7 @@ export default function ComposableScreenExample() {
                 controls: false,
                 muted: true,
                 autoPlay: true,
+                contentFit: 'cover' as const,
               },
             },
             // Input element
@@ -349,6 +350,7 @@ export default function ComposableScreenExample() {
                   id: 'zstack-overlay',
                   type: 'YStack' as const,
                   props: {
+                    flex: 1,
                     backgroundColor: 'rgba(0,0,0,0.45)',
                     padding: 20,
                     justifyContent: 'flex-end' as const,

--- a/example/app/example/composable-screen.tsx
+++ b/example/app/example/composable-screen.tsx
@@ -325,6 +325,49 @@ export default function ComposableScreenExample() {
                 },
               ],
             },
+            // ZStack: image with text overlay
+            {
+              id: 'zstack-demo',
+              type: 'ZStack' as const,
+              props: {
+                height: 200,
+                borderRadius: 16,
+                overflow: 'hidden',
+                marginVertical: 8,
+              },
+              children: [
+                {
+                  id: 'zstack-bg',
+                  type: 'Image' as const,
+                  props: {
+                    url: 'https://picsum.photos/800/400?random=20',
+                    height: 200,
+                    resizeMode: 'cover' as const,
+                  },
+                },
+                {
+                  id: 'zstack-overlay',
+                  type: 'YStack' as const,
+                  props: {
+                    backgroundColor: 'rgba(0,0,0,0.45)',
+                    padding: 20,
+                    justifyContent: 'flex-end' as const,
+                  },
+                  children: [
+                    {
+                      id: 'zstack-label',
+                      type: 'Text' as const,
+                      props: {
+                        content: 'ZStack: layered elements',
+                        fontSize: 18,
+                        fontWeight: '700',
+                        color: '#fff',
+                      },
+                    },
+                  ],
+                },
+              ],
+            },
             // Button element
             {
               id: 'hero-button',

--- a/example/app/example/index.tsx
+++ b/example/app/example/index.tsx
@@ -23,6 +23,7 @@ const examples: Example[] = [
       { name: "Form", route: "/example/composable-screen-form" },
       { name: "Carousel", route: "/example/composable-screen-carousel" },
       { name: "Button", route: "/example/composable-screen-button" },
+      { name: "ZStack", route: "/example/composable-screen-zstack" },
       { name: "All", route: "/example/composable-screen" },
     ],
   },

--- a/packages/onboarding-ui/CHANGELOG.md
+++ b/packages/onboarding-ui/CHANGELOG.md
@@ -5,6 +5,18 @@ here.
 
 ---
 
+## [1.13.1] - 2026-04-28
+
+### Added
+
+- **`ZStack` UIElement renderer** — new `ZStackElementComponent` that renders
+  children layered on top of each other. Each child is wrapped in
+  `position: "absolute"` filling the container, enabling image-with-text-overlay
+  and other depth-compositing patterns. Supports all `BaseBoxProps` including
+  `backgroundGradient` via `GradientBox`.
+
+---
+
 ## [1.13.0] - 2026-04-28
 
 ### Added

--- a/packages/onboarding-ui/CHANGELOG.md
+++ b/packages/onboarding-ui/CHANGELOG.md
@@ -5,6 +5,18 @@ here.
 
 ---
 
+## [1.14.0] - 2026-04-28
+
+### Added
+
+- **`ZStack` UIElement renderer** — new `ZStackElementComponent` that renders
+  children layered on top of each other. Each child is wrapped in
+  `position: "absolute"` filling the container, enabling image-with-text-overlay
+  and other depth-compositing patterns. Supports all `BaseBoxProps` including
+  `backgroundGradient` via `GradientBox`.
+
+---
+
 ## [1.13.1] - 2026-04-28
 
 ### Added

--- a/packages/onboarding-ui/package.json
+++ b/packages/onboarding-ui/package.json
@@ -46,7 +46,7 @@
   "peerDependencies": {
     "@react-native-community/datetimepicker": "*",
     "@react-native-picker/picker": "*",
-    "@rocapine/react-native-onboarding": "^1.11.1",
+    "@rocapine/react-native-onboarding": "^1.14.0",
     "@shopify/react-native-skia": ">=1.0.0",
     "@tanstack/react-query": ">=5.0.0",
     "@types/react": "*",

--- a/packages/onboarding-ui/package.json
+++ b/packages/onboarding-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocapine/react-native-onboarding-ui",
-  "version": "1.13.1",
+  "version": "1.14.0",
   "description": "UI components and renderers for Rocapine Onboarding Studio - Built on top of the headless SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/onboarding-ui/package.json
+++ b/packages/onboarding-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocapine/react-native-onboarding-ui",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "description": "UI components and renderers for Rocapine Onboarding Studio - Built on top of the headless SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/Renderer.tsx
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/Renderer.tsx
@@ -29,7 +29,7 @@ const ComposableScreenRendererBase = ({ step, onContinue }: ContentProps) => {
     [setComposableVariable, setHeadlessVariable]
   );
 
-  const renderChildren = (children: UIElement[], parentType: "XStack" | "YStack") =>
+  const renderChildren = (children: UIElement[], parentType: "XStack" | "YStack" | "ZStack") =>
     children.map((child) => renderElement(child, ctx, parentType));
 
   const ctx: RenderContext = {

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/StackElement.tsx
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/StackElement.tsx
@@ -24,7 +24,7 @@ type StackUIElement = Extract<UIElement, { type: "YStack" | "XStack" }>;
 type Props = {
   element: StackUIElement;
   ctx: RenderContext;
-  parentType?: "XStack" | "YStack";
+  parentType?: "XStack" | "YStack" | "ZStack";
 };
 
 export const StackElementComponent = ({ element, ctx, parentType }: Props): React.ReactElement => {

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/TextElement.tsx
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/TextElement.tsx
@@ -35,7 +35,7 @@ type TextUIElement = Extract<UIElement, { type: "Text" }>;
 type Props = {
   element: TextUIElement;
   ctx: RenderContext;
-  parentType?: "XStack" | "YStack";
+  parentType?: "XStack" | "YStack" | "ZStack";
 };
 
 export const TextElementComponent = ({ element, ctx, parentType }: Props): React.ReactElement => {

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/VideoElement.tsx
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/VideoElement.tsx
@@ -13,6 +13,7 @@ export type VideoElementProps = BaseBoxProps & {
   loop?: boolean;
   muted?: boolean;
   controls?: boolean;
+  contentFit?: "contain" | "cover" | "fill";
 };
 
 export const VideoElementPropsSchema = BaseBoxPropsSchema.extend({
@@ -21,6 +22,7 @@ export const VideoElementPropsSchema = BaseBoxPropsSchema.extend({
   loop: z.boolean().optional(),
   muted: z.boolean().optional(),
   controls: z.boolean().optional(),
+  contentFit: z.enum(["contain", "cover", "fill"]).optional(),
 });
 
 type VideoUIElement = Extract<UIElement, { type: "Video" }>;
@@ -51,6 +53,7 @@ try {
         style={style}
         allowsFullscreen={false}
         nativeControls={element.props.controls ?? false}
+        contentFit={element.props.contentFit ?? "contain"}
       />
     );
   };

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/ZStackElement.tsx
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/ZStackElement.tsx
@@ -47,7 +47,11 @@ export const ZStackElementComponent = ({ element, ctx }: Props): React.ReactElem
       }}
     >
       {element.children.map((child) => (
-        <View key={child.id} style={{ position: "absolute", top: 0, left: 0, right: 0, bottom: 0 }}>
+        <View
+          key={child.id}
+          pointerEvents="box-none"
+          style={{ position: "absolute", top: 0, left: 0, right: 0, bottom: 0 }}
+        >
           {ctx.renderChildren([child], "ZStack")}
         </View>
       ))}

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/ZStackElement.tsx
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/ZStackElement.tsx
@@ -1,0 +1,56 @@
+import React from "react";
+import { View } from "react-native";
+import { BaseBoxProps, BaseBoxPropsSchema } from "./BaseBoxProps";
+import { UIElement } from "../types";
+import { RenderContext, dim } from "./shared";
+import { GradientBox } from "./GradientBox";
+
+export type ZStackElementProps = BaseBoxProps;
+export const ZStackElementPropsSchema = BaseBoxPropsSchema;
+
+type ZStackUIElement = Extract<UIElement, { type: "ZStack" }>;
+
+type Props = {
+  element: ZStackUIElement;
+  ctx: RenderContext;
+};
+
+export const ZStackElementComponent = ({ element, ctx }: Props): React.ReactElement => {
+  const p = element.props;
+  return (
+    <GradientBox
+      gradient={p.backgroundGradient}
+      style={{
+        position: "relative",
+        flex: p.flex,
+        flexShrink: p.flexShrink,
+        flexGrow: p.flexGrow,
+        alignSelf: p.alignSelf,
+        width: dim(p.width),
+        height: dim(p.height),
+        minWidth: p.minWidth,
+        maxWidth: p.maxWidth,
+        minHeight: p.minHeight,
+        maxHeight: p.maxHeight,
+        padding: p.padding,
+        paddingHorizontal: p.paddingHorizontal,
+        paddingVertical: p.paddingVertical,
+        margin: p.margin,
+        marginHorizontal: p.marginHorizontal,
+        marginVertical: p.marginVertical,
+        backgroundColor: p.backgroundGradient ? undefined : p.backgroundColor,
+        borderWidth: p.borderWidth,
+        borderRadius: p.borderRadius,
+        borderColor: p.borderColor,
+        overflow: p.overflow,
+        opacity: p.opacity,
+      }}
+    >
+      {element.children.map((child) => (
+        <View key={child.id} style={{ position: "absolute", top: 0, left: 0, right: 0, bottom: 0 }}>
+          {ctx.renderChildren([child], "ZStack")}
+        </View>
+      ))}
+    </GradientBox>
+  );
+};

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/renderElement.tsx
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/renderElement.tsx
@@ -14,11 +14,12 @@ import { CheckboxGroupComponent } from "./CheckboxGroupElement";
 import { ButtonElementComponent } from "./ButtonElement";
 import { DatePickerElementComponent } from "./DatePickerElement";
 import { CarouselElementComponent } from "./CarouselElement";
+import { ZStackElementComponent } from "./ZStackElement";
 
 export const renderElement = (
   element: UIElement,
   ctx: RenderContext,
-  parentType?: "XStack" | "YStack"
+  parentType?: "XStack" | "YStack" | "ZStack"
 ): React.ReactNode => {
   if (element.type === "YStack" || element.type === "XStack") {
     return <StackElementComponent key={element.id} element={element} ctx={ctx} parentType={parentType} />;
@@ -70,6 +71,10 @@ export const renderElement = (
 
   if (element.type === "Carousel") {
     return <CarouselElementComponent key={element.id} element={element} ctx={ctx} />;
+  }
+
+  if (element.type === "ZStack") {
+    return <ZStackElementComponent key={element.id} element={element} ctx={ctx} />;
   }
 
   return null;

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/shared.ts
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/shared.ts
@@ -8,7 +8,7 @@ export type RenderContext = {
   variables: Record<string, ComposableVariableEntry>;
   setVariable: (key: string, entry: ComposableVariableEntry) => void;
   onContinue: () => void;
-  renderChildren: (elements: UIElement[], parentType: "XStack" | "YStack") => React.ReactNode;
+  renderChildren: (elements: UIElement[], parentType: "XStack" | "YStack" | "ZStack") => React.ReactNode;
 };
 
 export const interpolate = (template: string, variables: Record<string, ComposableVariableEntry>): string =>

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/types.ts
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/types.ts
@@ -13,6 +13,7 @@ import { type RadioGroupElementProps, RadioGroupElementPropsSchema } from "./ele
 import { type CheckboxGroupElementProps, CheckboxGroupElementPropsSchema } from "./elements/CheckboxGroupElement";
 import { type DatePickerElementProps, DatePickerElementPropsSchema } from "./elements/DatePickerElement";
 import { type CarouselElementProps, CarouselElementPropsSchema } from "./elements/CarouselElement";
+import { type ZStackElementProps, ZStackElementPropsSchema } from "./elements/ZStackElement";
 
 export type { BaseBoxProps } from "./elements/BaseBoxProps";
 export { BaseBoxPropsSchema } from "./elements/BaseBoxProps";
@@ -29,6 +30,7 @@ export type { RadioGroupElementProps } from "./elements/RadioGroupElement";
 export type { CheckboxGroupElementProps } from "./elements/CheckboxGroupElement";
 export type { DatePickerElementProps } from "./elements/DatePickerElement";
 export type { CarouselElementProps } from "./elements/CarouselElement";
+export type { ZStackElementProps } from "./elements/ZStackElement";
 
 // UIElement union — must live here (not in elements/) to avoid circular deps
 // because the Stack variant's children: UIElement[] references itself.
@@ -112,6 +114,13 @@ export type UIElement =
       type: "Carousel";
       props: CarouselElementProps;
       children: UIElement[];
+    }
+  | {
+      id: string;
+      name?: string;
+      type: "ZStack";
+      props: ZStackElementProps;
+      children: UIElement[];
     };
 
 export const UIElementSchema: z.ZodType<UIElement> = z.lazy(() =>
@@ -194,6 +203,13 @@ export const UIElementSchema: z.ZodType<UIElement> = z.lazy(() =>
       name: z.string().optional(),
       type: z.literal("Carousel"),
       props: CarouselElementPropsSchema,
+      children: z.array(UIElementSchema),
+    }),
+    z.object({
+      id: z.string(),
+      name: z.string().optional(),
+      type: z.literal("ZStack"),
+      props: ZStackElementPropsSchema,
       children: z.array(UIElementSchema),
     }),
   ])

--- a/packages/onboarding/CHANGELOG.md
+++ b/packages/onboarding/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to `@rocapine/react-native-onboarding` are documented here.
 
 ---
 
+## [1.14.0] - 2026-04-28
+
+### Added
+
+- **`ZStack` UIElement** — new container type that stacks children on top of each
+  other using absolute positioning. Props: all `BaseBoxProps` fields (width,
+  height, padding, borderRadius, overflow, backgroundGradient, etc.). Children
+  fill the container bounds by default, enabling image-with-overlay patterns.
+  `ZStackElementProps` and `ZStackElementPropsSchema` exported from the headless
+  package.
+
+---
+
 ## [1.13.1] - 2026-04-28
 
 ### Added

--- a/packages/onboarding/CHANGELOG.md
+++ b/packages/onboarding/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to `@rocapine/react-native-onboarding` are documented here.
 
 ---
 
+## [1.13.1] - 2026-04-28
+
+### Added
+
+- **`ZStack` UIElement** — new container type that stacks children on top of each
+  other using absolute positioning. Props: all `BaseBoxProps` fields (width,
+  height, padding, borderRadius, overflow, backgroundGradient, etc.). Children
+  fill the container bounds by default, enabling image-with-overlay patterns.
+  `ZStackElementProps` and `ZStackElementPropsSchema` exported from the headless
+  package.
+
+---
+
 ## [1.13.0] - 2026-04-28
 
 ### Added

--- a/packages/onboarding/package.json
+++ b/packages/onboarding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocapine/react-native-onboarding",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "description": "Headless React Native SDK for Rocapine Onboarding Studio - Data fetching, state management, and hooks",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/onboarding/package.json
+++ b/packages/onboarding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocapine/react-native-onboarding",
-  "version": "1.13.1",
+  "version": "1.14.0",
   "description": "Headless React Native SDK for Rocapine Onboarding Studio - Data fetching, state management, and hooks",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/onboarding/src/onboarding-example.ts
+++ b/packages/onboarding/src/onboarding-example.ts
@@ -321,6 +321,48 @@ export const onboardingExample = {
                 ],
               },
               {
+                id: "zstack-demo",
+                type: "ZStack",
+                props: {
+                  height: 200,
+                  borderRadius: 16,
+                  overflow: "hidden",
+                  marginVertical: 8,
+                },
+                children: [
+                  {
+                    id: "zstack-bg",
+                    type: "Image",
+                    props: {
+                      url: "https://picsum.photos/800/400?random=20",
+                      height: 200,
+                      resizeMode: "cover",
+                    },
+                  },
+                  {
+                    id: "zstack-overlay",
+                    type: "YStack",
+                    props: {
+                      backgroundColor: "rgba(0,0,0,0.45)",
+                      padding: 20,
+                      justifyContent: "flex-end",
+                    },
+                    children: [
+                      {
+                        id: "zstack-label",
+                        type: "Text",
+                        props: {
+                          content: "ZStack: layered elements",
+                          fontSize: 18,
+                          fontWeight: "700",
+                          color: "#fff",
+                        },
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
                 id: "hero-button",
                 type: "Button",
                 props: {

--- a/packages/onboarding/src/onboarding-example.ts
+++ b/packages/onboarding/src/onboarding-example.ts
@@ -149,6 +149,7 @@ export const onboardingExample = {
                   borderRadius: 12,
                   controls: true,
                   muted: true,
+                  contentFit: "cover",
                 },
               },
               {
@@ -343,6 +344,7 @@ export const onboardingExample = {
                     id: "zstack-overlay",
                     type: "YStack",
                     props: {
+                      flex: 1,
                       backgroundColor: "rgba(0,0,0,0.45)",
                       padding: 20,
                       justifyContent: "flex-end",

--- a/packages/onboarding/src/steps/ComposableScreen/elements/VideoElement.ts
+++ b/packages/onboarding/src/steps/ComposableScreen/elements/VideoElement.ts
@@ -7,6 +7,7 @@ export type VideoElementProps = BaseBoxProps & {
   loop?: boolean;
   muted?: boolean;
   controls?: boolean;
+  contentFit?: "contain" | "cover" | "fill";
 };
 
 export const VideoElementPropsSchema = BaseBoxPropsSchema.extend({
@@ -15,4 +16,5 @@ export const VideoElementPropsSchema = BaseBoxPropsSchema.extend({
   loop: z.boolean().optional(),
   muted: z.boolean().optional(),
   controls: z.boolean().optional(),
+  contentFit: z.enum(["contain", "cover", "fill"]).optional(),
 });

--- a/packages/onboarding/src/steps/ComposableScreen/elements/ZStackElement.ts
+++ b/packages/onboarding/src/steps/ComposableScreen/elements/ZStackElement.ts
@@ -1,0 +1,6 @@
+import { z } from "zod";
+import { BaseBoxProps, BaseBoxPropsSchema } from "./BaseBoxProps";
+
+export type ZStackElementProps = BaseBoxProps;
+
+export const ZStackElementPropsSchema = BaseBoxPropsSchema;

--- a/packages/onboarding/src/steps/ComposableScreen/types.ts
+++ b/packages/onboarding/src/steps/ComposableScreen/types.ts
@@ -13,6 +13,7 @@ import { type RadioGroupElementProps, RadioGroupElementPropsSchema } from "./ele
 import { type CheckboxGroupElementProps, CheckboxGroupElementPropsSchema } from "./elements/CheckboxGroupElement";
 import { type DatePickerElementProps, DatePickerElementPropsSchema } from "./elements/DatePickerElement";
 import { type CarouselElementProps, CarouselElementPropsSchema } from "./elements/CarouselElement";
+import { type ZStackElementProps, ZStackElementPropsSchema } from "./elements/ZStackElement";
 
 export type { BaseBoxProps, GradientBackground, GradientEdge, GradientStop, LinearGradientConfig } from "./elements/BaseBoxProps";
 export { BaseBoxPropsSchema, GradientBackgroundSchema } from "./elements/BaseBoxProps";
@@ -29,6 +30,7 @@ export type { RadioGroupElementProps } from "./elements/RadioGroupElement";
 export type { CheckboxGroupElementProps } from "./elements/CheckboxGroupElement";
 export type { DatePickerElementProps } from "./elements/DatePickerElement";
 export type { CarouselElementProps } from "./elements/CarouselElement";
+export type { ZStackElementProps } from "./elements/ZStackElement";
 
 // UIElement union — must live here (not in elements/) to avoid circular deps
 // because the Stack variant's children: UIElement[] references itself.
@@ -112,6 +114,13 @@ type UIElement =
       type: "Carousel";
       props: CarouselElementProps;
       children: UIElement[];
+    }
+  | {
+      id: string;
+      name?: string;
+      type: "ZStack";
+      props: ZStackElementProps;
+      children: UIElement[];
     };
 
 const UIElementSchema: z.ZodType<UIElement> = z.lazy(() =>
@@ -194,6 +203,13 @@ const UIElementSchema: z.ZodType<UIElement> = z.lazy(() =>
       name: z.string().optional(),
       type: z.literal("Carousel"),
       props: CarouselElementPropsSchema,
+      children: z.array(UIElementSchema),
+    }),
+    z.object({
+      id: z.string(),
+      name: z.string().optional(),
+      type: z.literal("ZStack"),
+      props: ZStackElementPropsSchema,
       children: z.array(UIElementSchema),
     }),
   ])

--- a/website/docs/page-types.mdx
+++ b/website/docs/page-types.mdx
@@ -432,7 +432,7 @@ Build arbitrary onboarding screens entirely from CMS data — no custom renderer
 | `Rive` | `<Rive>` | — | `rive-react-native` |
 | `Video` | `<VideoView>` | — | `expo-video` |
 
-**Stack props (`YStack` / `XStack` / `ZStack`):**
+**Stack props (`YStack` / `XStack`):**
 
 | Prop | Type | Notes |
 |------|------|-------|
@@ -449,10 +449,26 @@ Build arbitrary onboarding screens entirely from CMS data — no custom renderer
 | `overflow` | `"hidden" \| "visible" \| "scroll"` | Use `"hidden"` to clip rounded corners |
 | `opacity` | `number` | |
 
-:::note ZStack sizing
-`ZStack` uses `position: "absolute"` for every child — meaning children don't contribute to the container's intrinsic size. Always set an explicit `height` (and optionally `width`) on the `ZStack` itself so the container has a defined size.
+**ZStack props:**
 
-Children are layered in the order they appear: the first child is rendered at the bottom, the last child on top.
+`ZStack` accepts only the `BaseBoxProps` subset listed below. Flex/flow props such as `gap`, `alignItems`, `justifyContent`, and `flexWrap` are **not** honored — children are absolutely positioned, so flex layout does not apply.
+
+| Prop | Type | Notes |
+|------|------|-------|
+| `width` / `height` / `minWidth` / `maxWidth` / `minHeight` / `maxHeight` | `number` | Explicit `height` is recommended — absolute children do not size the parent |
+| `padding` / `paddingHorizontal` / `paddingVertical` | `number` | Applied to the `ZStack` container |
+| `margin` / `marginHorizontal` / `marginVertical` | `number` | |
+| `flex` / `flexShrink` / `flexGrow` | `number` | Apply to the `ZStack` itself within a parent flex container |
+| `alignSelf` | `"auto" \| "flex-start" \| "flex-end" \| "center" \| "stretch" \| "baseline"` | |
+| `backgroundColor` / `backgroundGradient` | `string` / `GradientBackground` | |
+| `borderWidth` / `borderRadius` / `borderColor` | `number \| string` | |
+| `overflow` | `"hidden" \| "visible" \| "scroll"` | Use `"hidden"` to clip overflowing children to rounded corners |
+| `opacity` | `number` | |
+
+:::note ZStack behavior
+Children are layered in declaration order: first child = bottom, last child = top. Each child is wrapped in `position: "absolute"` filling the container, so flex props on `ZStack` itself (`gap`, `alignItems`, `justifyContent`) have no effect — instead control the layout of each layer's content via the layer's own props (e.g. wrap content in a `YStack` with `justifyContent: "flex-end"` to anchor it to the bottom).
+
+The wrapper for each child uses `pointerEvents="box-none"`, so touches pass through transparent regions to layers underneath.
 :::
 
 **Image props:**

--- a/website/docs/page-types.mdx
+++ b/website/docs/page-types.mdx
@@ -403,7 +403,7 @@ Build arbitrary onboarding screens entirely from CMS data — no custom renderer
 - Any screen that doesn't fit a pre-built type
 
 **Key features:**
-- Recursive element tree (`YStack`, `XStack`, `Text`, `Image`, `Lottie`, `Rive`, `Icon`, `Video`, `Input`, `RadioGroup`, `CheckboxGroup`, `Button`, `DatePicker`, `Carousel`)
+- Recursive element tree (`YStack`, `XStack`, `ZStack`, `Text`, `Image`, `Lottie`, `Rive`, `Icon`, `Video`, `Input`, `RadioGroup`, `CheckboxGroup`, `Button`, `DatePicker`, `Carousel`)
 - Full flexbox layout support
 - Border, radius, overflow, and opacity control
 - Dimension constraints (`width`, `height`, `min/max`)
@@ -418,6 +418,7 @@ Build arbitrary onboarding screens entirely from CMS data — no custom renderer
 |---------|-----------|-----------|----------|
 | `YStack` | `<View>` | `column` | — |
 | `XStack` | `<View>` | `row` | — |
+| `ZStack` | `<View>` | depth (z-axis) | — |
 | `Text` | `<Text>` | — | — |
 | `Image` | `<Image>` | — | — |
 | `Icon` | Lucide icon | — | — (bundled) |
@@ -431,7 +432,7 @@ Build arbitrary onboarding screens entirely from CMS data — no custom renderer
 | `Rive` | `<Rive>` | — | `rive-react-native` |
 | `Video` | `<VideoView>` | — | `expo-video` |
 
-**Stack props (`YStack` / `XStack`):**
+**Stack props (`YStack` / `XStack` / `ZStack`):**
 
 | Prop | Type | Notes |
 |------|------|-------|
@@ -447,6 +448,12 @@ Build arbitrary onboarding screens entirely from CMS data — no custom renderer
 | `borderWidth` / `borderRadius` | `number` | |
 | `overflow` | `"hidden" \| "visible" \| "scroll"` | Use `"hidden"` to clip rounded corners |
 | `opacity` | `number` | |
+
+:::note ZStack sizing
+`ZStack` uses `position: "absolute"` for every child — meaning children don't contribute to the container's intrinsic size. Always set an explicit `height` (and optionally `width`) on the `ZStack` itself so the container has a defined size.
+
+Children are layered in the order they appear: the first child is rendered at the bottom, the last child on top.
+:::
 
 **Image props:**
 
@@ -883,7 +890,41 @@ If `expo-video` is not installed, the element renders a placeholder view with an
 }
 ```
 
-**Dependencies:** None for `YStack`, `XStack`, `Text`, `Image`, `Icon`, `Input`, `RadioGroup`, `CheckboxGroup`, `Button`. See the Carousel, Lottie, Rive, Video, and DatePicker sections above for elements with peer deps.
+**ZStack example — image with text overlay:**
+
+```json
+{
+  "id": "hero-overlay",
+  "type": "ZStack",
+  "props": {
+    "height": 200,
+    "borderRadius": 16,
+    "overflow": "hidden",
+    "marginVertical": 8
+  },
+  "children": [
+    {
+      "id": "bg",
+      "type": "Image",
+      "props": { "url": "https://example.com/hero.jpg", "height": 200, "resizeMode": "cover" }
+    },
+    {
+      "id": "overlay",
+      "type": "YStack",
+      "props": { "backgroundColor": "rgba(0,0,0,0.45)", "padding": 20, "justifyContent": "flex-end" },
+      "children": [
+        {
+          "id": "label",
+          "type": "Text",
+          "props": { "content": "Your headline here", "fontSize": 18, "fontWeight": "700", "color": "#fff" }
+        }
+      ]
+    }
+  ]
+}
+```
+
+**Dependencies:** None for `YStack`, `XStack`, `ZStack`, `Text`, `Image`, `Icon`, `Input`, `RadioGroup`, `CheckboxGroup`, `Button`. See the Carousel, Lottie, Rive, Video, and DatePicker sections above for elements with peer deps.
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds `ZStack` UIElement to `ComposableScreen` — stacks children on top of each other using absolute positioning
- Both SDK packages bumped `1.13.0 → 1.14.0` (minor)
- Website docs updated: element table, stack props heading, ZStack sizing note, and overlay example

## What is ZStack?

`ZStack` is a container that layers its children in the Z-axis (depth). Each child is rendered with `position: absolute, inset: 0`, filling the container. Children stack in declaration order — first child is at the bottom, last is on top.

**Primary use case:** image-with-text-overlay patterns (background image + semi-transparent scrim + text), badge overlays, or any composition requiring depth.

```json
{
  "id": "hero",
  "type": "ZStack",
  "props": { "height": 200, "borderRadius": 16, "overflow": "hidden" },
  "children": [
    { "id": "bg", "type": "Image", "props": { "url": "...", "height": 200, "resizeMode": "cover" } },
    { "id": "overlay", "type": "YStack", "props": { "backgroundColor": "rgba(0,0,0,0.45)", "padding": 20, "justifyContent": "flex-end" },
      "children": [{ "id": "label", "type": "Text", "props": { "content": "Headline", "fontSize": 18, "color": "#fff" } }]
    }
  ]
}
```

## Test plan

- [ ] Build both packages: `npm run build`
- [ ] Type-check example app: `cd example && npx tsc --noEmit`
- [ ] Open composable-screen example on device — verify ZStack card renders (image + dark overlay + white text)
- [ ] Verify children outside ZStack are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ZStack element for layering UI with stacked overlays.
  * contentFit option for videos ("contain", "cover", "fill") to control display.
  * New Composable Screen example showcasing ZStack overlays, gradients, badges, and navigation.

* **Documentation**
  * Docs updated with ZStack usage, behavior, sizing notes, and a JSON example.
  * Changelogs updated for v1.13.1 and v1.14.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->