### PR TITLE
✨ feat(composable-screen): add SafeAreaView UIElement (v1.15.0)

### DIFF
--- a/example/app/example/composable-screen.tsx
+++ b/example/app/example/composable-screen.tsx
@@ -17,6 +17,11 @@ export default function ComposableScreenExample() {
     payload: {
       elements: [
         {
+          id: 'safe-root',
+          type: 'SafeAreaView' as const,
+          props: { flex: 1, edges: ['top', 'bottom'] as ('top' | 'right' | 'bottom' | 'left')[] },
+          children: [
+        {
           id: 'root',
           type: 'YStack',
           props: { gap: 24, padding: 24 },
@@ -529,6 +534,8 @@ export default function ComposableScreenExample() {
               },
               children: [],
             },
+          ],
+        },
           ],
         },
       ],

--- a/packages/onboarding-ui/CHANGELOG.md
+++ b/packages/onboarding-ui/CHANGELOG.md
@@ -5,6 +5,29 @@ here.
 
 ---
 
+## [1.15.0] - 2026-04-28
+
+### Added
+
+- **`SafeAreaView` UIElement renderer** — new `SafeAreaViewElementComponent` that
+  delegates to `SafeAreaView` from `react-native-safe-area-context`. Forwards
+  `mode` and `edges` (array or per-edge object) and applies `BaseBoxProps`
+  styling.
+
+### Changed
+
+- **`OnboardingTemplate` no longer applies safe-area insets.** The template
+  previously read `useSafeAreaInsets()` and added `paddingTop`/`paddingBottom`.
+  Renderers now own safe-area handling: `Carousel`, `Commitment`, `Loader`,
+  `MediaContent`, `Picker`, `Question`, and `Ratings` wrap their content with
+  `<SafeAreaView edges={["top", "bottom"]}>`. The `ComposableScreen` renderer
+  intentionally does **not** wrap — author safe-area placement using the new
+  `SafeAreaView` UIElement so screens can render edge-to-edge backgrounds.
+- The progress-header offset (40px) remains in `OnboardingTemplate` as plain
+  padding, no longer combined with the top inset.
+
+---
+
 ## [1.14.0] - 2026-04-28
 
 ### Added

