### PR TITLE
✨ feat: runtime font download + load (v1.17.0)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,13 @@
 {
   "enabledPlugins": {
     "expo@claude-plugins-official": true
+  },
+  "permissions": {
+    "allow": [
+      "Bash(pnpm type:check)",
+      "Bash(npm run type)",
+      "Bash(npm run type:check)",
+      "Bash(pnpm lint)"
+    ]
   }
 }

--- a/.claude/skills/composable-screen-layout-debug/SKILL.md
+++ b/.claude/skills/composable-screen-layout-debug/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: composable-screen-layout-debug
+description: Diagnose ComposableScreen UIElement layout failures (zero size, clipped content, overflow, broken flex). Use when an element renders blank, collapses, or content is cut off.
+user-invocable: true
+argument-hint: "<ElementName or symptom>"
+---
+
+Walks through the common failure modes when a ComposableScreen UIElement renders incorrectly.
+
+## Symptom checklist
+
+| Symptom | Likely cause |
+|---------|--------------|
+| Element invisible / zero height | No `flex`, no `height`, no children with intrinsic size |
+| Content clipped on edges | `overflow: hidden` (default) blocks peek/shadow |
+| Carousel/Video/Lottie 0×0 | Library got string `"50%"` width or `undefined` height |
+| Children stacked wrong | Missing `flex: 1` on intermediate wrapper, parent has no defined height |
+| Gradient invisible | `backgroundGradient` set but `expo-linear-gradient` not installed → falls back to plain `View` |
+| `alignSelf` ignored | Parent is `ZStack` (absolute children) instead of YStack/XStack |
+
+## Diagnostic order
+
+### 1. Check what `dim()` returns
+
+`dim(props.width)` passes through numbers and `"50%"` strings. Libraries expecting numeric pixels (e.g. `react-native-reanimated-carousel`) will break on strings. If the element wraps such a library, measure with `onLayout`:
+
+```tsx
+const [size, setSize] = useState<{width: number; height: number} | null>(null);
+<View style={{flex: 1}} onLayout={e => setSize(e.nativeEvent.layout)}>
+  {size && size.width > 0 && <Lib width={size.width} height={size.height} />}
+</View>
+```
+
+### 2. Check parent stack type
+
+- `YStack` — vertical, children flow top→bottom
+- `XStack` — horizontal, children flow left→right
+- `ZStack` — absolute layering, children need explicit position
+
+If element vanishes inside `ZStack`, it's likely positioned at `0,0` with no width.
+
+### 3. Check `overflow`
+
+Default for `containerStyle` is `hidden`. Carousel `left-align` carouselType requires `visible` to render the peeking next slide. Same for any element with shadows/badges spilling outside bounds.
+
+### 4. Check gradient peer dep
+
+`GradientBox` silently falls back to plain `<View>` if `expo-linear-gradient` not installed. Check `node_modules/expo-linear-gradient` exists.
+
+### 5. Check `flex` chain
+
+Flex needs unbroken chain from screen root. If one ancestor lacks `flex: 1` or fixed height, descendants collapse. Use React DevTools or temporarily add `borderWidth: 1` debugging borders.
+
+### 6. Check Zod parse passed
+
+If Zod default isn't applied, the prop will be `undefined` at render time. Confirm parsed data, not raw `step.payload`.
+
+---
+
+## Reference: `containerStyle` canonical fields
+
+```typescript
+const containerStyle = {
+  alignSelf: props.alignSelf,
+  flex: props.flex,
+  flexShrink: props.flexShrink,
+  flexGrow: props.flexGrow,
+  width: dim(props.width),
+  height: dim(props.height),
+  minWidth: props.minWidth,
+  maxWidth: props.maxWidth,
+  minHeight: props.minHeight,
+  maxHeight: props.maxHeight,
+  margin: props.margin,
+  marginHorizontal: props.marginHorizontal,
+  marginVertical: props.marginVertical,
+  padding: props.padding,
+  paddingHorizontal: props.paddingHorizontal,
+  paddingVertical: props.paddingVertical,
+  borderRadius: props.borderRadius,
+  borderWidth: props.borderWidth,
+  borderColor: props.borderColor,
+  backgroundColor: props.backgroundGradient ? undefined : props.backgroundColor,
+  opacity: props.opacity,
+  overflow: props.overflow ?? "hidden",
+};
+```
+
+If your element is missing any of these, the user can't control that aspect from CMS payload.

--- a/.claude/skills/sync-studio-schema/SKILL.md
+++ b/.claude/skills/sync-studio-schema/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: sync-studio-schema
+description: Generate the onboarding-studio schema-mirror prompt from staged/recent changes to ComposableScreen types. Use after editing UIElement schemas, e.g. "draft studio sync prompt", "what do I tell studio".
+user-invocable: true
+argument-hint: ""
+---
+
+Reads recent changes to ComposableScreen `types.ts` files and emits the prompt to paste into the `onboarding-studio` repo.
+
+## Step 1 — Detect scope of change
+
+```bash
+git diff HEAD -- \
+  packages/onboarding/src/steps/ComposableScreen/types.ts \
+  packages/onboarding-ui/src/UI/Pages/ComposableScreen/types.ts \
+  'packages/onboarding/src/steps/ComposableScreen/elements/*.ts' \
+  'packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/*.tsx'
+```
+
+If empty, also check staged + last commit:
+```bash
+git diff --cached -- packages/onboarding/src/steps/ComposableScreen/
+git show HEAD --stat
+```
+
+## Step 2 — Classify each change
+
+For each modified element file, determine:
+- **New element** — file added (`A` in diff status)
+- **Modified element** — props added/removed/renamed/retyped
+- **Deleted element** — file removed (breaking)
+
+Inspect the diff for:
+- Added Zod field → new optional/required prop
+- Removed Zod field → removed prop (breaking)
+- `.default(X)` change → behavior change
+- Renamed type literal in `z.literal("X")` → breaking rename
+
+## Step 3 — Emit prompt
+
+Format:
+
+```text
+ComposableScreen UIElement schema updated in @rocapine/react-native-onboarding.
+Mirror these changes in onboarding-studio.
+
+Summary:
+<one line per element changed — what changed>
+
+Breaking: <yes/no — list specific breaks>
+
+Files changed in SDK:
+<paste from git diff --name-only>
+
+In onboarding-studio, update:
+- UIElement discriminated union / Zod schema
+- CMS editor forms (prop inputs, type pickers)
+- Stored payload migration (if breaking)
+- Preview renderer (if visual behavior changed)
+
+Reference SDK commit / branch: <git rev-parse --short HEAD or branch>
+```
+
+## Step 4 — Offer to copy to clipboard (mac)
+
+```bash
+echo "<prompt>" | pbcopy
+```
+
+Ask user before piping — don't auto-copy.

--- a/.claude/skills/update-uielement/SKILL.md
+++ b/.claude/skills/update-uielement/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: update-uielement
+description: Update an existing UIElement type in the Rocapine Onboarding monorepo (props, schema, or renderer changes). Use when modifying an existing ComposableScreen element, e.g. "add fontSize to TextElement", "change CarouselElement props", "update RadioGroup schema".
+user-invocable: true
+argument-hint: "<ElementName> <change description>"
+---
+
+Targeted edits to an existing UIElement variant. Propagates change across both SDK packages, example payloads, and emits the studio mirror prompt.
+
+## Step 0 — Identify scope
+
+Confirm with user:
+- **Element name** (PascalCase, must match existing `type` discriminator)
+- **What changes**: prop added/removed/renamed, default changed, schema validation tweak, renderer behavior fix
+- **Breaking?** removed/renamed prop = breaking; new optional prop = non-breaking
+
+If breaking, suggest bumping minor (or major) version after.
+
+---
+
+## Step 1 — Update headless schema
+
+File: `packages/onboarding/src/steps/ComposableScreen/elements/{ElementName}Element.ts`
+
+- Update `{ElementName}ElementProps` TS type
+- Update `{ElementName}ElementPropsSchema` Zod (keep defaults consistent with TS optionals)
+- Verify `BaseBoxPropsSchema.extend({...})` still extends — don't accidentally replace base
+
+If new prop has runtime default, add `.optional().default(X)` in Zod AND keep it optional in TS type.
+
+---
+
+## Step 2 — Mirror in UI package types
+
+File: `packages/onboarding-ui/src/UI/Pages/ComposableScreen/types.ts`
+
+Both `types.ts` files must stay byte-equivalent for UIElement union + schema. Apply same edits.
+
+---
+
+## Step 3 — Update renderer
+
+File: `packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/{ElementName}Element.tsx`
+
+- Use new prop in JSX
+- Sizing-sensitive elements (Carousel, Video, Lottie, Rive): if changing width/height behavior, prefer `onLayout` measurement over raw `props.width/height`. Don't pass `"50%"` strings to libraries expecting numbers.
+- Respect `containerStyle` pattern: alignSelf, flex, flex(Shrink|Grow), width/height via `dim()`, min/max, margin*, padding*, border*, opacity, overflow, backgroundColor (only if no `backgroundGradient`).
+
+---
+
+## Step 4 — Update example payloads
+
+- `packages/onboarding/src/onboarding-example.ts` — bump example to exercise new prop
+- `example/app/example/composable-screen.tsx` — same
+
+---
+
+## Step 5 — Build & typecheck
+
+```bash
+npm run build
+cd example && npm run type
+```
+
+---
+
+## Step 6 — Notify onboarding-studio
+
+Output diff-aware prompt:
+
+```text
+ComposableScreen "{ElementName}" UIElement schema updated in React Native SDK.
+
+Change:
+<concise summary — added X, removed Y, renamed Z>
+
+Breaking: <yes/no>
+
+Files changed:
+- packages/onboarding/src/steps/ComposableScreen/elements/{ElementName}Element.ts
+- packages/onboarding/src/steps/ComposableScreen/types.ts
+- packages/onboarding-ui/src/UI/Pages/ComposableScreen/types.ts
+- packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/{ElementName}Element.tsx
+
+In onboarding-studio:
+- Update UIElement Zod schema for "{ElementName}"
+- Update CMS editor form fields
+- If breaking: write migration for stored payloads
+```
+
+---
+
+## File map summary
+
+| Action | File |
+|--------|------|
+| **MODIFY** | `packages/onboarding/src/steps/ComposableScreen/elements/{ElementName}Element.ts` |
+| **MODIFY** | `packages/onboarding/src/steps/ComposableScreen/types.ts` |
+| **MODIFY** | `packages/onboarding-ui/src/UI/Pages/ComposableScreen/types.ts` |
+| **MODIFY** | `packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/{ElementName}Element.tsx` |
+| **MODIFY** | `packages/onboarding/src/onboarding-example.ts` |
+| **MODIFY** | `example/app/example/composable-screen.tsx` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,6 +101,29 @@ Available step types (each in `UI/Pages/{Type}/`):
 - Use `useTheme()` for all colors and typography — never hardcode values
 - `onContinue` receives selected value as parameter (for types like Picker, Question)
 
