### PR TITLE
✨ feat(composable-screen): button ordered actions + customActions injection (v1.16.0)

### DIFF
--- a/example/app/_layout.tsx
+++ b/example/app/_layout.tsx
@@ -45,6 +45,14 @@ export default function RootLayout() {
       locale="en"
       customAudienceParams={{
       }}
+      customActions={{
+        trackCta: async ({ variables }) => {
+          console.log("[customAction] trackCta fired with variables:", variables);
+        },
+        celebrate: async ({ variables }) => {
+          console.log("[customAction] celebrate", variables);
+        },
+      }}
     >
       <OnboardingProgressProvider>
         <Stack screenOptions={{ headerShown: false }} />

--- a/example/app/example/composable-screen.tsx
+++ b/example/app/example/composable-screen.tsx
@@ -375,7 +375,7 @@ export default function ComposableScreenExample() {
                 },
               ],
             },
-            // Button element
+            // Button element — runs a custom action with selected variables, then continues.
             {
               id: 'hero-button',
               type: 'Button' as const,
@@ -383,9 +383,13 @@ export default function ComposableScreenExample() {
                 label: 'Get Started',
                 variant: 'filled' as const,
                 marginVertical: 8,
+                actions: [
+                  { type: 'custom' as const, function: 'trackCta', variables: ['name', 'plan', 'goals'] },
+                  'continue' as const,
+                ],
               },
             },
-            // Outlined button variant
+            // Outlined button — uses the legacy `action: "continue"` form (back-compat alias).
             {
               id: 'hero-button-outlined',
               type: 'Button' as const,
@@ -393,6 +397,7 @@ export default function ComposableScreenExample() {
                 label: 'Learn More',
                 variant: 'outlined' as const,
                 marginVertical: 4,
+                action: 'continue' as const,
               },
             },
             // Highlighted info block
@@ -493,7 +498,7 @@ export default function ComposableScreenExample() {
                 },
               ],
             },