--- a/packages/onboarding-ui/package.json
+++ b/packages/onboarding-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocapine/react-native-onboarding-ui",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "description": "UI components and renderers for Rocapine Onboarding Studio - Built on top of the headless SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -46,7 +46,7 @@
   "peerDependencies": {
     "@react-native-community/datetimepicker": "*",
     "@react-native-picker/picker": "*",
-    "@rocapine/react-native-onboarding": "^1.14.0",
+    "@rocapine/react-native-onboarding": "^1.15.0",
     "@shopify/react-native-skia": ">=1.0.0",
     "@tanstack/react-query": ">=5.0.0",
     "@types/react": "*",

--- a/packages/onboarding-ui/src/UI/Pages/Carousel/Renderer.tsx
+++ b/packages/onboarding-ui/src/UI/Pages/Carousel/Renderer.tsx
@@ -1,4 +1,5 @@
 import { OnboardingTemplate } from "../../Templates/OnboardingTemplate";
+import { SafeAreaView } from "react-native-safe-area-context";
 import {
   CarouselStepType,
   CarouselStepTypeSchema,
@@ -58,6 +59,7 @@ const CarouselRendererBase = ({ step, onContinue, theme = defaultTheme }: Conten
   const isLastPage = currentPage === screens.length - 1;
 
   return (
+    <SafeAreaView style={{ flex: 1 }} edges={["top", "bottom"]}>
     <OnboardingTemplate
       step={step}
       onContinue={handleButtonPress}
@@ -101,6 +103,7 @@ const CarouselRendererBase = ({ step, onContinue, theme = defaultTheme }: Conten
         </View>
       </View>
     </OnboardingTemplate>
+    </SafeAreaView>
   );
 };
 

--- a/packages/onboarding-ui/src/UI/Pages/Commitment/Renderer.tsx
+++ b/packages/onboarding-ui/src/UI/Pages/Commitment/Renderer.tsx
@@ -8,6 +8,7 @@ import {
 } from "react-native";
 import { CommitmentStepType, CommitmentStepTypeSchema } from "./types";
 import { OnboardingTemplate } from "../../Templates/OnboardingTemplate";
+import { SafeAreaView } from "react-native-safe-area-context";
 import {
   Gesture,
   GestureDetector,
@@ -80,6 +81,7 @@ const CommitmentRendererBase = ({ step, onContinue, theme = defaultTheme }: Cont
   const isButtonDisabled = payload.variant === "signature" && !hasSignature;
 
   return (
+    <SafeAreaView style={{ flex: 1 }} edges={["top", "bottom"]}>
     <OnboardingTemplate
       step={validatedData}
       onContinue={onContinue}
@@ -219,6 +221,7 @@ const CommitmentRendererBase = ({ step, onContinue, theme = defaultTheme }: Cont
         </View>
       </ScrollView>
     </OnboardingTemplate>
+    </SafeAreaView>
   );
 };
 

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/SafeAreaViewElement.tsx
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/SafeAreaViewElement.tsx
@@ -1,0 +1,75 @@
+import React from "react";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { z } from "zod";
+import { BaseBoxProps, BaseBoxPropsSchema } from "./BaseBoxProps";
+import { UIElement } from "../types";
+import { RenderContext, dim } from "./shared";
+
+export type SafeAreaEdge = "top" | "right" | "bottom" | "left";
+export type SafeAreaEdgeMode = "off" | "additive" | "maximum";
+
+export type SafeAreaViewElementProps = BaseBoxProps & {
+  mode?: "padding" | "margin";
+  edges?: SafeAreaEdge[] | Partial<Record<SafeAreaEdge, SafeAreaEdgeMode>>;
+};
+
+const EdgeSchema = z.enum(["top", "right", "bottom", "left"]);
+const EdgeModeSchema = z.enum(["off", "additive", "maximum"]);
+
+export const SafeAreaViewElementPropsSchema = BaseBoxPropsSchema.extend({
+  mode: z.enum(["padding", "margin"]).optional(),
+  edges: z
+    .union([
+      z.array(EdgeSchema),
+      z.object({
+        top: EdgeModeSchema.optional(),
+        right: EdgeModeSchema.optional(),
+        bottom: EdgeModeSchema.optional(),
+        left: EdgeModeSchema.optional(),
+      }),
+    ])
+    .optional(),
+});
+
+type SafeAreaViewUIElement = Extract<UIElement, { type: "SafeAreaView" }>;
+
+type Props = {
+  element: SafeAreaViewUIElement;
+  ctx: RenderContext;
+};
+
+export const SafeAreaViewElementComponent = ({ element, ctx }: Props): React.ReactElement => {
+  const p = element.props;
+  return (
+    <SafeAreaView
+      mode={p.mode}
+      edges={p.edges as any}
+      style={{
+        flex: p.flex,
+        flexShrink: p.flexShrink,
+        flexGrow: p.flexGrow,
+        alignSelf: p.alignSelf,
+        width: dim(p.width),
+        height: dim(p.height),
+        minWidth: p.minWidth,
+        maxWidth: p.maxWidth,
+        minHeight: p.minHeight,
+        maxHeight: p.maxHeight,
+        padding: p.padding,
+        paddingHorizontal: p.paddingHorizontal,
+        paddingVertical: p.paddingVertical,
+        margin: p.margin,
+        marginHorizontal: p.marginHorizontal,
+        marginVertical: p.marginVertical,
+        backgroundColor: p.backgroundColor,
+        borderWidth: p.borderWidth,
+        borderRadius: p.borderRadius,
+        borderColor: p.borderColor,
+        overflow: p.overflow,
+        opacity: p.opacity,
+      }}
+    >
+      {ctx.renderChildren(element.children, "YStack")}
+    </SafeAreaView>
+  );
+};

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/SafeAreaViewElement.tsx
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/SafeAreaViewElement.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { z } from "zod";
 import { BaseBoxProps, BaseBoxPropsSchema } from "./BaseBoxProps";
+import { GradientBox } from "./GradientBox";
 import { UIElement } from "../types";
 import { RenderContext, dim } from "./shared";
 
@@ -40,34 +41,51 @@ type Props = {
 
 export const SafeAreaViewElementComponent = ({ element, ctx }: Props): React.ReactElement => {
   const p = element.props;
+  const hasGradient = !!p.backgroundGradient;
+  const frameStyle = {
+    flex: p.flex,
+    flexShrink: p.flexShrink,
+    flexGrow: p.flexGrow,
+    alignSelf: p.alignSelf,
+    width: dim(p.width),
+    height: dim(p.height),
+    minWidth: p.minWidth,
+    maxWidth: p.maxWidth,
+    minHeight: p.minHeight,
+    maxHeight: p.maxHeight,
+    margin: p.margin,
+    marginHorizontal: p.marginHorizontal,
+    marginVertical: p.marginVertical,
+    backgroundColor: hasGradient ? undefined : p.backgroundColor,
+    borderWidth: p.borderWidth,
+    borderRadius: p.borderRadius,
+    borderColor: p.borderColor,
+    overflow: hasGradient ? "hidden" as const : p.overflow,
+    opacity: p.opacity,
+  };
+
+  const safeAreaStyle = {
+    flex: hasGradient ? 1 : p.flex,
+    padding: p.padding,
+    paddingHorizontal: p.paddingHorizontal,
+    paddingVertical: p.paddingVertical,
+  };
+
+  if (hasGradient) {
+    return (
+      <GradientBox gradient={p.backgroundGradient} style={frameStyle}>
+        <SafeAreaView mode={p.mode} edges={p.edges as any} style={safeAreaStyle}>
+          {ctx.renderChildren(element.children, "YStack")}
+        </SafeAreaView>
+      </GradientBox>
+    );
+  }
+
   return (
     <SafeAreaView
       mode={p.mode}
       edges={p.edges as any}
-      style={{
-        flex: p.flex,
-        flexShrink: p.flexShrink,
-        flexGrow: p.flexGrow,
-        alignSelf: p.alignSelf,
-        width: dim(p.width),
-        height: dim(p.height),
-        minWidth: p.minWidth,
-        maxWidth: p.maxWidth,
-        minHeight: p.minHeight,
-        maxHeight: p.maxHeight,
-        padding: p.padding,
-        paddingHorizontal: p.paddingHorizontal,
-        paddingVertical: p.paddingVertical,
-        margin: p.margin,
-        marginHorizontal: p.marginHorizontal,
-        marginVertical: p.marginVertical,
-        backgroundColor: p.backgroundColor,
-        borderWidth: p.borderWidth,
-        borderRadius: p.borderRadius,
-        borderColor: p.borderColor,
-        overflow: p.overflow,
-        opacity: p.opacity,
-      }}
+      style={{ ...frameStyle, ...safeAreaStyle }}
     >
       {ctx.renderChildren(element.children, "YStack")}
     </SafeAreaView>

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/renderElement.tsx
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/renderElement.tsx
@@ -15,6 +15,7 @@ import { ButtonElementComponent } from "./ButtonElement";
 import { DatePickerElementComponent } from "./DatePickerElement";
 import { CarouselElementComponent } from "./CarouselElement";
 import { ZStackElementComponent } from "./ZStackElement";
+import { SafeAreaViewElementComponent } from "./SafeAreaViewElement";
 
 export const renderElement = (
   element: UIElement,
@@ -75,6 +76,10 @@ export const renderElement = (
 
   if (element.type === "ZStack") {
     return <ZStackElementComponent key={element.id} element={element} ctx={ctx} />;
+  }
+
+  if (element.type === "SafeAreaView") {
+    return <SafeAreaViewElementComponent key={element.id} element={element} ctx={ctx} />;
   }
 
   return null;

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/types.ts
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/types.ts
@@ -14,6 +14,7 @@ import { type CheckboxGroupElementProps, CheckboxGroupElementPropsSchema } from 
 import { type DatePickerElementProps, DatePickerElementPropsSchema } from "./elements/DatePickerElement";
 import { type CarouselElementProps, CarouselElementPropsSchema } from "./elements/CarouselElement";
 import { type ZStackElementProps, ZStackElementPropsSchema } from "./elements/ZStackElement";
+import { type SafeAreaViewElementProps, SafeAreaViewElementPropsSchema } from "./elements/SafeAreaViewElement";
 
 export type { BaseBoxProps } from "./elements/BaseBoxProps";
 export { BaseBoxPropsSchema } from "./elements/BaseBoxProps";
@@ -31,6 +32,7 @@ export type { CheckboxGroupElementProps } from "./elements/CheckboxGroupElement"
 export type { DatePickerElementProps } from "./elements/DatePickerElement";
 export type { CarouselElementProps } from "./elements/CarouselElement";
 export type { ZStackElementProps } from "./elements/ZStackElement";
+export type { SafeAreaViewElementProps, SafeAreaEdge, SafeAreaEdgeMode } from "./elements/SafeAreaViewElement";
 
 // UIElement union — must live here (not in elements/) to avoid circular deps
 // because the Stack variant's children: UIElement[] references itself.
@@ -121,6 +123,13 @@ export type UIElement =
       type: "ZStack";
       props: ZStackElementProps;
       children: UIElement[];
+    }
+  | {
+      id: string;
+      name?: string;
+      type: "SafeAreaView";
+      props: SafeAreaViewElementProps;
+      children: UIElement[];
     };
 
 export const UIElementSchema: z.ZodType<UIElement> = z.lazy(() =>
@@ -210,6 +219,13 @@ export const UIElementSchema: z.ZodType<UIElement> = z.lazy(() =>
       name: z.string().optional(),
       type: z.literal("ZStack"),
       props: ZStackElementPropsSchema,
+      children: z.array(UIElementSchema),
+    }),
+    z.object({
+      id: z.string(),
+      name: z.string().optional(),
+      type: z.literal("SafeAreaView"),
+      props: SafeAreaViewElementPropsSchema,
       children: z.array(UIElementSchema),
     }),
   ])

--- a/packages/onboarding-ui/src/UI/Pages/Loader/Renderer.tsx
+++ b/packages/onboarding-ui/src/UI/Pages/Loader/Renderer.tsx
@@ -115,6 +115,7 @@ const BarsVariant = ({
       <ScrollView
         contentContainerStyle={styles.scrollContent}
         showsVerticalScrollIndicator={false}
+        alwaysBounceVertical={false}
       >
         <View style={styles.container}>
           {/* Title */}
@@ -179,6 +180,7 @@ const CircleVariant = ({
       <ScrollView
         contentContainerStyle={styles.scrollContent}
         showsVerticalScrollIndicator={false}
+        alwaysBounceVertical={false}
       >
         <View style={styles.container}>
           {/* Circular Progress */}

--- a/packages/onboarding-ui/src/UI/Pages/Loader/Renderer.tsx
+++ b/packages/onboarding-ui/src/UI/Pages/Loader/Renderer.tsx
@@ -1,4 +1,5 @@
 import { OnboardingTemplate } from "../../Templates/OnboardingTemplate";
+import { SafeAreaView } from "react-native-safe-area-context";
 import { LoaderStepType, LoaderStepTypeSchema, LoaderStep } from "./types";
 import {
   View,
@@ -97,6 +98,7 @@ const BarsVariant = ({
   const styles = createStyles(theme);
 
   return (
+    <SafeAreaView style={{ flex: 1 }} edges={["top", "bottom"]}>
     <OnboardingTemplate
       step={step}
       onContinue={onContinue}
@@ -147,6 +149,7 @@ const BarsVariant = ({
         />
       )}
     </OnboardingTemplate>
+    </SafeAreaView>
   );
 };
 
@@ -171,6 +174,7 @@ const CircleVariant = ({
   const styles = createStyles(theme);
 
   return (
+    <SafeAreaView style={{ flex: 1 }} edges={["top", "bottom"]}>
     <OnboardingTemplate step={step} onContinue={onContinue} theme={theme}>
       <ScrollView
         contentContainerStyle={styles.scrollContent}
@@ -201,6 +205,7 @@ const CircleVariant = ({
         </View>
       </ScrollView>
     </OnboardingTemplate>
+    </SafeAreaView>
   );
 };
 

--- a/packages/onboarding-ui/src/UI/Pages/MediaContent/Renderer.tsx
+++ b/packages/onboarding-ui/src/UI/Pages/MediaContent/Renderer.tsx
@@ -1,4 +1,5 @@
 import { OnboardingTemplate } from "../../Templates/OnboardingTemplate";
+import { SafeAreaView } from "react-native-safe-area-context";
 import { MediaContentStepType, MediaContentStepTypeSchema } from "./types";
 import { View, Text, StyleSheet, Image, ScrollView } from "react-native";
 import { Theme } from "../../Theme/types";
@@ -115,6 +116,7 @@ const MediaContentRendererBase = ({ step, onContinue, theme = defaultTheme }: Co
   };
 
   return (
+    <SafeAreaView style={{ flex: 1 }} edges={["top", "bottom"]}>
     <OnboardingTemplate
       step={step}
       onContinue={onContinue}
@@ -126,6 +128,7 @@ const MediaContentRendererBase = ({ step, onContinue, theme = defaultTheme }: Co
     >
       {renderContent()}
     </OnboardingTemplate>
+    </SafeAreaView>
   );
 };
 

--- a/packages/onboarding-ui/src/UI/Pages/Picker/Renderer.tsx
+++ b/packages/onboarding-ui/src/UI/Pages/Picker/Renderer.tsx
@@ -1,4 +1,5 @@
 import { OnboardingTemplate } from "../../Templates/OnboardingTemplate";
+import { SafeAreaView } from "react-native-safe-area-context";
 import { PickerStepType, PickerStepTypeSchema, WeightUnit, HeightUnit } from "./types";
 import { View, Text, StyleSheet, TextInput, KeyboardAvoidingView, Platform, TouchableWithoutFeedback, Keyboard } from "react-native";
 import { useState } from "react";
@@ -86,6 +87,7 @@ const PickerRendererBase = ({ step, onContinue, theme = defaultTheme }: ContentP
 
   // Fallback for other picker types (to be implemented)
   return (
+    <SafeAreaView style={{ flex: 1 }} edges={["top", "bottom"]}>
     <OnboardingTemplate
       step={step}
       onContinue={() => onContinue()}
@@ -102,6 +104,7 @@ const PickerRendererBase = ({ step, onContinue, theme = defaultTheme }: ContentP
         </View>
       </View>
     </OnboardingTemplate>
+    </SafeAreaView>
   );
 };
 
@@ -145,6 +148,7 @@ const WeightPicker = ({
   };
 
   return (
+    <SafeAreaView style={{ flex: 1 }} edges={["top", "bottom"]}>
     <OnboardingTemplate
       step={step}
       onContinue={handleContinue}
@@ -189,6 +193,7 @@ const WeightPicker = ({
         </View>
       </View>
     </OnboardingTemplate>
+    </SafeAreaView>
   );
 };
 
@@ -261,6 +266,7 @@ const HeightPicker = ({
   };
 
   return (
+    <SafeAreaView style={{ flex: 1 }} edges={["top", "bottom"]}>
     <OnboardingTemplate
       step={step}
       onContinue={handleContinue}
@@ -330,6 +336,7 @@ const HeightPicker = ({
         </View>
       </View>
     </OnboardingTemplate>
+    </SafeAreaView>
   );
 };
 
@@ -361,6 +368,7 @@ const NamePicker = ({
   };
 
   return (
+    <SafeAreaView style={{ flex: 1 }} edges={["top", "bottom"]}>
     <KeyboardAvoidingView
       behavior={Platform.OS === "ios" ? "padding" : "height"}
       style={{ flex: 1 }}
@@ -412,6 +420,7 @@ const NamePicker = ({
         </View>
       </TouchableWithoutFeedback>
     </KeyboardAvoidingView>
+    </SafeAreaView>
   );
 };
 
@@ -476,6 +485,7 @@ const DatePicker = ({
   };
 
   return (
+    <SafeAreaView style={{ flex: 1 }} edges={["top", "bottom"]}>
     <OnboardingTemplate
       step={step}
       onContinue={handleContinue}
@@ -531,6 +541,7 @@ const DatePicker = ({
         </View>
       </View>
     </OnboardingTemplate>
+    </SafeAreaView>
   );
 };
 

--- a/packages/onboarding-ui/src/UI/Pages/Picker/Renderer.tsx
+++ b/packages/onboarding-ui/src/UI/Pages/Picker/Renderer.tsx
@@ -87,7 +87,7 @@ const PickerRendererBase = ({ step, onContinue, theme = defaultTheme }: ContentP
 
   // Fallback for other picker types (to be implemented)
   return (
-    <SafeAreaView style={{ flex: 1 }} edges={["top", "bottom"]}>
+    <SafeAreaView style={{ flex: 1 }} edges={["top", "bottom", "left", "right"]}>
     <OnboardingTemplate
       step={step}
       onContinue={() => onContinue()}
@@ -148,7 +148,7 @@ const WeightPicker = ({
   };
 
   return (
-    <SafeAreaView style={{ flex: 1 }} edges={["top", "bottom"]}>
+    <SafeAreaView style={{ flex: 1 }} edges={["top", "bottom", "left", "right"]}>
     <OnboardingTemplate
       step={step}
       onContinue={handleContinue}
@@ -266,7 +266,7 @@ const HeightPicker = ({
   };
 
   return (
-    <SafeAreaView style={{ flex: 1 }} edges={["top", "bottom"]}>
+    <SafeAreaView style={{ flex: 1 }} edges={["top", "bottom", "left", "right"]}>
     <OnboardingTemplate
       step={step}
       onContinue={handleContinue}
@@ -368,7 +368,7 @@ const NamePicker = ({
   };
 
   return (
-    <SafeAreaView style={{ flex: 1 }} edges={["top", "bottom"]}>
+    <SafeAreaView style={{ flex: 1 }} edges={["top", "bottom", "left", "right"]}>
     <KeyboardAvoidingView
       behavior={Platform.OS === "ios" ? "padding" : "height"}
       style={{ flex: 1 }}
@@ -485,7 +485,7 @@ const DatePicker = ({
   };
 
   return (
-    <SafeAreaView style={{ flex: 1 }} edges={["top", "bottom"]}>
+    <SafeAreaView style={{ flex: 1 }} edges={["top", "bottom", "left", "right"]}>
     <OnboardingTemplate
       step={step}
       onContinue={handleContinue}

--- a/packages/onboarding-ui/src/UI/Pages/Question/Renderer.tsx
+++ b/packages/onboarding-ui/src/UI/Pages/Question/Renderer.tsx
@@ -129,6 +129,7 @@ const QuestionRendererBase = ({ step, onContinue, theme = defaultTheme, customCo
             style={styles.scrollView}
             contentContainerStyle={styles.scrollContent}
             showsVerticalScrollIndicator={false}
+            alwaysBounceVertical={false}
           >
             <AnswersList
               answers={answers}

--- a/packages/onboarding-ui/src/UI/Pages/Question/Renderer.tsx
+++ b/packages/onboarding-ui/src/UI/Pages/Question/Renderer.tsx
@@ -8,6 +8,7 @@ import {
   StyleSheet,
 } from "react-native";
 import { OnboardingTemplate } from "../../Templates/OnboardingTemplate";
+import { SafeAreaView } from "react-native-safe-area-context";
 import { getTextStyle } from "../../Theme/helpers";
 import { Theme } from "../../Theme/types";
 import { defaultTheme } from "../../Theme/defaultTheme";
@@ -86,6 +87,7 @@ const QuestionRendererBase = ({ step, onContinue, theme = defaultTheme, customCo
     customComponents?.QuestionAnswerButton || DefaultQuestionAnswerButton;
 
   return (
+    <SafeAreaView style={{ flex: 1 }} edges={["top", "bottom"]}>
     <OnboardingTemplate
       step={step}
       onContinue={handleContinue || (() => { })}
@@ -139,6 +141,7 @@ const QuestionRendererBase = ({ step, onContinue, theme = defaultTheme, customCo
         </View>
       </View>
     </OnboardingTemplate>
+    </SafeAreaView>
   );
 };
 

--- a/packages/onboarding-ui/src/UI/Pages/Ratings/Renderer.tsx
+++ b/packages/onboarding-ui/src/UI/Pages/Ratings/Renderer.tsx
@@ -1,6 +1,7 @@
 import { Image, ScrollView, StyleSheet, Text, View } from "react-native";
 import Svg, { Path } from "react-native-svg";
 import { OnboardingTemplate } from "../../Templates/OnboardingTemplate";
+import { SafeAreaView } from "react-native-safe-area-context";
 import { RatingsStepType, RatingsStepTypeSchema } from "./types";
 import { useState } from "react";
 import { Theme } from "../../Theme/types";
@@ -76,6 +77,7 @@ const RatingsRendererBase = ({ step, onContinue, theme = defaultTheme }: Ratings
   };
 
   return (
+    <SafeAreaView style={{ flex: 1 }} edges={["top", "bottom"]}>
     <OnboardingTemplate
       step={step}
       onContinue={handlePress}
@@ -168,6 +170,7 @@ const RatingsRendererBase = ({ step, onContinue, theme = defaultTheme }: Ratings
         </ScrollView>
       </View>
     </OnboardingTemplate>
+    </SafeAreaView>
   );
 };
 

--- a/packages/onboarding-ui/src/UI/Pages/Ratings/Renderer.tsx
+++ b/packages/onboarding-ui/src/UI/Pages/Ratings/Renderer.tsx
@@ -94,6 +94,7 @@ const RatingsRendererBase = ({ step, onContinue, theme = defaultTheme }: Ratings
         <ScrollView
           contentContainerStyle={styles.scrollContent}
           showsVerticalScrollIndicator={false}
+          alwaysBounceVertical={false}
         >
           {/* Award Section */}
           <View style={styles.awardSection}>

--- a/packages/onboarding-ui/src/UI/Templates/OnboardingTemplate.tsx
+++ b/packages/onboarding-ui/src/UI/Templates/OnboardingTemplate.tsx
@@ -1,6 +1,5 @@
 import { StyleSheet, Text, TouchableOpacity, View } from "react-native";
 import { OnboardingStepType } from "../types";
-import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { getTextStyle } from "../Theme/helpers";
 import { Theme } from "../Theme/types";
 import { defaultTheme } from "../Theme/defaultTheme";
@@ -60,16 +59,13 @@ export const OnboardingTemplate = ({
   button,
   theme = defaultTheme,
 }: OnboardingTemplateProps) => {
-  const { top, bottom } = useSafeAreaInsets();
-
   return (
     <View
       style={[
         styles.container,
         {
           backgroundColor: theme.colors.neutral.lowest,
-          paddingTop: step.displayProgressHeader ? top + 40 : top,
-          paddingBottom: bottom
+          paddingTop: step.displayProgressHeader ? 40 : 0,
         },
       ]}
     >

--- a/packages/onboarding/CHANGELOG.md
+++ b/packages/onboarding/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to `@rocapine/react-native-onboarding` are documented here.
 
 ---
 
+## [1.15.0] - 2026-04-28
+
+### Added
+
+- **`SafeAreaView` UIElement** — new container element mirroring
+  `react-native-safe-area-context`'s `SafeAreaView`. Props: `mode?: "padding" | "margin"`,
+  `edges?` accepting either `("top" | "right" | "bottom" | "left")[]` or a per-edge
+  object mapping each edge to `"off" | "additive" | "maximum"`. Extends `BaseBoxProps`.
+  Exports: `SafeAreaViewElementProps`, `SafeAreaEdge`, `SafeAreaEdgeMode`,
+  `SafeAreaViewElementPropsSchema`.
+
+---
+
 ## [1.14.0] - 2026-04-28
 
 ### Added

--- a/packages/onboarding/CHANGELOG.md
+++ b/packages/onboarding/CHANGELOG.md
@@ -15,6 +15,14 @@ All notable changes to `@rocapine/react-native-onboarding` are documented here.
   Exports: `SafeAreaViewElementProps`, `SafeAreaEdge`, `SafeAreaEdgeMode`,
   `SafeAreaViewElementPropsSchema`.
 
+> **Backend note:** The `onboarding-studio` server must be updated to accept and
+> validate the new `"SafeAreaView"` element type in the `ComposableScreen`
+> UIElement union. Mirror `SafeAreaViewElementPropsSchema` (with the strict
+> per-edge object) in the backend validation layer and add `SafeAreaView` to the
+> CMS editor element-type picker. Run the schema-sync/publish process in
+> `onboarding-studio` (regenerate Zod schemas, bump validator package, deploy)
+> before publishing this SDK release so CI and runtime payloads do not drift.
+
 ---
 
 ## [1.14.0] - 2026-04-28

--- a/packages/onboarding/package.json
+++ b/packages/onboarding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocapine/react-native-onboarding",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "description": "Headless React Native SDK for Rocapine Onboarding Studio - Data fetching, state management, and hooks",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/onboarding/src/onboarding-example.ts
+++ b/packages/onboarding/src/onboarding-example.ts
@@ -96,6 +96,11 @@ export const onboardingExample = {
       payload: {
         elements: [
           {
+            id: "safe-root",
+            type: "SafeAreaView",
+            props: { flex: 1, edges: ["top", "bottom"] },
+            children: [
+          {
             id: "root",
             type: "YStack",
             props: { gap: 24, padding: 24 },
@@ -423,6 +428,8 @@ export const onboardingExample = {
                   },
                 },
               },
+            ],
+          },
             ],
           },
         ],

--- a/packages/onboarding/src/steps/ComposableScreen/elements/SafeAreaViewElement.ts
+++ b/packages/onboarding/src/steps/ComposableScreen/elements/SafeAreaViewElement.ts
@@ -17,7 +17,7 @@ export const SafeAreaViewElementPropsSchema = BaseBoxPropsSchema.extend({
   edges: z
     .union([
       z.array(EdgeSchema),
-      z.object({
+      z.strictObject({
         top: EdgeModeSchema.optional(),
         right: EdgeModeSchema.optional(),
         bottom: EdgeModeSchema.optional(),

--- a/packages/onboarding/src/steps/ComposableScreen/elements/SafeAreaViewElement.ts
+++ b/packages/onboarding/src/steps/ComposableScreen/elements/SafeAreaViewElement.ts
@@ -1,0 +1,28 @@
+import { z } from "zod";
+import { BaseBoxPropsSchema, type BaseBoxProps } from "./BaseBoxProps";
+
+export type SafeAreaEdge = "top" | "right" | "bottom" | "left";
+export type SafeAreaEdgeMode = "off" | "additive" | "maximum";
+
+export type SafeAreaViewElementProps = BaseBoxProps & {
+  mode?: "padding" | "margin";
+  edges?: SafeAreaEdge[] | Partial<Record<SafeAreaEdge, SafeAreaEdgeMode>>;
+};
+
+const EdgeSchema = z.enum(["top", "right", "bottom", "left"]);
+const EdgeModeSchema = z.enum(["off", "additive", "maximum"]);
+
+export const SafeAreaViewElementPropsSchema = BaseBoxPropsSchema.extend({
+  mode: z.enum(["padding", "margin"]).optional(),
+  edges: z
+    .union([
+      z.array(EdgeSchema),
+      z.object({
+        top: EdgeModeSchema.optional(),
+        right: EdgeModeSchema.optional(),
+        bottom: EdgeModeSchema.optional(),
+        left: EdgeModeSchema.optional(),
+      }),
+    ])
+    .optional(),
+});

--- a/packages/onboarding/src/steps/ComposableScreen/types.ts
+++ b/packages/onboarding/src/steps/ComposableScreen/types.ts
@@ -14,6 +14,7 @@ import { type CheckboxGroupElementProps, CheckboxGroupElementPropsSchema } from 
 import { type DatePickerElementProps, DatePickerElementPropsSchema } from "./elements/DatePickerElement";
 import { type CarouselElementProps, CarouselElementPropsSchema } from "./elements/CarouselElement";
 import { type ZStackElementProps, ZStackElementPropsSchema } from "./elements/ZStackElement";
+import { type SafeAreaViewElementProps, SafeAreaViewElementPropsSchema } from "./elements/SafeAreaViewElement";
 
 export type { BaseBoxProps, GradientBackground, GradientEdge, GradientStop, LinearGradientConfig } from "./elements/BaseBoxProps";
 export { BaseBoxPropsSchema, GradientBackgroundSchema } from "./elements/BaseBoxProps";
@@ -31,6 +32,7 @@ export type { CheckboxGroupElementProps } from "./elements/CheckboxGroupElement"
 export type { DatePickerElementProps } from "./elements/DatePickerElement";
 export type { CarouselElementProps } from "./elements/CarouselElement";
 export type { ZStackElementProps } from "./elements/ZStackElement";
+export type { SafeAreaViewElementProps, SafeAreaEdge, SafeAreaEdgeMode } from "./elements/SafeAreaViewElement";
 
 // UIElement union — must live here (not in elements/) to avoid circular deps
 // because the Stack variant's children: UIElement[] references itself.
@@ -121,6 +123,13 @@ type UIElement =
       type: "ZStack";
       props: ZStackElementProps;
       children: UIElement[];
+    }
+  | {
+      id: string;
+      name?: string;
+      type: "SafeAreaView";
+      props: SafeAreaViewElementProps;
+      children: UIElement[];
     };
 
 const UIElementSchema: z.ZodType<UIElement> = z.lazy(() =>
@@ -210,6 +219,13 @@ const UIElementSchema: z.ZodType<UIElement> = z.lazy(() =>
       name: z.string().optional(),
       type: z.literal("ZStack"),
       props: ZStackElementPropsSchema,
+      children: z.array(UIElementSchema),
+    }),
+    z.object({
+      id: z.string(),
+      name: z.string().optional(),
+      type: z.literal("SafeAreaView"),
+      props: SafeAreaViewElementPropsSchema,
       children: z.array(UIElementSchema),
     }),
   ])

--- a/website/docs/page-types.mdx
+++ b/website/docs/page-types.mdx
@@ -403,7 +403,7 @@ Build arbitrary onboarding screens entirely from CMS data — no custom renderer
 - Any screen that doesn't fit a pre-built type
 
 **Key features:**
-- Recursive element tree (`YStack`, `XStack`, `ZStack`, `Text`, `Image`, `Lottie`, `Rive`, `Icon`, `Video`, `Input`, `RadioGroup`, `CheckboxGroup`, `Button`, `DatePicker`, `Carousel`)
+- Recursive element tree (`YStack`, `XStack`, `ZStack`, `SafeAreaView`, `Text`, `Image`, `Lottie`, `Rive`, `Icon`, `Video`, `Input`, `RadioGroup`, `CheckboxGroup`, `Button`, `DatePicker`, `Carousel`)
 - Full flexbox layout support
 - Border, radius, overflow, and opacity control
 - Dimension constraints (`width`, `height`, `min/max`)
@@ -419,6 +419,7 @@ Build arbitrary onboarding screens entirely from CMS data — no custom renderer
 | `YStack` | `<View>` | `column` | — |
 | `XStack` | `<View>` | `row` | — |
 | `ZStack` | `<View>` | depth (z-axis) | — |
+| `SafeAreaView` | `<SafeAreaView>` | column | `react-native-safe-area-context` |
 | `Text` | `<Text>` | — | — |
 | `Image` | `<Image>` | — | — |
 | `Icon` | Lucide icon | — | — (bundled) |
@@ -469,6 +470,33 @@ Build arbitrary onboarding screens entirely from CMS data — no custom renderer
 Children are layered in declaration order: first child = bottom, last child = top. Each child is wrapped in `position: "absolute"` filling the container, so flex props on `ZStack` itself (`gap`, `alignItems`, `justifyContent`) have no effect — instead control the layout of each layer's content via the layer's own props (e.g. wrap content in a `YStack` with `justifyContent: "flex-end"` to anchor it to the bottom).
 
 The wrapper for each child uses `pointerEvents="box-none"`, so touches pass through transparent regions to layers underneath.
+:::
+
+**SafeAreaView props:**
+
+`SafeAreaView` mirrors the props of `SafeAreaView` from `react-native-safe-area-context`. Use it to inset content from system UI (notch, home indicator) inside a `ComposableScreen`. Other renderers wrap themselves in `SafeAreaView` automatically; `ComposableScreen` does not, so opt in here when needed.
+
+| Prop | Type | Notes |
+|------|------|-------|
+| `mode` | `"padding" \| "margin"` | Defaults to `"padding"`. `"margin"` is useful when the SafeAreaView itself has a background that should not extend into the inset region |
+| `edges` | `Edge[]` or `{ top?, right?, bottom?, left? }` | `Edge` is `"top" \| "right" \| "bottom" \| "left"`. Object form maps each edge to `"off" \| "additive" \| "maximum"` for fine-grained control |
+| All `BaseBoxProps` | — | `flex`, `padding`, `backgroundColor`, `borderRadius`, etc. |
+
+**SafeAreaView example:**
+
+```json
+{
+  "id": "safe-root",
+  "type": "SafeAreaView",
+  "props": { "flex": 1, "edges": ["top", "bottom"] },
+  "children": [
+    { "id": "content", "type": "YStack", "props": { "padding": 24, "gap": 16 }, "children": [ /* ... */ ] }
+  ]
+}
+```
+
+:::note OnboardingTemplate no longer applies insets
+As of 1.15.0, `OnboardingTemplate` does not apply safe-area insets. Built-in page types (`Question`, `MediaContent`, `Carousel`, etc.) now wrap themselves with `SafeAreaView edges={["top","bottom"]}`. For `ComposableScreen`, place a `SafeAreaView` UIElement at the root of your tree (or omit it for full edge-to-edge rendering).
 :::
 
 **Image props:**
@@ -940,7 +968,7 @@ If `expo-video` is not installed, the element renders a placeholder view with an
 }
 ```
 
-**Dependencies:** None for `YStack`, `XStack`, `ZStack`, `Text`, `Image`, `Icon`, `Input`, `RadioGroup`, `CheckboxGroup`, `Button`. See the Carousel, Lottie, Rive, Video, and DatePicker sections above for elements with peer deps.
+**Dependencies:** None for `YStack`, `XStack`, `ZStack`, `Text`, `Image`, `Icon`, `Input`, `RadioGroup`, `CheckboxGroup`, `Button`. `SafeAreaView` requires `react-native-safe-area-context` (already a peer dep of `@rocapine/react-native-onboarding-ui`). See the Carousel, Lottie, Rive, Video, and DatePicker sections above for elements with peer deps.
 
 ---
 


### PR DESCRIPTION
## Summary
- Add `SafeAreaView` UIElement to ComposableScreen — mirrors `react-native-safe-area-context` props (`mode`, `edges` as array or per-edge object), extends `BaseBoxProps`, accepts children.
- Strip safe-area inset logic from `OnboardingTemplate`; non-composable renderers (Carousel, Commitment, Loader, MediaContent, Picker, Question, Ratings) wrap themselves in `<SafeAreaView edges={["top","bottom"]}>`. ComposableScreen renders edge-to-edge — author opt-in via the new element.
- Bump both SDK packages to `1.15.0`; update CHANGELOGs and `website/docs/page-types.mdx`.

## Test plan
- [ ] `npm run build` passes
- [ ] `cd example && npm run type:check` passes
- [ ] Run example app, verify Question/MediaContent/Picker/etc. screens still respect notch + home indicator
- [ ] Verify ComposableScreen demo renders edge-to-edge unless `SafeAreaView` element is added
- [ ] CMS (onboarding-studio) mirrors schema before publishing 1.15.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a SafeAreaView UI element for composable screens to opt into safe-area layout.

* **Behavior Changes**
  * Built-in pages now wrap content in safe-area (top & bottom); main template no longer applies automatic insets and preserves a fixed 40px progress-header offset.
  * Several scroll views disable vertical bounce for a firmer scrolling feel.

* **Documentation**
  * Docs updated for SafeAreaView usage and revised safe-area handling.

* **Chores**
  * Bumped packages to 1.15.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->