+## ComposableScreen UIElement Conventions
+
+### Container style (BaseBoxProps)
+
+Every UIElement renderer that wraps content must build a `containerStyle` from `BaseBoxProps` covering: `alignSelf`, `flex`, `flexShrink`, `flexGrow`, `width` (via `dim()`), `height` (via `dim()`), `minWidth/maxWidth/minHeight/maxHeight`, `margin*`, `padding*`, `borderRadius/Width/Color`, `backgroundColor` (only if no `backgroundGradient`), `opacity`, `overflow`. Apply to outermost wrapper (`GradientBox` or `View`). Missing fields = user can't control that aspect from CMS payload.
+
+### Sizing libraries that need numeric pixels
+
+`react-native-reanimated-carousel`, `react-native-video`, Lottie/Rive components don't accept `"50%"` strings. When wrapping such a library in a UIElement:
+
+1. Pass `containerStyle` (with `dim()`) to the outermost wrapper
+2. Wrap the library in an inner `View` with `flex: 1` + `onLayout`
+3. Render the library only after first measurement (`size.width > 0 && size.height > 0`)
+4. Pass measured numeric `size.width/height` to the library
+
+### Overflow gotcha
+
+Default `overflow` is `hidden`. Carousel's `left-align` carouselType needs `visible` for the peek effect. Same for shadows/badges spilling outside bounds. Don't blanket-set `hidden` in refactors.
+
+### Gradient peer dep
+
+`GradientBox` silently falls back to plain `View` if `expo-linear-gradient` isn't installed. If `backgroundGradient` appears unrendered, check the peer dep first.
+
 ## Custom Components System
 
 `OnboardingProvider` accepts `customComponents` prop to replace UI components while keeping SDK data flow.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ npm run publish:all        # Build and publish both packages to npm
 cd example/
 npm install
 npm start             # Start Expo dev server
-npm run type          # TypeScript type checking (tsc --noEmit)
+npm run type:check    # TypeScript type checking (tsc --noEmit)
 npm run lint          # ESLint via expo lint
 npm run ios
 npm run android
@@ -39,16 +39,19 @@ npm run android
 
 **Important**: After modifying anything in `packages/`, run `npm run build` (or the relevant workspace build) before reloading the example app, since the example references local packages via `file:../packages/*`.
 
+**Workspace type resolution**: `@rocapine/react-native-onboarding` resolves to its `dist/index.d.ts` via the workspace symlink + `package.json#types`. Adding a new exported symbol in `packages/onboarding/src/` is invisible to `packages/onboarding-ui/` and `example/` `tsc` runs until the headless package is built (or `npm run watch:headless` is running). Build before typechecking after adding exports.
+
 ## Architecture
 
 ### Two-Package Split
 
 **Headless SDK** (`packages/onboarding/src/`):
 - `OnboardingStudioClient.ts` — API client that fetches steps from Supabase backend. URL params: `projectId`, `platform`, `appVersion`, `locale`, `draft`. Returns step data + custom headers (`ONBS-Onboarding-Id`, `ONBS-Audience-Id`, `ONBS-Onboarding-Name`).
-- `infra/provider/` — `OnboardingProvider`: wraps app with `QueryClientProvider` + `ThemeProvider`, manages caching via AsyncStorage, and **automatically includes ProgressBar**
+- `infra/provider/` — `OnboardingProvider`: wraps app with `QueryClientProvider` + `ThemeProvider`, manages caching via AsyncStorage, and **automatically includes ProgressBar**. The internal `OnboardingDataGate` reads `useQuery({ data, error })` and **throws `error`** so a host `ErrorBoundary` catches network/parse failures — never swallow the error and fall through to `fontsFallback`.
 - `infra/hooks/useOnboardingQuestions.ts` — Hook returning `{ step, isLastStep, stepsLength, onboardingMetadata, steps }`. Uses `useSuspenseQuery`; manages progress context automatically.
+- `infra/fonts/` — Runtime font registry (see "Runtime Fonts" section).
 - `steps/` — Zod schemas and TypeScript types for each step variant (source of truth for data shapes)
-- `types.ts` — Core types; `index.ts` — public exports
+- `types.ts` — Core types; `index.ts` — public exports. **CHANGELOG entries describing union/enum members are illustrative** — when in doubt, check the actual exported type (e.g. `FontWeightKey`) for the canonical set.
 
 **UI Package** (`packages/onboarding-ui/src/`):
 - `UI/OnboardingPage.tsx` — Central router: switch on `step.type` → delegates to specific Renderer
@@ -123,6 +126,29 @@ Default `overflow` is `hidden`. Carousel's `left-align` carouselType needs `visi
 ### Gradient peer dep
 
 `GradientBox` silently falls back to plain `View` if `expo-linear-gradient` isn't installed. If `backgroundGradient` appears unrendered, check the peer dep first.
+
+## Runtime Fonts
+
+The `Onboarding` response carries an optional `fonts?: FontsManifest` field — `Record<family, Partial<Record<FontWeightKey, url>>>`. Files are downloaded and registered via `expo-font` (optional peer) by `FontLoaderGate`, which mounts a `FontRegistryContext`.
+
+### `FontLoaderGate` state convention
+
+- `registry === null` is the **loading sentinel** — gate renders `fallback`.
+- `registry === {}` is **ready, no fonts** — gate renders children.
+- Async registration must `setRegistry(null)` before the call and `.catch(() => setRegistry({}))` so a fetch failure doesn't strand the gate.
+
+### Hook choice rule (Text-rendering elements)
+
+For any UIElement that renders `<Text>` or `<TextInput>` and accepts `fontWeight`:
+
+```ts
+const f = useResolvedFontStyle(props.fontFamily, props.fontWeight);
+// style: { fontFamily: f.fontFamily, fontWeight: f.resolvedToVariant ? undefined : (props.fontWeight as any) ?? <theme default> }
+```
+
+When `f.resolvedToVariant === true`, the registry matched a concrete weighted variant (e.g. `Inter-700`) — **suppress `fontWeight`**, otherwise iOS/Android will apply synthetic emboldening on top of an already-weighted font file.
+
+Use the legacy `useResolvedFontFamily` only for elements that never set `fontWeight`.
 
 ## Custom Components System
 

--- a/example/app/_layout.tsx
+++ b/example/app/_layout.tsx
@@ -8,6 +8,7 @@ import { useFonts } from "expo-font";
 import * as SplashScreen from "expo-splash-screen";
 import { useEffect } from "react";
 import { OnboardingProgressProvider } from "@rocapine/react-native-onboarding-ui";
+import { Dimensions } from "react-native";
 
 // Keep splash screen visible while fonts load
 SplashScreen.preventAutoHideAsync();