-            // Gradient Button
+            // Gradient Button — fires multiple custom actions before continuing.
             {
               id: 'gradient-button',
               type: 'Button' as const,
@@ -501,6 +506,11 @@ export default function ComposableScreenExample() {
                 label: 'Gradient Button',
                 variant: 'filled' as const,
                 marginVertical: 4,
+                actions: [
+                  { type: 'custom' as const, function: 'celebrate' },
+                  { type: 'custom' as const, function: 'trackCta', variables: ['name'] },
+                  'continue' as const,
+                ],
                 backgroundGradient: {
                   type: 'linear' as const,
                   from: 'left' as const,

--- a/packages/onboarding-ui/CHANGELOG.md
+++ b/packages/onboarding-ui/CHANGELOG.md
@@ -5,6 +5,28 @@ here.
 
 ---
 
+## [1.16.0] - 2026-04-29
+
+### Added
+
+- **Button `actions` execution** — `ButtonElement` now runs the headless
+  `ButtonAction[]` chain on press: sequential, `await`s async handlers,
+  warns on missing handler, aborts on thrown error, `"continue"` is terminal.
+- **`customActions` plumbing** — `RenderContext` exposes `customActions` to
+  every ComposableScreen element. `ComposableScreenRenderer` reads them from
+  the headless `OnboardingProgressContext` (set via
+  `<OnboardingProvider customActions={...}>`).
+- Re-exports `ButtonAction`, `CustomButtonAction`, `CustomActionHandler`,
+  `CustomActions`, `ComposableVariableEntry` from the headless package.
+
+### Changed
+
+- `ComposableVariableEntry` is now sourced from the headless package
+  (`@rocapine/react-native-onboarding`); the UI provider re-exports it.
+  Existing imports from `OnboardingProgressProvider` continue to work.
+
+---
+
 ## [1.15.0] - 2026-04-28
 
 ### Added

--- a/packages/onboarding-ui/package.json
+++ b/packages/onboarding-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocapine/react-native-onboarding-ui",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "description": "UI components and renderers for Rocapine Onboarding Studio - Built on top of the headless SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -46,7 +46,7 @@
   "peerDependencies": {
     "@react-native-community/datetimepicker": "*",
     "@react-native-picker/picker": "*",
-    "@rocapine/react-native-onboarding": "^1.15.0",
+    "@rocapine/react-native-onboarding": "^1.16.0",
     "@shopify/react-native-skia": ">=1.0.0",
     "@tanstack/react-query": ">=5.0.0",
     "@types/react": "*",

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/Renderer.tsx
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/Renderer.tsx
@@ -19,7 +19,7 @@ const ComposableScreenRendererBase = ({ step, onContinue }: ContentProps) => {
   const validatedData = useMemo(() => ComposableScreenStepTypeSchema.parse(step), [step]);
   const { elements } = validatedData.payload;
   const { composableVariables, setComposableVariable } = useContext(OnboardingProgressContext);
-  const { setVariable: setHeadlessVariable } = useContext(HeadlessProgressContext);
+  const { setVariable: setHeadlessVariable, customActions } = useContext(HeadlessProgressContext);
 
   const setVariableAndSync = useCallback(
     (key: string, entry: ComposableVariableEntry) => {
@@ -37,6 +37,7 @@ const ComposableScreenRendererBase = ({ step, onContinue }: ContentProps) => {
     variables: composableVariables,
     setVariable: setVariableAndSync,
     onContinue,
+    customActions,
     renderChildren,
   };
 

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/ButtonElement.tsx
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/ButtonElement.tsx
@@ -5,9 +5,35 @@ import { BaseBoxProps, BaseBoxPropsSchema } from "./BaseBoxProps";
 import { UIElement } from "../types";
 import { RenderContext, dim } from "./shared";
 import { GradientBox } from "./GradientBox";
+import { ComposableVariableEntry } from "../../../Provider/OnboardingProgressProvider";
+
+export type CustomButtonAction = {
+  type: "custom";
+  function: string;
+  variables?: string[];
+};
+
+export const CustomButtonActionSchema = z.object({
+  type: z.literal("custom"),
+  function: z.string().min(1, "function must not be empty"),
+  variables: z.array(z.string()).optional(),
+});
+
+export type ButtonAction = "continue" | CustomButtonAction;
+
+export const ButtonActionSchema = z.union([
+  z.literal("continue"),
+  CustomButtonActionSchema,
+]);
 
 export type ButtonElementProps = BaseBoxProps & {
   label: string;
+  /**
+   * Ordered list of actions to run on press. Sequential, await async handlers,
+   * abort on error, `"continue"` is terminal.
+   */
+  actions?: ButtonAction[];
+  /** @deprecated Use `actions` instead. */
   action?: "continue";
   variant?: "filled" | "outlined" | "ghost";
   backgroundColor?: string;
@@ -20,6 +46,7 @@ export type ButtonElementProps = BaseBoxProps & {
 
 export const ButtonElementPropsSchema = BaseBoxPropsSchema.extend({
   label: z.string().min(1, "label must not be empty"),
+  actions: z.array(ButtonActionSchema).optional(),
   action: z.enum(["continue"]).optional(),
   variant: z.enum(["filled", "outlined", "ghost"]).optional(),
   backgroundColor: z.string().optional(),
@@ -38,13 +65,37 @@ type Props = {
 };
 
 export const ButtonElementComponent = ({ element, ctx }: Props): React.ReactElement => {
-  const { theme, onContinue } = ctx;
-  const action = element.props.action;
-  const handlePress = () => {
-    if (action === undefined || action === "continue") {
-      onContinue();
+  const { theme, onContinue, customActions, variables } = ctx;
+  const handlePress = async () => {
+    const { actions, action } = element.props;
+    const effective: ButtonAction[] =
+      actions ?? (action === "continue" ? ["continue"] : []);
+
+    for (const act of effective) {
+      if (act === "continue") {
+        onContinue();
+        return;
+      }
+      const handler = customActions[act.function];
+      if (!handler) {
+        console.warn(
+          `[ComposableScreen] No customAction registered for "${act.function}"`
+        );
+        continue;
+      }
+      const requested = act.variables ?? [];
+      const vars: Record<string, ComposableVariableEntry | undefined> = {};
+      for (const name of requested) vars[name] = variables[name];
+      try {
+        await handler({ variables: vars });
+      } catch (err) {
+        console.error(
+          `[ComposableScreen] customAction "${act.function}" threw:`,
+          err
+        );
+        return;
+      }
     }
-    // other action values are no-ops
   };
   const variant = element.props.variant ?? "filled";
   const isFilled = variant === "filled";

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/shared.ts
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/shared.ts
@@ -1,4 +1,5 @@
 import React from "react";
+import { CustomActions } from "@rocapine/react-native-onboarding";
 import { UIElement } from "../types";
 import { Theme } from "../../../Theme/types";
 import { ComposableVariableEntry } from "../../../Provider/OnboardingProgressProvider";
@@ -8,6 +9,7 @@ export type RenderContext = {
   variables: Record<string, ComposableVariableEntry>;
   setVariable: (key: string, entry: ComposableVariableEntry) => void;
   onContinue: () => void;
+  customActions: CustomActions;
   renderChildren: (elements: UIElement[], parentType: "XStack" | "YStack" | "ZStack") => React.ReactNode;
 };
 

--- a/packages/onboarding-ui/src/UI/Provider/OnboardingProgressProvider.tsx
+++ b/packages/onboarding-ui/src/UI/Provider/OnboardingProgressProvider.tsx
@@ -1,7 +1,10 @@
 import { createContext, useState, useCallback } from "react";
 import { SafeAreaProvider } from "react-native-safe-area-context";
+import type { ComposableVariableEntry } from "@rocapine/react-native-onboarding";
 import { ThemeProvider } from "../Theme/ThemeProvider";
 import { ColorScheme } from "../Theme/types";
+
+export type { ComposableVariableEntry };
 
 export const OnboardingProgressProvider = ({
   children,
@@ -34,8 +37,6 @@ export const OnboardingProgressProvider = ({
     </SafeAreaProvider>
   );
 };
-
-export type ComposableVariableEntry = { value: string; label?: string };
 
 export const OnboardingProgressContext = createContext({
   activeStep: { number: 0, displayProgressHeader: false },

--- a/packages/onboarding-ui/src/index.ts
+++ b/packages/onboarding-ui/src/index.ts
@@ -4,6 +4,11 @@ export type {
   Onboarding,
   OnboardingMetadata,
   OnboardingStudioClientOptions,
+  CustomActionHandler,
+  CustomActions,
+  ButtonAction,
+  CustomButtonAction,
+  ComposableVariableEntry,
 } from "@rocapine/react-native-onboarding";
 
 // UI Components and Router

--- a/packages/onboarding/CHANGELOG.md
+++ b/packages/onboarding/CHANGELOG.md
@@ -4,6 +4,38 @@ All notable changes to `@rocapine/react-native-onboarding` are documented here.
 
 ---
 
+## [1.16.0] - 2026-04-29
+
+### Added
+
+- **`Button.actions` ordered action array** — `ButtonElement.props` now accepts
+  `actions?: ButtonAction[]`, where `ButtonAction = "continue" | { type: "custom"; function: string; variables?: string[] }`.
+  Actions run sequentially on press; `await`s any returned Promise; aborts the
+  remaining chain on a thrown error; `"continue"` is terminal.
+- **`OnboardingProvider.customActions` prop** — `Record<string, CustomActionHandler>`
+  where `CustomActionHandler = (args: { variables: Record<string, ComposableVariableEntry | undefined> }) => void | Promise<void>`.
+  Functions are invoked by name from `Button.actions` `{ type: "custom", function, variables }`,
+  receiving the requested variables filtered from the live ComposableScreen
+  variable map.
+- New exports: `ButtonAction`, `CustomButtonAction`, `ButtonActionSchema`,
+  `CustomButtonActionSchema`, `CustomActionHandler`, `CustomActions`,
+  `ComposableVariableEntry`.
+
+### Changed
+
+- `Button.action?: "continue"` is now **deprecated** but still accepted as a
+  back-compat alias. When `actions` is absent and `action === "continue"`,
+  runtime treats it as `actions: ["continue"]`. CMS payloads should migrate to
+  `actions`.
+
+> **Backend note:** The `onboarding-studio` server must mirror the new
+> `Button.actions` field in its `ComposableScreen` UIElement schema (Zod) and
+> CMS editor (ordered list of `"continue"` or
+> `{ type: "custom"; function: string; variables?: string[] }`). The legacy
+> `action` field should be kept readable for historical payloads.
+
+---
+
 ## [1.15.0] - 2026-04-28
 
 ### Added

--- a/packages/onboarding/package.json
+++ b/packages/onboarding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocapine/react-native-onboarding",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "description": "Headless React Native SDK for Rocapine Onboarding Studio - Data fetching, state management, and hooks",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/onboarding/src/index.ts
+++ b/packages/onboarding/src/index.ts
@@ -2,6 +2,16 @@
 export { OnboardingStudioClient } from "./OnboardingStudioClient";
 export * from "./types";
 export * from "./onboarding-example";
+// ComposableScreen types (Button actions, variable entry, etc.)
+export type {
+  ButtonAction,
+  CustomButtonAction,
+  ComposableVariableEntry,
+} from "./steps/ComposableScreen/types";
+export {
+  ButtonActionSchema,
+  CustomButtonActionSchema,
+} from "./steps/ComposableScreen/types";
 // Hooks and providers
 export * from "./infra";
 // Branching

--- a/packages/onboarding/src/infra/provider/OnboardingProvider.tsx
+++ b/packages/onboarding/src/infra/provider/OnboardingProvider.tsx
@@ -4,6 +4,7 @@ import { OnboardingStudioClient } from "../../OnboardingStudioClient";
 import { getOnboardingQuery } from "../queries/getOnboarding.query";
 import { Onboarding } from "../../types";
 import { OnboardingStepType } from "../../steps/types";
+import { ComposableVariableEntry } from "../../steps/ComposableScreen/types";
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -13,11 +14,24 @@ const queryClient = new QueryClient({
   },
 })
 
+export type CustomActionHandler = (args: {
+  variables: Record<string, ComposableVariableEntry | undefined>;
+}) => void | Promise<void>;
+
+export type CustomActions = Record<string, CustomActionHandler>;
+
 interface OnboardingProviderProps {
   children: React.ReactNode;
   client: OnboardingStudioClient;
   locale?: string;
   customAudienceParams?: Record<string, any>;
+  /**
+   * Map of named handlers invokable from ComposableScreen Button `actions`
+   * with `{ type: "custom", function: <name>, variables?: [...] }`. Handlers
+   * receive the requested variables filtered from the live ComposableScreen
+   * variable map and may return a Promise.
+   */
+  customActions?: CustomActions;
 }
 
 export const OnboardingProvider = ({
@@ -25,6 +39,7 @@ export const OnboardingProvider = ({
   client,
   locale = "en",
   customAudienceParams = {},
+  customActions = {},
 }: OnboardingProviderProps) => {
   const [activeStep, setActiveStep] = useState({
     number: 0,
@@ -55,6 +70,7 @@ export const OnboardingProvider = ({
           setOnboarding,
           variables,
           setVariable,
+          customActions,
         }}
       >
         {children}
@@ -75,6 +91,7 @@ export const OnboardingProgressContext = createContext<{
   setOnboarding: (onboarding: Onboarding<OnboardingStepType>) => void;
   variables: Record<string, any>;
   setVariable: (name: string, value: any) => void;
+  customActions: CustomActions;
 }>({
   activeStep: { number: 0, displayProgressHeader: false },
   setActiveStep: () => { },
@@ -87,4 +104,5 @@ export const OnboardingProgressContext = createContext<{
   setOnboarding: () => { },
   variables: {},
   setVariable: () => { },
+  customActions: {},
 });

--- a/packages/onboarding/src/infra/provider/index.ts
+++ b/packages/onboarding/src/infra/provider/index.ts
@@ -2,3 +2,7 @@ export {
   OnboardingProvider,
   OnboardingProgressContext,
 } from "./OnboardingProvider";
+export type {
+  CustomActionHandler,
+  CustomActions,
+} from "./OnboardingProvider";

--- a/packages/onboarding/src/onboarding-example.ts
+++ b/packages/onboarding/src/onboarding-example.ts
@@ -376,6 +376,10 @@ export const onboardingExample = {
                   label: "Get Started",
                   variant: "filled",
                   marginVertical: 8,
+                  actions: [
+                    { type: "custom", function: "trackCta", variables: ["name", "plan", "goals"] },
+                    "continue",
+                  ],
                 },
               },
               {

--- a/packages/onboarding/src/steps/ComposableScreen/elements/ButtonElement.ts
+++ b/packages/onboarding/src/steps/ComposableScreen/elements/ButtonElement.ts
@@ -1,8 +1,36 @@
 import { z } from "zod";
 import { BaseBoxProps, BaseBoxPropsSchema } from "./BaseBoxProps";
 
+export type CustomButtonAction = {
+  type: "custom";
+  function: string;
+  variables?: string[];
+};
+
+export const CustomButtonActionSchema = z.object({
+  type: z.literal("custom"),
+  function: z.string().min(1, "function must not be empty"),
+  variables: z.array(z.string()).optional(),
+});
+
+export type ButtonAction = "continue" | CustomButtonAction;
+
+export const ButtonActionSchema = z.union([
+  z.literal("continue"),
+  CustomButtonActionSchema,
+]);
+
 export type ButtonElementProps = BaseBoxProps & {
   label: string;
+  /**
+   * Ordered list of actions to run on press. Sequential, await async handlers,
+   * abort on error, `"continue"` is terminal.
+   */
+  actions?: ButtonAction[];
+  /**
+   * @deprecated Use `actions` instead. When `actions` is absent and `action === "continue"`,
+   * runtime treats it as `actions: ["continue"]`.
+   */
   action?: "continue";
   variant?: "filled" | "outlined" | "ghost";
   backgroundColor?: string;
@@ -15,6 +43,7 @@ export type ButtonElementProps = BaseBoxProps & {
 
 export const ButtonElementPropsSchema = BaseBoxPropsSchema.extend({
   label: z.string().min(1, "label must not be empty"),
+  actions: z.array(ButtonActionSchema).optional(),
   action: z.enum(["continue"]).optional(),
   variant: z.enum(["filled", "outlined", "ghost"]).optional(),
   backgroundColor: z.string().optional(),

--- a/packages/onboarding/src/steps/ComposableScreen/types.ts
+++ b/packages/onboarding/src/steps/ComposableScreen/types.ts
@@ -26,13 +26,20 @@ export type { RiveElementProps } from "./elements/RiveElement";
 export type { IconElementProps } from "./elements/IconElement";
 export type { VideoElementProps } from "./elements/VideoElement";
 export type { InputElementProps } from "./elements/InputElement";
-export type { ButtonElementProps } from "./elements/ButtonElement";
+export type { ButtonElementProps, ButtonAction, CustomButtonAction } from "./elements/ButtonElement";
+export { ButtonActionSchema, CustomButtonActionSchema } from "./elements/ButtonElement";
 export type { RadioGroupElementProps } from "./elements/RadioGroupElement";
 export type { CheckboxGroupElementProps } from "./elements/CheckboxGroupElement";
 export type { DatePickerElementProps } from "./elements/DatePickerElement";
 export type { CarouselElementProps } from "./elements/CarouselElement";
 export type { ZStackElementProps } from "./elements/ZStackElement";
 export type { SafeAreaViewElementProps, SafeAreaEdge, SafeAreaEdgeMode } from "./elements/SafeAreaViewElement";
+
+/**
+ * A variable entry stored in the ComposableScreen variables map.
+ * `value` is the canonical value (string), `label` is an optional display label.
+ */
+export type ComposableVariableEntry = { value: string; label?: string };
 
 // UIElement union — must live here (not in elements/) to avoid circular deps
 // because the Stack variant's children: UIElement[] references itself.

--- a/website/docs/api-reference.mdx
+++ b/website/docs/api-reference.mdx
@@ -19,6 +19,11 @@ import { OnboardingProvider } from "@rocapine/react-native-onboarding";
   client={client}
   locale="en"
   customAudienceParams={{ onboardingId: "abc-123" }}
+  customActions={{
+    trackCta: async ({ variables }) => {
+      console.log("trackCta", variables);
+    },
+  }}
 >
   <YourApp />
 </OnboardingProvider>
@@ -31,6 +36,25 @@ import { OnboardingProvider } from "@rocapine/react-native-onboarding";
 | `client` | `OnboardingStudioClient` | **Required** | Client instance for API communication |
 | `locale` | `string` | `"en"` | Locale for fetching steps |
 | `customAudienceParams` | `Record<string, any>` | `{}` | Additional parameters for API |
+| `customActions` | `CustomActions` | `{}` | Map of named handlers invokable from `ComposableScreen` `Button.actions` `{ type: "custom", function, variables? }`. See [Custom Actions](./customization/custom-actions.mdx) |
+
+#### CustomActionHandler
+
+```typescript
+import type {
+  CustomActionHandler,
+  CustomActions,
+  ComposableVariableEntry,
+} from "@rocapine/react-native-onboarding";
+
+type CustomActionHandler = (args: {
+  variables: Record<string, ComposableVariableEntry | undefined>;
+}) => void | Promise<void>;
+
+type CustomActions = Record<string, CustomActionHandler>;
+```
+
+`variables` is filtered to the names listed in the action's `variables` array (missing keys yield `undefined`). Handlers may return a `Promise` — the action chain awaits before proceeding.
 
 ---
 

--- a/website/docs/core-concepts.mdx
+++ b/website/docs/core-concepts.mdx
@@ -71,6 +71,11 @@ When you wrap your app with `OnboardingProvider` and `ThemeProvider`:
 <OnboardingProvider
   client={client}
   customAudienceParams={{ onboardingId: "abc-123" }}
+  customActions={{
+    trackCta: async ({ variables }) => {
+      console.log("trackCta", variables);
+    },
+  }}
 >
   <ThemeProvider>
     <YourApp />
@@ -83,6 +88,7 @@ The SDK:
 2. Sets up AsyncStorage caching (OnboardingProvider)
 3. Prepares theme context (ThemeProvider)
 4. Establishes progress tracking (OnboardingProvider)
+5. Registers `customActions` for `ComposableScreen` Button presses — see [Custom Actions](./customization/custom-actions.mdx)
 
 ### 2. Data Fetching
 

--- a/website/docs/customization/custom-actions.mdx
+++ b/website/docs/customization/custom-actions.mdx
@@ -1,0 +1,190 @@
+---
+sidebar_position: 4
+---
+
+# Custom Actions
+
+Wire developer-defined functions to `ComposableScreen` `Button` presses. Run analytics, fire side effects, gate navigation on async work — all without writing a custom renderer.
+
+## Overview
+
+Each `Button` element in a `ComposableScreen` carries an ordered `actions` array. The runtime walks the array on press, executing each entry sequentially:
+
+- `"continue"` — advances the onboarding (terminal — anything after is ignored).
+- `{ type: "custom", function: "<name>", variables?: ["<key>", ...] }` — invokes a handler you registered on `OnboardingProvider.customActions`. Listed variables are read from the live ComposableScreen variable map and forwarded to the handler.
+
+Handlers may be async — the chain awaits each `Promise` before proceeding.
+
+## Schema
+
+```typescript
+type ButtonAction =
+  | "continue"
+  | { type: "custom"; function: string; variables?: string[] };
+```
+
+```jsonc
+// CMS payload — Button element
+{
+  "id": "primary-cta",
+  "type": "Button",
+  "props": {
+    "label": "Get Started",
+    "variant": "filled",
+    "actions": [
+      { "type": "custom", "function": "trackCta", "variables": ["name", "plan"] },
+      { "type": "custom", "function": "syncProfile", "variables": ["name", "plan", "goals"] },
+      "continue"
+    ]
+  }
+}
+```
+
+## Handler signature
+
+```typescript
+import type {
+  CustomActionHandler,
+  CustomActions,
+  ComposableVariableEntry,
+} from "@rocapine/react-native-onboarding";
+
+type CustomActionHandler = (args: {
+  variables: Record<string, ComposableVariableEntry | undefined>;
+}) => void | Promise<void>;
+
+type CustomActions = Record<string, CustomActionHandler>;
+```
+
+`variables` is filtered to the names listed in the action's `variables` array. Each entry is `{ value: string; label?: string }` — the same shape `Input`, `RadioGroup`, `CheckboxGroup`, and `DatePicker` write to the variable context. Missing keys yield `undefined` so the handler can detect them.
+
+## Registration
+
+Pass `customActions` to the headless `OnboardingProvider` once at the app root.
+
+```tsx
+import {
+  OnboardingProvider,
+  OnboardingStudioClient,
+} from "@rocapine/react-native-onboarding";
+
+const client = new OnboardingStudioClient(process.env.EXPO_PUBLIC_PROJECT_ID!, {
+  appVersion: "1.0.0",
+});
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <OnboardingProvider
+      client={client}
+      customActions={{
+        trackCta: async ({ variables }) => {
+          await analytics.track("cta_pressed", {
+            name: variables.name?.value,
+            plan: variables.plan?.value,
+          });
+        },
+        syncProfile: async ({ variables }) => {
+          await api.post("/profile", {
+            name: variables.name?.value,
+            plan: variables.plan?.value,
+            goals: variables.goals?.value, // CheckboxGroup writes JSON.stringify(string[])
+          });
+        },
+      }}
+    >
+      {children}
+    </OnboardingProvider>
+  );
+}
+```
+
+## Execution semantics
+
+| Behavior | Detail |
+|---|---|
+| **Order** | Sequential — each action awaits the prior. |
+| **Async** | Returned `Promise` is awaited. |
+| **`"continue"`** | Terminal — chain stops. Place `"continue"` last. |
+| **Thrown error** | `console.error` and chain aborts (subsequent actions, including `"continue"`, do not run). |
+| **Unknown handler name** | `console.warn` and chain skips to the next action. |
+| **Empty array / no `actions` / no legacy `action`** | Press is a no-op. |
+
+## Variable shape by element
+
+`variables` reflects whatever the variable-writing elements stored. Keep this table handy when authoring handlers:
+
+| Element | `value` | `label` |
+|---|---|---|
+| `Input` | Raw text | — |
+| `RadioGroup` | Selected item value (`"monthly"`) | Selected item label (`"Monthly"`) |
+| `CheckboxGroup` | `JSON.stringify(string[])` of selected values | Comma-joined display labels |
+| `DatePicker` | ISO 8601 string | Locale-formatted date |
+
+Parse `CheckboxGroup` values with `JSON.parse(variables.goals?.value ?? "[]")` when you need the array.
+
+## Patterns
+
+### Analytics-only (no nav change)
+
+`"continue"` not present → no navigation. Use this for buttons that fire side effects but stay on the screen.
+
+```jsonc
+{
+  "actions": [
+    { "type": "custom", "function": "trackTooltipOpen" }
+  ]
+}
+```
+
+### Gate navigation on a network call
+
+```jsonc
+{
+  "actions": [
+    { "type": "custom", "function": "validateProfile", "variables": ["name", "email"] },
+    "continue"
+  ]
+}
+```
+
+```tsx
+customActions={{
+  validateProfile: async ({ variables }) => {
+    const res = await api.post("/validate", {
+      name: variables.name?.value,
+      email: variables.email?.value,
+    });
+    if (!res.ok) throw new Error("validation failed"); // aborts chain → "continue" skipped
+  },
+}}
+```
+
+### Fan-out side effects, then continue
+
+```jsonc
+{
+  "actions": [
+    { "type": "custom", "function": "trackCta" },
+    { "type": "custom", "function": "syncProfile", "variables": ["name", "plan"] },
+    "continue"
+  ]
+}
+```
+
+## Migrating from `action: "continue"`
+
+The legacy `action?: "continue"` field is still accepted for back-compat. When `actions` is absent and `action === "continue"`, the runtime treats it as `actions: ["continue"]`. Prefer emitting `actions` from new CMS payloads.
+
+```jsonc
+// Old
+{ "props": { "label": "Continue", "action": "continue" } }
+
+// New
+{ "props": { "label": "Continue", "actions": ["continue"] } }
+```
+
+## Related
+
+- [ComposableScreen page type & `Button` props](../page-types.mdx#composablescreen)
+- [API Reference — `OnboardingProvider`](../api-reference.mdx#onboardingprovider)
+- [Custom Components](./custom-components.mdx) — replace UI components rather than wire callbacks

--- a/website/docs/customization/intro.mdx
+++ b/website/docs/customization/intro.mdx
@@ -72,6 +72,38 @@ import { ThemeProvider } from "@rocapine/react-native-onboarding-ui";
 
 ---
 
+### Level 2b: Custom Actions ⚡
+**Run developer-defined functions on `ComposableScreen` `Button` presses**
+
+- Targets the `ComposableScreen` Button `actions` array
+- Inject named handlers via `OnboardingProvider.customActions`
+- Forward selected variables (e.g. `Input`/`RadioGroup` values) to your handler
+- Async-aware — chain awaits `Promise` returns; throw to abort navigation
+
+**Best for:**
+- Analytics on CTA presses
+- Gating navigation on a network call
+- Triggering side effects (deep links, native modules, profile sync) from the CMS
+
+```typescript
+import { OnboardingProvider } from "@rocapine/react-native-onboarding";
+
+<OnboardingProvider
+  client={client}
+  customActions={{
+    trackCta: async ({ variables }) => {
+      await analytics.track("cta_pressed", { name: variables.name?.value });
+    },
+  }}
+>
+  <YourApp />
+</OnboardingProvider>
+```
+
+[Learn more about Custom Actions →](./custom-actions.mdx)
+
+---
+
 ### Level 3: Custom Renderers 🎭
 **Complete control over entire screens**
 
@@ -189,7 +221,8 @@ Start with the customization level that matches your needs:
 
 1. 🎨 [**Theming**](./theming.mdx) - Colors, typography, and semantic styles
 2. 🔧 [**Custom Components**](./custom-components.mdx) - Replace specific UI components
-3. 🎭 [**Custom Renderers**](./custom-renderers.mdx) - Complete screen control
+3. ⚡ [**Custom Actions**](./custom-actions.mdx) - Wire handlers to ComposableScreen Button presses
+4. 🎭 [**Custom Renderers**](./custom-renderers.mdx) - Complete screen control
 
 :::tip Start Simple
 We recommend starting with Level 1 (Theming) and only moving to higher levels when needed. Most customization needs can be met with theming alone.

--- a/website/docs/page-types.mdx
+++ b/website/docs/page-types.mdx
@@ -622,7 +622,8 @@ As of 1.15.0, `OnboardingTemplate` does not apply safe-area insets. Built-in pag
 |------|------|-------|
 | `label` | `string` | **Required** — button text |
 | `variant` | `"filled" \| "outlined" \| "ghost"` | Visual style; `filled` = solid primary background, `outlined` = border only, `ghost` = no background or border |
-| `action` | `"continue"` | Calls `onContinue` when tapped; defaults to `"continue"` |
+| `actions` | `ButtonAction[]` | Ordered list run on press. See **Button actions** below. When omitted (and no legacy `action`), the press is a no-op |
+| `action` | `"continue"` | **Deprecated** — back-compat alias. When `actions` is absent and `action === "continue"`, runtime treats it as `actions: ["continue"]` |
 | `backgroundColor` | `string` | Overrides variant background color |
 | `color` | `string` | Label text color |
 | `fontSize` | `number` | |
@@ -635,6 +636,59 @@ As of 1.15.0, `OnboardingTemplate` does not apply safe-area insets. Built-in pag
 | `padding` / `paddingHorizontal` / `paddingVertical` | `number` | |
 | `borderWidth` / `borderRadius` / `borderColor` | `number \| string` | |
 | `opacity` | `number` | |
+
+**Button actions**
+
+`Button.actions` is an ordered array. Each entry is one of:
+
+- `"continue"` — advances to the next onboarding step (calls the `onContinue` callback wired to the renderer).
+- `{ type: "custom", function: string, variables?: string[] }` — invokes a developer-injected handler registered on `OnboardingProvider.customActions`. `variables` lists the keys to read from the live ComposableScreen variable map and forward to the handler.
+
+Execution rules:
+
+- Sequential. Each action awaits the previous before starting.
+- Async-aware. If a custom handler returns a `Promise`, the runtime awaits it.
+- `"continue"` is **terminal** — any actions after it are ignored.
+- A thrown error in a custom handler is logged via `console.error` and the remaining chain is aborted.
+- An unknown `function` name (no matching key in `customActions`) emits `console.warn` and the chain skips to the next action.
+
+```jsonc
+{
+  "id": "primary-cta",
+  "type": "Button",
+  "props": {
+    "label": "Get Started",
+    "variant": "filled",
+    "actions": [
+      { "type": "custom", "function": "trackCta", "variables": ["name", "plan"] },
+      "continue"
+    ]
+  }
+}
+```
+
+Register the matching handlers on `OnboardingProvider`:
+
+```tsx
+import { OnboardingProvider } from "@rocapine/react-native-onboarding";
+
+<OnboardingProvider
+  client={client}
+  customActions={{
+    trackCta: async ({ variables }) => {
+      // variables → { name?: { value, label? }, plan?: { value, label? } }
+      await analytics.track("cta_pressed", {
+        name: variables.name?.value,
+        plan: variables.plan?.value,
+      });
+    },
+  }}
+>
+  {children}
+</OnboardingProvider>
+```
+
+See [Custom Actions](./customization/custom-actions.mdx) for the full handler signature and patterns.
 
 **DatePicker props:**
 


### PR DESCRIPTION
## Summary

- `Button.actions: ButtonAction[]` — ordered chain of `"continue"` and `{ type: "custom", function, variables? }`. Sequential, async-aware, terminal `"continue"`, abort on throw.
- `OnboardingProvider.customActions` — name → handler map. Handlers receive `{ variables: Record<string, ComposableVariableEntry | undefined> }` filtered to the action's `variables` list.
- Legacy `Button.action: "continue"` kept as deprecated alias.
- `ComposableVariableEntry` moved to headless (single source of truth); UI re-exports.
- Both packages bumped to v1.16.0; CHANGELOGs updated.
- Docusaurus site documents the new field, handler signature, and patterns (`customization/custom-actions.mdx`).
- Example app demos `trackCta` + `celebrate` handlers; `composable-screen` fixture exercises both new `actions` and legacy `action`.

## CMS mirror prompt

The `onboarding-studio` schema must mirror `Button.actions`:
- Add `actions` to the `Button` Zod schema (`ButtonAction = "continue" | { type: "custom"; function: string; variables?: string[] }`).
- CMS editor: ordered list editor (continue / custom) with variable multi-select for the custom variant.
- Keep reading legacy `action` for historical payloads; emit `actions` going forward.

## Test plan

- [ ] `npm run build` (root) — both packages compile clean
- [ ] `cd example && npx tsc --noEmit` — example type-checks
- [ ] `cd website && npm run build` — docs build clean
- [ ] Run example in simulator — `Get Started` button on Composable Screen logs `trackCta fired with {...}` then advances
- [ ] Outlined button (legacy `action: "continue"`) still advances
- [ ] Gradient button chains `celebrate` → `trackCta` → `continue` (logs in order)
- [ ] Unknown handler name path: temporarily emit `function: "missing"` → `console.warn` and chain proceeds
- [ ] Async throw aborts chain (continue not fired)