--- a/example/app/example/composable-screen-fonts.tsx
+++ b/example/app/example/composable-screen-fonts.tsx
@@ -1,0 +1,189 @@
+import { ActivityIndicator, Pressable, StyleSheet, Text, View } from 'react-native';
+import { useRouter } from 'expo-router';
+import { FontLoaderGate, type FontsManifest } from '@rocapine/react-native-onboarding';
+import * as OnboardingUi from '@rocapine/react-native-onboarding-ui';
+
+export const unstable_settings = {
+  anchor: '(tabs)',
+};
+
+const fonts: FontsManifest = {
+  Inter: {
+    regular: 'https://cdn.jsdelivr.net/fontsource/fonts/inter@latest/latin-400-normal.ttf',
+    medium: 'https://cdn.jsdelivr.net/fontsource/fonts/inter@latest/latin-500-normal.ttf',
+    bold: 'https://cdn.jsdelivr.net/fontsource/fonts/inter@latest/latin-700-normal.ttf',
+  },
+  Lobster: {
+    regular: 'https://cdn.jsdelivr.net/fontsource/fonts/lobster@latest/latin-400-normal.ttf',
+  },
+};
+
+export default function ComposableScreenFontsExample() {
+  const router = useRouter();
+
+  const step = {
+    id: 'composable-screen-fonts',
+    type: 'ComposableScreen',
+    name: 'Runtime Fonts',
+    displayProgressHeader: false,
+    payload: {
+      elements: [
+        {
+          id: 'safe-root',
+          type: 'SafeAreaView' as const,
+          props: { flex: 1, edges: ['top', 'bottom'] as ('top' | 'right' | 'bottom' | 'left')[] },
+          children: [
+            {
+              id: 'root',
+              type: 'YStack' as const,
+              props: { gap: 20, padding: 24, flex: 1, justifyContent: 'center' as const },
+              children: [
+                {
+                  id: 'display',
+                  type: 'Text' as const,
+                  props: {
+                    content: 'Lobster',
+                    fontFamily: 'Lobster',
+                    fontSize: 56,
+                    textAlign: 'center' as const,
+                  },
+                },
+                {
+                  id: 'caption',
+                  type: 'Text' as const,
+                  props: {
+                    content: 'Downloaded at runtime via expo-font',
+                    fontFamily: 'Inter',
+                    fontWeight: '400',
+                    fontSize: 14,
+                    textAlign: 'center' as const,
+                    opacity: 0.6,
+                  },
+                },
+                {
+                  id: 'divider',
+                  type: 'YStack' as const,
+                  props: { height: 24 },
+                  children: [],
+                },
+                {
+                  id: 'inter-regular',
+                  type: 'Text' as const,
+                  props: {
+                    content: 'Inter Regular (400) — quick brown fox',
+                    fontFamily: 'Inter',
+                    fontWeight: '400',
+                    fontSize: 18,
+                    textAlign: 'center' as const,
+                  },
+                },
+                {
+                  id: 'inter-medium',
+                  type: 'Text' as const,
+                  props: {
+                    content: 'Inter Medium (500) — quick brown fox',
+                    fontFamily: 'Inter',
+                    fontWeight: '500',
+                    fontSize: 18,
+                    textAlign: 'center' as const,
+                  },
+                },
+                {
+                  id: 'inter-bold',
+                  type: 'Text' as const,
+                  props: {
+                    content: 'Inter Bold (700) — quick brown fox',
+                    fontFamily: 'Inter',
+                    fontWeight: '700',
+                    fontSize: 18,
+                    textAlign: 'center' as const,
+                  },
+                },
+                {
+                  id: 'inter-fallback',
+                  type: 'Text' as const,
+                  props: {
+                    content: 'Inter Light (300) — falls back to Regular (closest weight)',
+                    fontFamily: 'Inter',
+                    fontWeight: '300',
+                    fontSize: 14,
+                    textAlign: 'center' as const,
+                    opacity: 0.6,
+                  },
+                },
+                {
+                  id: 'cta',
+                  type: 'Button' as const,
+                  props: {
+                    label: 'Done',
+                    actions: ['continue' as const],
+                    fontFamily: 'Inter',
+                    fontWeight: '700',
+                    marginVertical: 24,
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    customPayload: null,
+    continueButtonLabel: 'Done',
+    figmaUrl: null,
+  } satisfies OnboardingUi.ComposableScreenStepType;
+
+  return (
+    <View style={{ flex: 1 }}>
+      <FontLoaderGate fonts={fonts} fallback={<LoadingFallback />}>
+        <OnboardingUi.ComposableScreenRenderer step={step} onContinue={() => router.back()} />
+      </FontLoaderGate>
+      <Pressable style={styles.backButton} onPress={() => router.back()}>
+        <Text style={styles.backButtonText}>‹</Text>
+      </Pressable>
+    </View>
+  );
+}
+
+const LoadingFallback = () => (
+  <View style={styles.loading}>
+    <ActivityIndicator size="large" />
+    <Text style={styles.loadingText}>Downloading fonts…</Text>
+  </View>
+);
+
+const styles = StyleSheet.create({
+  loading: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 12,
+  },
+  loadingText: {
+    fontSize: 14,
+    color: '#666',
+  },
+  backButton: {
+    position: 'absolute',
+    top: 50,
+    left: 20,
+    width: 32,
+    height: 32,
+    backgroundColor: 'rgba(255, 255, 255, 0.9)',
+    borderRadius: 16,
+    alignItems: 'center',
+    justifyContent: 'center',
+    zIndex: 1000,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.1,
+    shadowRadius: 4,
+    elevation: 3,
+  },
+  backButtonText: {
+    color: '#007AFF',
+    fontSize: 32,
+    fontWeight: '400',
+    lineHeight: 32,
+  },
+});

--- a/example/app/example/composable-screen.tsx
+++ b/example/app/example/composable-screen.tsx
@@ -129,6 +129,7 @@ export default function ComposableScreenExample() {
               props: {
                 content: 'This screen is composed entirely from a JSON payload — no custom renderer needed.',
                 fontSize: 15,
+                fontStyle: 'italic',
                 textAlign: 'center',
                 lineHeight: 22,
                 opacity: 0.6,

--- a/example/app/example/index.tsx
+++ b/example/app/example/index.tsx
@@ -24,6 +24,7 @@ const examples: Example[] = [
       { name: "Carousel", route: "/example/composable-screen-carousel" },
       { name: "Button", route: "/example/composable-screen-button" },
       { name: "ZStack", route: "/example/composable-screen-zstack" },
+      { name: "Runtime Fonts", route: "/example/composable-screen-fonts" },
       { name: "All", route: "/example/composable-screen" },
     ],
   },

--- a/packages/onboarding-ui/CHANGELOG.md
+++ b/packages/onboarding-ui/CHANGELOG.md
@@ -5,6 +5,40 @@ here.
 
 ---
 
+## [Unreleased]
+
+### Added
+
+- **`fontStyle` rendering** on `TextElement`, `ButtonElement`,
+  `InputElement` (top-level), and `RadioGroupElement` /
+  `CheckboxGroupElement` (`itemFontStyle`). Renderers pass the value through
+  to the underlying `<Text>` / `<TextInput>` style, alongside `fontFamily` and
+  `fontWeight`.
+
+### Changed
+
+- **`Button`/`Text`/`Input` font weight resolution** — switched from
+  `useResolvedFontFamily` to `useResolvedFontStyle` from
+  `@rocapine/react-native-onboarding`. When the registry matches a concrete
+  weighted variant (e.g. `Inter-700`), `fontWeight` is suppressed on the
+  rendered `<Text>` to avoid synthetic emboldening on top of an
+  already-weighted font file.
+
+### Fixed
+
+- **`CarouselElement` sizing** — wrap the carousel in an inner
+  `View flex:1` with `onLayout` and pass measured `width`/`height` to
+  `react-native-reanimated-carousel` instead of `Dimensions.get("window")`.
+  Render is gated until first measurement.
+- **`OnboardingDataGate` error handling** — `useQuery` errors are now thrown
+  so a host `ErrorBoundary` catches them, instead of silently rendering the
+  `fontsFallback` forever.
+- **`FontLoaderGate`** — resets registry to a loading sentinel before async
+  registration and falls back to an empty registry on rejection so a fetch
+  failure doesn't strand the gate.
+
+---
+
 ## [1.17.0] - 2026-04-30
 
 ### Changed

--- a/packages/onboarding-ui/CHANGELOG.md
+++ b/packages/onboarding-ui/CHANGELOG.md
@@ -5,6 +5,29 @@ here.
 
 ---
 
+## [1.17.0] - 2026-04-30
+
+### Changed
+
+- **ComposableScreen typography elements use the runtime font registry** —
+  `TextElement`, `ButtonElement`, and `InputElement` now call
+  `useResolvedFontFamily(fontFamily, fontWeight)` from
+  `@rocapine/react-native-onboarding` to resolve a `family + weight` request
+  to the runtime-registered font variant. CMS authors continue to set
+  `fontFamily` to the family name declared in the `Onboarding.fonts` manifest;
+  the SDK picks the right registered variant (e.g. `Inter` + `500` →
+  `Inter-500`) and falls back to the closest registered weight when an exact
+  match is unavailable.
+
+> Element Zod schemas are unchanged. No CMS migration required for existing
+> payloads — they keep working with system fonts.
+
+### Bumped
+
+- Peer dependency on `@rocapine/react-native-onboarding` is now `^1.17.0`.
+
+---
+
 ## [1.16.0] - 2026-04-29
 
 ### Added

--- a/packages/onboarding-ui/package.json
+++ b/packages/onboarding-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocapine/react-native-onboarding-ui",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "description": "UI components and renderers for Rocapine Onboarding Studio - Built on top of the headless SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -46,7 +46,7 @@
   "peerDependencies": {
     "@react-native-community/datetimepicker": "*",
     "@react-native-picker/picker": "*",
-    "@rocapine/react-native-onboarding": "^1.16.0",
+    "@rocapine/react-native-onboarding": "^1.17.0",
     "@shopify/react-native-skia": ">=1.0.0",
     "@tanstack/react-query": ">=5.0.0",
     "@types/react": "*",

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/ButtonElement.tsx
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/ButtonElement.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { z } from "zod";
 import { Text, TouchableOpacity } from "react-native";
+import { useResolvedFontFamily } from "@rocapine/react-native-onboarding";
 import { BaseBoxProps, BaseBoxPropsSchema } from "./BaseBoxProps";
 import { UIElement } from "../types";
 import { RenderContext, dim } from "./shared";
@@ -109,6 +110,10 @@ export const ButtonElementComponent = ({ element, ctx }: Props): React.ReactElem
 
   const hasGradient = isFilled && !!element.props.backgroundGradient;
   const borderRadius = element.props.borderRadius ?? 90;
+  const resolvedFontFamily = useResolvedFontFamily(
+    element.props.fontFamily,
+    element.props.fontWeight
+  );
 
   const labelNode = (
     <Text
@@ -116,7 +121,7 @@ export const ButtonElementComponent = ({ element, ctx }: Props): React.ReactElem
         color: textColor,
         fontSize: element.props.fontSize ?? theme.typography.textStyles.button.fontSize,
         fontWeight: (element.props.fontWeight as any) ?? theme.typography.textStyles.button.fontWeight,
-        fontFamily: element.props.fontFamily,
+        fontFamily: resolvedFontFamily,
         textAlign: element.props.textAlign ?? "center",
       }}
     >

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/ButtonElement.tsx
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/ButtonElement.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { z } from "zod";
 import { Text, TouchableOpacity } from "react-native";
-import { useResolvedFontFamily } from "@rocapine/react-native-onboarding";
+import { useResolvedFontStyle } from "@rocapine/react-native-onboarding";
 import { BaseBoxProps, BaseBoxPropsSchema } from "./BaseBoxProps";
 import { UIElement } from "../types";
 import { RenderContext, dim } from "./shared";
@@ -110,7 +110,7 @@ export const ButtonElementComponent = ({ element, ctx }: Props): React.ReactElem
 
   const hasGradient = isFilled && !!element.props.backgroundGradient;
   const borderRadius = element.props.borderRadius ?? 90;
-  const resolvedFontFamily = useResolvedFontFamily(
+  const resolvedFont = useResolvedFontStyle(
     element.props.fontFamily,
     element.props.fontWeight
   );
@@ -120,8 +120,10 @@ export const ButtonElementComponent = ({ element, ctx }: Props): React.ReactElem
       style={{
         color: textColor,
         fontSize: element.props.fontSize ?? theme.typography.textStyles.button.fontSize,
-        fontWeight: (element.props.fontWeight as any) ?? theme.typography.textStyles.button.fontWeight,
-        fontFamily: resolvedFontFamily,
+        fontWeight: resolvedFont.resolvedToVariant
+          ? undefined
+          : ((resolvedFont.fontWeight as any) ?? theme.typography.textStyles.button.fontWeight),
+        fontFamily: resolvedFont.fontFamily,
         textAlign: element.props.textAlign ?? "center",
       }}
     >

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/ButtonElement.tsx
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/ButtonElement.tsx
@@ -42,6 +42,7 @@ export type ButtonElementProps = BaseBoxProps & {
   fontSize?: number;
   fontWeight?: string;
   fontFamily?: string;
+  fontStyle?: "normal" | "italic";
   textAlign?: "left" | "center" | "right";
 };
 
@@ -55,6 +56,7 @@ export const ButtonElementPropsSchema = BaseBoxPropsSchema.extend({
   fontSize: z.number().optional(),
   fontWeight: z.string().optional(),
   fontFamily: z.string().optional(),
+  fontStyle: z.enum(["normal", "italic"]).optional(),
   textAlign: z.enum(["left", "center", "right"]).optional(),
 });
 
@@ -124,6 +126,7 @@ export const ButtonElementComponent = ({ element, ctx }: Props): React.ReactElem
           ? undefined
           : ((resolvedFont.fontWeight as any) ?? theme.typography.textStyles.button.fontWeight),
         fontFamily: resolvedFont.fontFamily,
+        fontStyle: element.props.fontStyle,
         textAlign: element.props.textAlign ?? "center",
       }}
     >

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/CarouselElement.tsx
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/CarouselElement.tsx
@@ -1,5 +1,5 @@
-import React, { useRef } from "react";
-import { useWindowDimensions } from "react-native";
+import React, { useRef, useState } from "react";
+import { Dimensions, View, type LayoutChangeEvent } from "react-native";
 import { z } from "zod";
 import { useSharedValue } from "react-native-reanimated";
 import Carousel, { Pagination, ICarouselInstance } from "react-native-reanimated-carousel";
@@ -46,20 +46,27 @@ type Props = {
 export function CarouselElementComponent({ element, ctx }: Props): React.ReactElement {
   const { theme } = ctx;
   const { props, children } = element;
-  const { width: windowWidth } = useWindowDimensions();
   const progress = useSharedValue<number>(0);
   const ref = useRef<ICarouselInstance>(null);
+  const [size, setSize] = useState<{ width: number; height: number } | null>(null);
 
   const carouselType = props.carouselType ?? "normal";
 
+  const onLayout = (e: LayoutChangeEvent) => {
+    const { width, height } = e.nativeEvent.layout;
+    if (!size || size.width !== width || size.height !== height) {
+      setSize({ width, height });
+    }
+  };
+
   // Stack uses 75% width (shows side items); left-align uses 82% (peek effect)
+  const availableWidth = size?.width ?? 0;
   const itemWidth =
     carouselType === "stack"
-      ? windowWidth * 0.75
+      ? availableWidth * 0.75
       : carouselType === "left-align"
-        ? windowWidth * 0.82
-        : (typeof props.width === "number" ? props.width : windowWidth);
-  const itemHeight = typeof props.height === "number" ? props.height : 220;
+        ? availableWidth * 0.82
+        : availableWidth;
 
   const containerStyle = {
     alignSelf: props.alignSelf,
@@ -67,6 +74,7 @@ export function CarouselElementComponent({ element, ctx }: Props): React.ReactEl
     flexShrink: props.flexShrink,
     flexGrow: props.flexGrow,
     width: dim(props.width),
+    height: dim(props.height),
     minWidth: props.minWidth,
     maxWidth: props.maxWidth,
     minHeight: props.minHeight,
@@ -106,10 +114,10 @@ export function CarouselElementComponent({ element, ctx }: Props): React.ReactEl
   const dotsMarginTop = props.dotsMarginTop ?? 12;
   const dotBg = props.dotColor ?? theme.colors.neutral.low;
   const activeDotBg = props.activeDotColor ?? theme.colors.primary;
-  console.log(props.autoPlay, props.autoPlayInterval);
-  console.log(element);
+  console.log(Dimensions.get("window"));
+
   return (
-    <GradientBox gradient={props.backgroundGradient} style={containerStyle as any}>
+    <GradientBox gradient={props.backgroundGradient} style={containerStyle}>
       <Carousel
         ref={ref}
         loop={props.loop}
@@ -118,9 +126,9 @@ export function CarouselElementComponent({ element, ctx }: Props): React.ReactEl
         snapEnabled={true}
         pagingEnabled={true}
         data={children}
-        width={itemWidth}
-        height={itemHeight}
-        style={{ width: itemWidth, height: itemHeight }}
+        width={Dimensions.get("window").width}
+        height={props.height}
+        style={{ height: "100%", width: "100%" }}
         renderItem={({ item }: { item: UIElement }) => ctx.renderChildren([item], "YStack")}
         onProgressChange={(_: number, absoluteProgress: number) => {
           progress.value = absoluteProgress;

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/CarouselElement.tsx
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/CarouselElement.tsx
@@ -38,6 +38,8 @@ export const CarouselElementPropsSchema = BaseBoxPropsSchema.extend({
 
 type CarouselUIElement = Extract<UIElement, { type: "Carousel" }>;
 
+const DEFAULT_HEIGHT = 240;
+
 type Props = {
   element: CarouselUIElement;
   ctx: RenderContext;
@@ -68,13 +70,17 @@ export function CarouselElementComponent({ element, ctx }: Props): React.ReactEl
         ? availableWidth * 0.82
         : availableWidth;
 
+  const hasExplicitSize =
+    props.height != null || props.flex != null || props.flexGrow != null;
+  const heightFallback = hasExplicitSize ? undefined : DEFAULT_HEIGHT;
+
   const containerStyle = {
     alignSelf: props.alignSelf,
     flex: props.flex,
     flexShrink: props.flexShrink,
     flexGrow: props.flexGrow,
     width: dim(props.width),
-    height: dim(props.height),
+    height: dim(props.height) ?? heightFallback,
     minWidth: props.minWidth,
     maxWidth: props.maxWidth,
     minHeight: props.minHeight,

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/CarouselElement.tsx
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/CarouselElement.tsx
@@ -1,5 +1,5 @@
 import React, { useRef, useState } from "react";
-import { Dimensions, View, type LayoutChangeEvent } from "react-native";
+import { View, type LayoutChangeEvent } from "react-native";
 import { z } from "zod";
 import { useSharedValue } from "react-native-reanimated";
 import Carousel, { Pagination, ICarouselInstance } from "react-native-reanimated-carousel";
@@ -114,27 +114,32 @@ export function CarouselElementComponent({ element, ctx }: Props): React.ReactEl
   const dotsMarginTop = props.dotsMarginTop ?? 12;
   const dotBg = props.dotColor ?? theme.colors.neutral.low;
   const activeDotBg = props.activeDotColor ?? theme.colors.primary;
-  console.log(Dimensions.get("window"));
+
+  const ready = !!size && size.width > 0 && size.height > 0;
 
   return (
     <GradientBox gradient={props.backgroundGradient} style={containerStyle}>
-      <Carousel
-        ref={ref}
-        loop={props.loop}
-        autoPlay={props.autoPlay}
-        autoPlayInterval={props.autoPlayInterval}
-        snapEnabled={true}
-        pagingEnabled={true}
-        data={children}
-        width={Dimensions.get("window").width}
-        height={props.height}
-        style={{ height: "100%", width: "100%" }}
-        renderItem={({ item }: { item: UIElement }) => ctx.renderChildren([item], "YStack")}
-        onProgressChange={(_: number, absoluteProgress: number) => {
-          progress.value = absoluteProgress;
-        }}
-        {...(modeProps as any)}
-      />
+      <View style={{ flex: 1 }} onLayout={onLayout}>
+        {ready && (
+          <Carousel
+            ref={ref}
+            loop={props.loop}
+            autoPlay={props.autoPlay}
+            autoPlayInterval={props.autoPlayInterval}
+            snapEnabled={true}
+            pagingEnabled={true}
+            data={children}
+            width={itemWidth}
+            height={size!.height}
+            style={{ width: size!.width, height: size!.height }}
+            renderItem={({ item }: { item: UIElement }) => ctx.renderChildren([item], "YStack")}
+            onProgressChange={(_: number, absoluteProgress: number) => {
+              progress.value = absoluteProgress;
+            }}
+            {...(modeProps as any)}
+          />
+        )}
+      </View>
       {(props.showDots ?? true) && (
         <Pagination.Basic
           progress={progress}

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/CheckboxGroupElement.tsx
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/CheckboxGroupElement.tsx
@@ -23,6 +23,7 @@ export type CheckboxGroupElementProps = BaseBoxProps & {
   itemFontSize?: number;
   itemFontWeight?: string;
   itemFontFamily?: string;
+  itemFontStyle?: "normal" | "italic";
   itemPadding?: number;
   itemPaddingHorizontal?: number;
   itemPaddingVertical?: number;
@@ -45,6 +46,7 @@ export const CheckboxGroupElementPropsSchema = BaseBoxPropsSchema.extend({
   itemFontSize: z.number().optional(),
   itemFontWeight: z.string().optional(),
   itemFontFamily: z.string().optional(),
+  itemFontStyle: z.enum(["normal", "italic"]).optional(),
   itemPadding: z.number().optional(),
   itemPaddingHorizontal: z.number().optional(),
   itemPaddingVertical: z.number().optional(),
@@ -190,6 +192,7 @@ export const CheckboxGroupComponent = ({ element, ctx }: Props): React.ReactElem
                 fontSize: element.props.itemFontSize ?? theme.typography.textStyles.body.fontSize,
                 fontWeight: (element.props.itemFontWeight as any) ?? theme.typography.textStyles.body.fontWeight,
                 fontFamily: element.props.itemFontFamily,
+                fontStyle: element.props.itemFontStyle,
               }}
             >
               {item.label}

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/InputElement.tsx
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/InputElement.tsx
@@ -23,6 +23,7 @@ export type InputElementProps = BaseBoxProps & {
   fontSize?: number;
   fontWeight?: string;
   fontFamily?: string;
+  fontStyle?: "normal" | "italic";
   lineHeight?: number;
   letterSpacing?: number;
   textAlign?: "left" | "center" | "right";
@@ -46,6 +47,7 @@ export const InputElementPropsSchema = BaseBoxPropsSchema.extend({
   fontSize: z.number().optional(),
   fontWeight: z.string().optional(),
   fontFamily: z.string().optional(),
+  fontStyle: z.enum(["normal", "italic"]).optional(),
   lineHeight: z.number().optional(),
   letterSpacing: z.number().optional(),
   textAlign: z.enum(["left", "center", "right"]).optional(),
@@ -120,6 +122,7 @@ export const InputElementComponent = ({ element, ctx }: Props): React.ReactEleme
         fontSize: element.props.fontSize ?? theme.typography.textStyles.body.fontSize,
         fontWeight: resolvedFont.resolvedToVariant ? undefined : (element.props.fontWeight as any),
         fontFamily: resolvedFont.fontFamily,
+        fontStyle: element.props.fontStyle,
         lineHeight: element.props.lineHeight,
         letterSpacing: element.props.letterSpacing,
         textAlign: element.props.textAlign,

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/InputElement.tsx
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/InputElement.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from "react";
 import { z } from "zod";
 import { View, TextInput } from "react-native";
-import { useResolvedFontFamily } from "@rocapine/react-native-onboarding";
+import { useResolvedFontStyle } from "@rocapine/react-native-onboarding";
 import { BaseBoxProps, BaseBoxPropsSchema } from "./BaseBoxProps";
 import { UIElement } from "../types";
 import { RenderContext, dim } from "./shared";
@@ -77,7 +77,7 @@ export const InputElementComponent = ({ element, ctx }: Props): React.ReactEleme
     }
   };
 
-  const resolvedFontFamily = useResolvedFontFamily(
+  const resolvedFont = useResolvedFontStyle(
     element.props.fontFamily,
     element.props.fontWeight
   );
@@ -118,8 +118,8 @@ export const InputElementComponent = ({ element, ctx }: Props): React.ReactEleme
         borderColor: element.props.borderColor ?? theme.colors.neutral.low,
         color: element.props.color ?? theme.colors.text.primary,
         fontSize: element.props.fontSize ?? theme.typography.textStyles.body.fontSize,
-        fontWeight: element.props.fontWeight as any,
-        fontFamily: resolvedFontFamily,
+        fontWeight: resolvedFont.resolvedToVariant ? undefined : (element.props.fontWeight as any),
+        fontFamily: resolvedFont.fontFamily,
         lineHeight: element.props.lineHeight,
         letterSpacing: element.props.letterSpacing,
         textAlign: element.props.textAlign,

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/InputElement.tsx
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/InputElement.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from "react";
 import { z } from "zod";
 import { View, TextInput } from "react-native";
+import { useResolvedFontFamily } from "@rocapine/react-native-onboarding";
 import { BaseBoxProps, BaseBoxPropsSchema } from "./BaseBoxProps";
 import { UIElement } from "../types";
 import { RenderContext, dim } from "./shared";
@@ -76,6 +77,11 @@ export const InputElementComponent = ({ element, ctx }: Props): React.ReactEleme
     }
   };
 
+  const resolvedFontFamily = useResolvedFontFamily(
+    element.props.fontFamily,
+    element.props.fontWeight
+  );
+
   return (
     <TextInput
       value={value}
@@ -113,7 +119,7 @@ export const InputElementComponent = ({ element, ctx }: Props): React.ReactEleme
         color: element.props.color ?? theme.colors.text.primary,
         fontSize: element.props.fontSize ?? theme.typography.textStyles.body.fontSize,
         fontWeight: element.props.fontWeight as any,
-        fontFamily: element.props.fontFamily,
+        fontFamily: resolvedFontFamily,
         lineHeight: element.props.lineHeight,
         letterSpacing: element.props.letterSpacing,
         textAlign: element.props.textAlign,

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/RadioGroupElement.tsx
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/RadioGroupElement.tsx
@@ -23,6 +23,7 @@ export type RadioGroupElementProps = BaseBoxProps & {
   itemFontSize?: number;
   itemFontWeight?: string;
   itemFontFamily?: string;
+  itemFontStyle?: "normal" | "italic";
   itemPadding?: number;
   itemPaddingHorizontal?: number;
   itemPaddingVertical?: number;
@@ -45,6 +46,7 @@ export const RadioGroupElementPropsSchema = BaseBoxPropsSchema.extend({
   itemFontSize: z.number().optional(),
   itemFontWeight: z.string().optional(),
   itemFontFamily: z.string().optional(),
+  itemFontStyle: z.enum(["normal", "italic"]).optional(),
   itemPadding: z.number().optional(),
   itemPaddingHorizontal: z.number().optional(),
   itemPaddingVertical: z.number().optional(),
@@ -172,6 +174,7 @@ export const RadioGroupComponent = ({ element, ctx }: Props): React.ReactElement
                 fontSize: element.props.itemFontSize ?? theme.typography.textStyles.body.fontSize,
                 fontWeight: (element.props.itemFontWeight as any) ?? theme.typography.textStyles.body.fontWeight,
                 fontFamily: element.props.itemFontFamily,
+                fontStyle: element.props.itemFontStyle,
               }}
             >
               {item.label}

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/TextElement.tsx
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/TextElement.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { z } from "zod";
 import { Text } from "react-native";
+import { useResolvedFontFamily } from "@rocapine/react-native-onboarding";
 import { BaseBoxProps, BaseBoxPropsSchema } from "./BaseBoxProps";
 import { UIElement } from "../types";
 import { RenderContext, interpolate, dim } from "./shared";
@@ -45,6 +46,7 @@ export const TextElementComponent = ({ element, ctx, parentType }: Props): React
     p.mode === "expression"
       ? interpolate(p.content, variables)
       : p.content;
+  const resolvedFontFamily = useResolvedFontFamily(p.fontFamily, p.fontWeight);
 
   const textNode = (
     <Text
@@ -61,7 +63,7 @@ export const TextElementComponent = ({ element, ctx, parentType }: Props): React
         maxHeight: p.backgroundGradient ? undefined : p.maxHeight,
         fontSize: p.fontSize,
         fontWeight: p.fontWeight as any,
-        fontFamily: p.fontFamily,
+        fontFamily: resolvedFontFamily,
         color: p.color ?? theme.colors.text.primary,
         textAlign: p.textAlign,
         letterSpacing: p.letterSpacing,

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/TextElement.tsx
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/TextElement.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { z } from "zod";
 import { Text } from "react-native";
-import { useResolvedFontFamily } from "@rocapine/react-native-onboarding";
+import { useResolvedFontStyle } from "@rocapine/react-native-onboarding";
 import { BaseBoxProps, BaseBoxPropsSchema } from "./BaseBoxProps";
 import { UIElement } from "../types";
 import { RenderContext, interpolate, dim } from "./shared";
@@ -46,7 +46,7 @@ export const TextElementComponent = ({ element, ctx, parentType }: Props): React
     p.mode === "expression"
       ? interpolate(p.content, variables)
       : p.content;
-  const resolvedFontFamily = useResolvedFontFamily(p.fontFamily, p.fontWeight);
+  const resolvedFont = useResolvedFontStyle(p.fontFamily, p.fontWeight);
 
   const textNode = (
     <Text
@@ -62,8 +62,8 @@ export const TextElementComponent = ({ element, ctx, parentType }: Props): React
         minHeight: p.backgroundGradient ? undefined : p.minHeight,
         maxHeight: p.backgroundGradient ? undefined : p.maxHeight,
         fontSize: p.fontSize,
-        fontWeight: p.fontWeight as any,
-        fontFamily: resolvedFontFamily,
+        fontWeight: resolvedFont.resolvedToVariant ? undefined : (p.fontWeight as any),
+        fontFamily: resolvedFont.fontFamily,
         color: p.color ?? theme.colors.text.primary,
         textAlign: p.textAlign,
         letterSpacing: p.letterSpacing,

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/TextElement.tsx
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/TextElement.tsx
@@ -13,6 +13,7 @@ export type TextElementProps = BaseBoxProps & {
   fontSize?: number;
   fontWeight?: string;
   fontFamily?: string;
+  fontStyle?: "normal" | "italic";
   color?: string;
   textAlign?: "left" | "center" | "right";
   letterSpacing?: number;
@@ -25,6 +26,7 @@ export const TextElementPropsSchema = BaseBoxPropsSchema.extend({
   fontSize: z.number().optional(),
   fontWeight: z.string().optional(),
   fontFamily: z.string().optional(),
+  fontStyle: z.enum(["normal", "italic"]).optional(),
   color: z.string().optional(),
   textAlign: z.enum(["left", "center", "right"]).optional(),
   letterSpacing: z.number().optional(),
@@ -64,6 +66,7 @@ export const TextElementComponent = ({ element, ctx, parentType }: Props): React
         fontSize: p.fontSize,
         fontWeight: resolvedFont.resolvedToVariant ? undefined : (p.fontWeight as any),
         fontFamily: resolvedFont.fontFamily,
+        fontStyle: p.fontStyle,
         color: p.color ?? theme.colors.text.primary,
         textAlign: p.textAlign,
         letterSpacing: p.letterSpacing,

--- a/packages/onboarding/CHANGELOG.md
+++ b/packages/onboarding/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to `@rocapine/react-native-onboarding` are documented here.
 
 ---
 
+## [Unreleased]
+
+### Added
+
+- **`fontStyle: "normal" | "italic"`** on Text-rendering ComposableScreen
+  UIElements. Top-level prop on `TextElementProps`, `ButtonElementProps`,
+  `InputElementProps`. Per-item prop `itemFontStyle` on
+  `RadioGroupElementProps` and `CheckboxGroupElementProps`. All optional;
+  Zod-validated as `z.enum(["normal", "italic"]).optional()`.
+
+> **Backend note:** The `onboarding-studio` server must mirror the new
+> `fontStyle` (and `itemFontStyle` for RadioGroup/CheckboxGroup) field on the
+> affected UIElement schemas and expose it in the CMS editor wherever
+> `fontWeight`/`fontFamily` are configurable.
+
+---
+
 ## [1.17.0] - 2026-04-30
 
 ### Added

--- a/packages/onboarding/CHANGELOG.md
+++ b/packages/onboarding/CHANGELOG.md
@@ -4,6 +4,44 @@ All notable changes to `@rocapine/react-native-onboarding` are documented here.
 
 ---
 
+## [1.17.0] - 2026-04-30
+
+### Added
+
+- **Runtime font download + load** — `Onboarding` response now accepts an
+  optional top-level `fonts?: FontsManifest` field, where
+  `FontsManifest = Record<string, Partial<Record<FontWeightKey, string>>>`.
+  Font files are downloaded and registered via `expo-font` (optional peer
+  dependency) when the onboarding payload is fetched. `FontWeightKey` accepts
+  named (`regular`, `medium`, `semibold`, `bold`, `extrabold`) or numeric
+  (`100`…`900`) keys, normalized internally.
+- **`OnboardingProvider.fontsFallback?: ReactNode`** — rendered while the
+  onboarding payload is fetched and remote fonts are downloading. Defaults to
+  `null`.
+- **`<FontLoaderGate fonts={...} fallback={...}>`** — standalone gate component
+  that registers fonts and exposes a `FontRegistry` via context, for hosts that
+  do not use `OnboardingProvider`.
+- **`useFontRegistry()`** and **`useResolvedFontFamily(family, weight)`** hooks
+  for resolving a `family + weight` request to the registered font name with a
+  closest-weight fallback (CSS-style font matching).
+- New exports: `FontWeightKey`, `FontFamilyManifest`, `FontsManifest`,
+  `FontRegistry`, `registerFonts`, `resolveFontFamily`, `normalizeWeight`,
+  `FontRegistryProvider`, `useFontRegistry`, `useResolvedFontFamily`,
+  `FontLoaderGate`.
+
+### Changed
+
+- `OnboardingProvider` now wraps children in an internal `OnboardingDataGate`
+  (`useQuery`) followed by `FontLoaderGate`, blocking render until the
+  onboarding payload is fetched and any declared fonts finish loading. The
+  previous `prefetchQuery` call is removed.
+
+> **Backend note:** `onboarding-studio` should mirror the new `Onboarding.fonts`
+> field — see the migration prompt in the PR description. ComposableScreen
+> UIElement schemas are unchanged; this is an API-level addition.
+
+---
+
 ## [1.16.0] - 2026-04-29
 
 ### Added

--- a/packages/onboarding/package.json
+++ b/packages/onboarding/package.json
@@ -35,8 +35,14 @@
     "vitest": "^4.1.5"
   },
   "peerDependencies": {
+    "expo-font": "*",
     "react": "*",
     "react-native": "*"
+  },
+  "peerDependenciesMeta": {
+    "expo-font": {
+      "optional": true
+    }
   },
   "files": [
     "dist",

--- a/packages/onboarding/package.json
+++ b/packages/onboarding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocapine/react-native-onboarding",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "description": "Headless React Native SDK for Rocapine Onboarding Studio - Data fetching, state management, and hooks",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/onboarding/src/infra/fonts/FontRegistryContext.tsx
+++ b/packages/onboarding/src/infra/fonts/FontRegistryContext.tsx
@@ -1,0 +1,17 @@
+import { createContext, useContext, useMemo } from "react";
+import type { FontRegistry } from "./registry";
+import { resolveFontFamily } from "./registry";
+
+const FontRegistryContext = createContext<FontRegistry>({});
+
+export const FontRegistryProvider = FontRegistryContext.Provider;
+
+export const useFontRegistry = (): FontRegistry => useContext(FontRegistryContext);
+
+export const useResolvedFontFamily = (
+  family: string | null | undefined,
+  weight: string | number | null | undefined
+): string | undefined => {
+  const registry = useFontRegistry();
+  return useMemo(() => resolveFontFamily(registry, family, weight), [registry, family, weight]);
+};

--- a/packages/onboarding/src/infra/fonts/FontRegistryContext.tsx
+++ b/packages/onboarding/src/infra/fonts/FontRegistryContext.tsx
@@ -15,3 +15,31 @@ export const useResolvedFontFamily = (
   const registry = useFontRegistry();
   return useMemo(() => resolveFontFamily(registry, family, weight), [registry, family, weight]);
 };
+
+/**
+ * Resolves a `family + weight` request to a registered font name. Returns
+ * `resolvedToVariant: true` when the registry matched a concrete weighted
+ * variant — callers should then suppress `fontWeight` on the rendered Text to
+ * avoid synthetic emboldening on top of an already-weighted font file.
+ */
+export const useResolvedFontStyle = (
+  family: string | null | undefined,
+  weight: string | number | null | undefined
+): {
+  fontFamily: string | undefined;
+  fontWeight: string | number | undefined;
+  resolvedToVariant: boolean;
+} => {
+  const registry = useFontRegistry();
+  return useMemo(() => {
+    const fontFamily = resolveFontFamily(registry, family, weight);
+    const variants = family ? registry?.[family] : undefined;
+    const resolvedToVariant =
+      !!variants && fontFamily !== undefined && fontFamily !== family;
+    return {
+      fontFamily,
+      fontWeight: resolvedToVariant ? undefined : (weight ?? undefined),
+      resolvedToVariant,
+    };
+  }, [registry, family, weight]);
+};

--- a/packages/onboarding/src/infra/fonts/index.ts
+++ b/packages/onboarding/src/infra/fonts/index.ts
@@ -1,0 +1,11 @@
+export {
+  registerFonts,
+  resolveFontFamily,
+  normalizeWeight,
+  type FontRegistry,
+} from "./registry";
+export {
+  FontRegistryProvider,
+  useFontRegistry,
+  useResolvedFontFamily,
+} from "./FontRegistryContext";

--- a/packages/onboarding/src/infra/fonts/index.ts
+++ b/packages/onboarding/src/infra/fonts/index.ts
@@ -8,4 +8,5 @@ export {
   FontRegistryProvider,
   useFontRegistry,
   useResolvedFontFamily,
+  useResolvedFontStyle,
 } from "./FontRegistryContext";

--- a/packages/onboarding/src/infra/fonts/registry.ts
+++ b/packages/onboarding/src/infra/fonts/registry.ts
@@ -1,0 +1,104 @@
+import type { FontFamilyManifest, FontsManifest, FontWeightKey } from "../../types";
+
+export type FontRegistry = Record<string, Record<number, string>>;
+
+const WEIGHT_NAME_TO_NUM: Record<string, number> = {
+  regular: 400,
+  medium: 500,
+  semibold: 600,
+  bold: 700,
+  extrabold: 800,
+};
+
+export const normalizeWeight = (key: FontWeightKey | string | number | undefined): number => {
+  if (key === undefined || key === null) return 400;
+  if (typeof key === "number") return key;
+  const named = WEIGHT_NAME_TO_NUM[key];
+  if (named) return named;
+  const parsed = parseInt(key, 10);
+  return Number.isFinite(parsed) ? parsed : 400;
+};
+
+const buildRegisteredName = (family: string, weight: number) => `${family}-${weight}`;
+
+let expoFontWarned = false;
+const loadExpoFont = (): typeof import("expo-font") | null => {
+  try {
+    return require("expo-font");
+  } catch {
+    if (!expoFontWarned) {
+      console.warn(
+        "[onboarding] `fonts` manifest provided but `expo-font` is not installed. Skipping runtime font registration."
+      );
+      expoFontWarned = true;
+    }
+    return null;
+  }
+};
+
+export const registerFonts = async (manifest: FontsManifest | undefined): Promise<FontRegistry> => {
+  const registry: FontRegistry = {};
+  if (!manifest || Object.keys(manifest).length === 0) return registry;
+
+  const Font = loadExpoFont();
+  if (!Font) return registry;
+
+  const loads: Array<Promise<void>> = [];
+
+  for (const [family, variants] of Object.entries(manifest)) {
+    if (!variants) continue;
+    registry[family] = registry[family] ?? {};
+
+    for (const [weightKey, url] of Object.entries(variants as FontFamilyManifest)) {
+      if (!url) continue;
+      const weight = normalizeWeight(weightKey as FontWeightKey);
+      const registeredName = buildRegisteredName(family, weight);
+      registry[family][weight] = registeredName;
+
+      loads.push(
+        Font.loadAsync({ [registeredName]: { uri: url } as any }).catch((error: unknown) => {
+          console.warn(
+            `[onboarding] Failed to load font "${family}" weight ${weight} from ${url}:`,
+            error
+          );
+          delete registry[family][weight];
+        })
+      );
+    }
+  }
+
+  await Promise.all(loads);
+  return registry;
+};
+
+export const resolveFontFamily = (
+  registry: FontRegistry | null | undefined,
+  family: string | null | undefined,
+  weight: string | number | null | undefined
+): string | undefined => {
+  if (!family) return undefined;
+  if (!registry) return family;
+  const variants = registry[family];
+  if (!variants) return family;
+
+  const requested = normalizeWeight(weight as FontWeightKey | undefined);
+  const exact = variants[requested];
+  if (exact) return exact;
+
+  const available = Object.keys(variants)
+    .map(Number)
+    .filter((n) => Number.isFinite(n))
+    .sort((a, b) => a - b);
+  if (available.length === 0) return family;
+
+  let best = available[0];
+  let bestDelta = Math.abs(best - requested);
+  for (const candidate of available) {
+    const delta = Math.abs(candidate - requested);
+    if (delta < bestDelta) {
+      best = candidate;
+      bestDelta = delta;
+    }
+  }
+  return variants[best];
+};

--- a/packages/onboarding/src/infra/index.ts
+++ b/packages/onboarding/src/infra/index.ts
@@ -1,2 +1,3 @@
 export * from "./provider";
 export * from "./hooks";
+export * from "./fonts";

--- a/packages/onboarding/src/infra/provider/FontLoader.tsx
+++ b/packages/onboarding/src/infra/provider/FontLoader.tsx
@@ -1,0 +1,32 @@
+import { useEffect, useState } from "react";
+import type { FontsManifest } from "../../types";
+import { FontRegistryProvider } from "../fonts/FontRegistryContext";
+import { registerFonts, type FontRegistry } from "../fonts/registry";
+
+interface FontLoaderGateProps {
+  fonts: FontsManifest | undefined;
+  fallback?: React.ReactNode;
+  children: React.ReactNode;
+}
+
+export const FontLoaderGate = ({ fonts, fallback = null, children }: FontLoaderGateProps) => {
+  const hasFonts = !!fonts && Object.keys(fonts).length > 0;
+  const [registry, setRegistry] = useState<FontRegistry | null>(hasFonts ? null : {});
+
+  useEffect(() => {
+    if (!hasFonts) {
+      setRegistry({});
+      return;
+    }
+    let cancelled = false;
+    registerFonts(fonts).then((result) => {
+      if (!cancelled) setRegistry(result);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [fonts, hasFonts]);
+
+  if (registry === null) return <>{fallback}</>;
+  return <FontRegistryProvider value={registry}>{children}</FontRegistryProvider>;
+};

--- a/packages/onboarding/src/infra/provider/FontLoader.tsx
+++ b/packages/onboarding/src/infra/provider/FontLoader.tsx
@@ -19,9 +19,17 @@ export const FontLoaderGate = ({ fonts, fallback = null, children }: FontLoaderG
       return;
     }
     let cancelled = false;
-    registerFonts(fonts).then((result) => {
-      if (!cancelled) setRegistry(result);
-    });
+    setRegistry(null);
+    registerFonts(fonts)
+      .then((result) => {
+        if (!cancelled) setRegistry(result);
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          console.error("[onboarding] Font registration failed:", err);
+          setRegistry({});
+        }
+      });
     return () => {
       cancelled = true;
     };

--- a/packages/onboarding/src/infra/provider/OnboardingProvider.tsx
+++ b/packages/onboarding/src/infra/provider/OnboardingProvider.tsx
@@ -58,10 +58,11 @@ const OnboardingDataGate = ({
   fontsFallback,
   children,
 }: OnboardingDataGateProps) => {
-  const { data } = useQuery<Onboarding<OnboardingStepType>>(
+  const { data, error } = useQuery<Onboarding<OnboardingStepType>>(
     getOnboardingQuery<OnboardingStepType>(client, locale, customAudienceParams, setOnboarding)
   );
 
+  if (error) throw error;
   if (!data) return <>{fontsFallback ?? null}</>;
 
   return (

--- a/packages/onboarding/src/infra/provider/OnboardingProvider.tsx
+++ b/packages/onboarding/src/infra/provider/OnboardingProvider.tsx
@@ -1,10 +1,11 @@
 import { createContext, useCallback, useState } from "react";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { QueryClient, QueryClientProvider, useQuery } from "@tanstack/react-query";
 import { OnboardingStudioClient } from "../../OnboardingStudioClient";
 import { getOnboardingQuery } from "../queries/getOnboarding.query";
 import { Onboarding } from "../../types";
 import { OnboardingStepType } from "../../steps/types";
 import { ComposableVariableEntry } from "../../steps/ComposableScreen/types";
+import { FontLoaderGate } from "./FontLoader";
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -32,7 +33,43 @@ interface OnboardingProviderProps {
    * variable map and may return a Promise.
    */
   customActions?: CustomActions;
+  /**
+   * Rendered while the onboarding payload is fetched and any remote fonts
+   * declared in the response (`onboarding.fonts`) are downloaded and registered.
+   * Defaults to `null`.
+   */
+  fontsFallback?: React.ReactNode;
 }
+
+interface OnboardingDataGateProps {
+  client: OnboardingStudioClient;
+  locale: string;
+  customAudienceParams: Record<string, any>;
+  setOnboarding: (onboarding: Onboarding<OnboardingStepType>) => void;
+  fontsFallback?: React.ReactNode;
+  children: React.ReactNode;
+}
+
+const OnboardingDataGate = ({
+  client,
+  locale,
+  customAudienceParams,
+  setOnboarding,
+  fontsFallback,
+  children,
+}: OnboardingDataGateProps) => {
+  const { data } = useQuery<Onboarding<OnboardingStepType>>(
+    getOnboardingQuery<OnboardingStepType>(client, locale, customAudienceParams, setOnboarding)
+  );
+
+  if (!data) return <>{fontsFallback ?? null}</>;
+
+  return (
+    <FontLoaderGate fonts={data.fonts} fallback={fontsFallback}>
+      {children}
+    </FontLoaderGate>
+  );
+};
 
 export const OnboardingProvider = ({
   children,
@@ -40,6 +77,7 @@ export const OnboardingProvider = ({
   locale = "en",
   customAudienceParams = {},
   customActions = {},
+  fontsFallback,
 }: OnboardingProviderProps) => {
   const [activeStep, setActiveStep] = useState({
     number: 0,
@@ -52,11 +90,8 @@ export const OnboardingProvider = ({
     setVariables((prev) => ({ ...prev, [name]: value }));
   }, []);
 
-  queryClient.prefetchQuery(getOnboardingQuery(client, locale, customAudienceParams, setOnboarding))
-
   return (
     <QueryClientProvider client={queryClient}>
-
       <OnboardingProgressContext.Provider
         value={{
           activeStep,
@@ -73,7 +108,15 @@ export const OnboardingProvider = ({
           customActions,
         }}
       >
-        {children}
+        <OnboardingDataGate
+          client={client}
+          locale={locale}
+          customAudienceParams={customAudienceParams}
+          setOnboarding={setOnboarding}
+          fontsFallback={fontsFallback}
+        >
+          {children}
+        </OnboardingDataGate>
       </OnboardingProgressContext.Provider>
     </QueryClientProvider>
   );

--- a/packages/onboarding/src/infra/provider/index.ts
+++ b/packages/onboarding/src/infra/provider/index.ts
@@ -6,3 +6,4 @@ export type {
   CustomActionHandler,
   CustomActions,
 } from "./OnboardingProvider";
+export { FontLoaderGate } from "./FontLoader";

--- a/packages/onboarding/src/onboarding-example.ts
+++ b/packages/onboarding/src/onboarding-example.ts
@@ -9,6 +9,16 @@ export const onboardingExample = {
     audienceOrder: undefined,
     draft: true,
   },
+  fonts: {
+    Inter: {
+      regular: "https://cdn.jsdelivr.net/fontsource/fonts/inter@latest/latin-400-normal.ttf",
+      medium: "https://cdn.jsdelivr.net/fontsource/fonts/inter@latest/latin-500-normal.ttf",
+      bold: "https://cdn.jsdelivr.net/fontsource/fonts/inter@latest/latin-700-normal.ttf",
+    },
+    Lobster: {
+      regular: "https://cdn.jsdelivr.net/fontsource/fonts/lobster@latest/latin-400-normal.ttf",
+    },
+  },
   steps: [
     {
       id: "welcome",
@@ -188,8 +198,19 @@ export const onboardingExample = {
                   content: "Built from the CMS",
                   fontSize: 28,
                   fontWeight: "700",
-                  fontFamily: "System",
+                  fontFamily: "Inter",
                   textAlign: "center",
+                },
+              },
+              {
+                id: "headline-display",
+                type: "Text",
+                props: {
+                  content: "Runtime-loaded font",
+                  fontSize: 32,
+                  fontFamily: "Lobster",
+                  textAlign: "center",
+                  marginVertical: 4,
                 },
               },
               {

--- a/packages/onboarding/src/onboarding-example.ts
+++ b/packages/onboarding/src/onboarding-example.ts
@@ -209,6 +209,7 @@ export const onboardingExample = {
                   content: "Runtime-loaded font",
                   fontSize: 32,
                   fontFamily: "Lobster",
+                  fontStyle: "italic",
                   textAlign: "center",
                   marginVertical: 4,
                 },

--- a/packages/onboarding/src/steps/ComposableScreen/elements/ButtonElement.ts
+++ b/packages/onboarding/src/steps/ComposableScreen/elements/ButtonElement.ts
@@ -38,6 +38,7 @@ export type ButtonElementProps = BaseBoxProps & {
   fontSize?: number;
   fontWeight?: string;
   fontFamily?: string;
+  fontStyle?: "normal" | "italic";
   textAlign?: "left" | "center" | "right";
 };
 
@@ -51,5 +52,6 @@ export const ButtonElementPropsSchema = BaseBoxPropsSchema.extend({
   fontSize: z.number().optional(),
   fontWeight: z.string().optional(),
   fontFamily: z.string().optional(),
+  fontStyle: z.enum(["normal", "italic"]).optional(),
   textAlign: z.enum(["left", "center", "right"]).optional(),
 });

--- a/packages/onboarding/src/steps/ComposableScreen/elements/CheckboxGroupElement.ts
+++ b/packages/onboarding/src/steps/ComposableScreen/elements/CheckboxGroupElement.ts
@@ -18,6 +18,7 @@ export type CheckboxGroupElementProps = BaseBoxProps & {
   itemFontSize?: number;
   itemFontWeight?: string;
   itemFontFamily?: string;
+  itemFontStyle?: "normal" | "italic";
   itemPadding?: number;
   itemPaddingHorizontal?: number;
   itemPaddingVertical?: number;
@@ -40,6 +41,7 @@ export const CheckboxGroupElementPropsSchema = BaseBoxPropsSchema.extend({
   itemFontSize: z.number().optional(),
   itemFontWeight: z.string().optional(),
   itemFontFamily: z.string().optional(),
+  itemFontStyle: z.enum(["normal", "italic"]).optional(),
   itemPadding: z.number().optional(),
   itemPaddingHorizontal: z.number().optional(),
   itemPaddingVertical: z.number().optional(),

--- a/packages/onboarding/src/steps/ComposableScreen/elements/InputElement.ts
+++ b/packages/onboarding/src/steps/ComposableScreen/elements/InputElement.ts
@@ -18,6 +18,7 @@ export type InputElementProps = BaseBoxProps & {
   fontSize?: number;
   fontWeight?: string;
   fontFamily?: string;
+  fontStyle?: "normal" | "italic";
   lineHeight?: number;
   letterSpacing?: number;
   textAlign?: "left" | "center" | "right";
@@ -41,6 +42,7 @@ export const InputElementPropsSchema = BaseBoxPropsSchema.extend({
   fontSize: z.number().optional(),
   fontWeight: z.string().optional(),
   fontFamily: z.string().optional(),
+  fontStyle: z.enum(["normal", "italic"]).optional(),
   lineHeight: z.number().optional(),
   letterSpacing: z.number().optional(),
   textAlign: z.enum(["left", "center", "right"]).optional(),

--- a/packages/onboarding/src/steps/ComposableScreen/elements/RadioGroupElement.ts
+++ b/packages/onboarding/src/steps/ComposableScreen/elements/RadioGroupElement.ts
@@ -18,6 +18,7 @@ export type RadioGroupElementProps = BaseBoxProps & {
   itemFontSize?: number;
   itemFontWeight?: string;
   itemFontFamily?: string;
+  itemFontStyle?: "normal" | "italic";
   itemPadding?: number;
   itemPaddingHorizontal?: number;
   itemPaddingVertical?: number;
@@ -40,6 +41,7 @@ export const RadioGroupElementPropsSchema = BaseBoxPropsSchema.extend({
   itemFontSize: z.number().optional(),
   itemFontWeight: z.string().optional(),
   itemFontFamily: z.string().optional(),
+  itemFontStyle: z.enum(["normal", "italic"]).optional(),
   itemPadding: z.number().optional(),
   itemPaddingHorizontal: z.number().optional(),
   itemPaddingVertical: z.number().optional(),

--- a/packages/onboarding/src/steps/ComposableScreen/elements/TextElement.ts
+++ b/packages/onboarding/src/steps/ComposableScreen/elements/TextElement.ts
@@ -7,6 +7,7 @@ export type TextElementProps = BaseBoxProps & {
   fontSize?: number;
   fontWeight?: string;
   fontFamily?: string;
+  fontStyle?: "normal" | "italic";
   color?: string;
   textAlign?: "left" | "center" | "right";
   letterSpacing?: number;
@@ -19,6 +20,7 @@ export const TextElementPropsSchema = BaseBoxPropsSchema.extend({
   fontSize: z.number().optional(),
   fontWeight: z.string().optional(),
   fontFamily: z.string().optional(),
+  fontStyle: z.enum(["normal", "italic"]).optional(),
   color: z.string().optional(),
   textAlign: z.enum(["left", "center", "right"]).optional(),
   letterSpacing: z.number().optional(),

--- a/packages/onboarding/src/types.ts
+++ b/packages/onboarding/src/types.ts
@@ -44,10 +44,31 @@ export interface OnboardingMetadata {
   draft?: boolean;
 }
 
+export type FontWeightKey =
+  | "regular"
+  | "medium"
+  | "semibold"
+  | "bold"
+  | "extrabold"
+  | "100"
+  | "200"
+  | "300"
+  | "400"
+  | "500"
+  | "600"
+  | "700"
+  | "800"
+  | "900";
+
+export type FontFamilyManifest = Partial<Record<FontWeightKey, string>>;
+
+export type FontsManifest = Record<string, FontFamilyManifest>;
+
 export interface Onboarding<StepType extends BaseStepType = BaseStepType> {
   metadata: OnboardingMetadata;
   steps: StepType[];
   configuration: any;
+  fonts?: FontsManifest;
 }
 
 export interface GetStepsResponseHeaders {

--- a/rocapine-onboarding.code-workspace
+++ b/rocapine-onboarding.code-workspace
@@ -30,7 +30,7 @@
         "request": "launch",
         "cwd": "${workspaceFolder:📱 example app}",
         "runtimeExecutable": "npm",
-        "runtimeArgs": ["run", "ios"],
+        "runtimeArgs": ["run", "start"],
         "console": "integratedTerminal",
         "skipFiles": ["<node_internals>/**"],
       },

--- a/website/docs/customization/theming.mdx
+++ b/website/docs/customization/theming.mdx
@@ -201,9 +201,13 @@ The SDK uses three font categories:
 - **text**: Used for body text, buttons, labels
 - **tagline**: Used for special emphasis text
 
-**IMPORTANT:** The SDK accepts font names but **does not load fonts**. You must load custom fonts using `expo-font`.
+There are two ways to load custom fonts:
 
-#### Step 1: Load Fonts
+1. **Bundle locally with `expo-font`** — for fonts shipped with the app binary.
+2. **Download at runtime via the `Onboarding.fonts` manifest** — for fonts the
+   CMS declares per onboarding (no native rebuild required).
+
+#### Option A — Local fonts via `expo-font`
 
 ```typescript
 import { useFonts } from 'expo-font';
@@ -233,6 +237,73 @@ export default function RootLayout() {
   );
 }
 ```
+
+#### Option B — Runtime fonts via the Onboarding payload (since 1.17.0)
+
+The backend can ship a font manifest in the onboarding response. The SDK
+downloads each variant via `expo-font` (optional peer dep) and blocks render
+until they are ready. ComposableScreen `TextElement`, `ButtonElement`, and
+`InputElement` automatically resolve `fontFamily + fontWeight` to the right
+registered variant — CMS authors keep using the family name they declared.
+
+Backend `Onboarding` response shape:
+
+```json
+{
+  "metadata": { /* ... */ },
+  "steps": [ /* ... */ ],
+  "configuration": { /* ... */ },
+  "fonts": {
+    "Inter": {
+      "regular": "https://cdn/.../Inter-Regular.ttf",
+      "medium": "https://cdn/.../Inter-Medium.ttf",
+      "bold": "https://cdn/.../Inter-Bold.ttf"
+    },
+    "Lobster": {
+      "regular": "https://cdn/.../Lobster-Regular.ttf"
+    }
+  }
+}
+```
+
+Weight keys may be **named** (`regular`, `medium`, `semibold`, `bold`,
+`extrabold`) or **numeric** (`100`…`900`); both are normalized internally.
+When the requested weight is not registered, the resolver falls back to the
+closest available weight (CSS-style font matching).
+
+Show a fallback while fonts download:
+
+```tsx
+import { OnboardingProvider } from "@rocapine/react-native-onboarding";
+import { ActivityIndicator } from "react-native";
+
+<OnboardingProvider
+  client={client}
+  fontsFallback={<ActivityIndicator />}
+>
+  <YourApp />
+</OnboardingProvider>
+```
+
+For non-`OnboardingProvider` hosts, mount fonts directly with `FontLoaderGate`:
+
+```tsx
+import { FontLoaderGate, type FontsManifest } from "@rocapine/react-native-onboarding";
+
+const fonts: FontsManifest = {
+  Inter: {
+    regular: "https://cdn/.../Inter-Regular.ttf",
+    bold: "https://cdn/.../Inter-Bold.ttf",
+  },
+};
+
+<FontLoaderGate fonts={fonts} fallback={<ActivityIndicator />}>
+  <YourScreen />
+</FontLoaderGate>
+```
+
+If `expo-font` is not installed in the host app, `registerFonts` resolves to an
+empty registry and logs a single warning — text falls back to system fonts.
 
 ### Font Sizes
 

--- a/website/docs/customization/theming.mdx
+++ b/website/docs/customization/theming.mdx
@@ -289,6 +289,7 @@ For non-`OnboardingProvider` hosts, mount fonts directly with `FontLoaderGate`:
 
 ```tsx
 import { FontLoaderGate, type FontsManifest } from "@rocapine/react-native-onboarding";
+import { ActivityIndicator } from "react-native";
 
 const fonts: FontsManifest = {
   Inter: {


### PR DESCRIPTION
## Summary

- Adds optional `fonts` manifest (per family, per weight) to the `Onboarding` API payload. SDK downloads + registers fonts at runtime via `expo-font` (optional peer dep) and blocks render until ready via a new `OnboardingDataGate` + `FontLoaderGate` inside `OnboardingProvider`.
- ComposableScreen `TextElement`, `ButtonElement`, `InputElement` now resolve `fontFamily + fontWeight` to the runtime-registered variant via `useResolvedFontFamily`, with closest-weight fallback (CSS-style font matching). No element schema change.
- New public exports: `FontWeightKey`, `FontFamilyManifest`, `FontsManifest`, `FontRegistry`, `registerFonts`, `resolveFontFamily`, `normalizeWeight`, `FontRegistryProvider`, `useFontRegistry`, `useResolvedFontFamily`, `FontLoaderGate`. New `OnboardingProvider.fontsFallback?: ReactNode` prop.
- Bumps both packages to `1.17.0`, updates CHANGELOGs and website theming docs.
- Adds `example/app/example/composable-screen-fonts.tsx` demonstrating runtime Inter (regular/medium/bold) + Lobster with closest-weight fallback.

## Backend (`onboarding-studio`) follow-up

`Onboarding.fonts` is **API-level**; ComposableScreen UIElement schemas are unchanged. Mirror the field in the onboarding model + CMS editor + JSON serialization. Full migration prompt in the PR thread / chat handoff.

```ts
type FontWeightKey =
  | "regular" | "medium" | "semibold" | "bold" | "extrabold"
  | "100" | "200" | "300" | "400" | "500" | "600" | "700" | "800" | "900";

interface Onboarding {
  // ... existing fields
  fonts?: Record<string, Partial<Record<FontWeightKey, string>>>;
}
```

## Test plan

- [ ] `npm run build` — both packages compile clean
- [ ] `cd example && npm run type:check` — example type-checks
- [ ] Run example app, navigate to **Composable Screen → Runtime Fonts**:
  - [ ] `Lobster` headline renders in display font
  - [ ] Inter `400` / `500` / `700` text variants visibly differ
  - [ ] Inter `300` falls back to Regular (`400`) — closest-weight fallback
  - [ ] `ActivityIndicator + "Downloading fonts…"` shown briefly while fonts download
  - [ ] Subsequent app launches: no flicker (expo-font filesystem cache)
- [ ] Run example onboarding flow (fallback `onboardingExample`): "Built from the CMS" renders in Inter Bold, "Runtime-loaded font" in Lobster
- [ ] Sanity check on iOS + Android

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Runtime font loading from onboarding payloads with render-gating and optional fallback UI.
  * Automatic font resolution to registered weighted variants (avoids synthetic emboldening).
  * New styling props: fontStyle for Text/Button/Input and itemFontStyle for radio/checkbox labels.
  * Example screen demonstrating runtime fonts and font-loading UX.

* **Bug Fixes**
  * Improved carousel sizing and onboarding data/error handling.

* **Documentation**
  * Expanded typography and runtime font guidance; added diagnostics and sync skills.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->