### PR TITLE
🐛 fix(fonts): accept array-shape variants in runtime font manifest (v1.17.1)

### DIFF
--- a/packages/onboarding-ui/CHANGELOG.md
+++ b/packages/onboarding-ui/CHANGELOG.md
@@ -39,6 +39,20 @@ here.
 
 ---
 
+## [1.17.1] - 2026-05-04
+
+### Fixed
+
+- **Runtime font registration** via `OnboardingProvider` — fonts declared on
+  the onboarding payload now load correctly when the backend returns the
+  variant-array shape (`{ family: [{ weight, style, url }, ...] }`). Previous
+  versions silently failed with `loadSingleFontAsync expected resource of
+  type Asset` and bogus `weight 8 from [object Object]` warnings, leaving
+  `fontFamily` strings unmapped to weighted variants. No UI-package API
+  change; fix lives in the headless SDK consumed by `FontLoaderGate`.
+
+---
+
 ## [1.17.0] - 2026-04-30
 
 ### Changed

--- a/packages/onboarding-ui/package.json
+++ b/packages/onboarding-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocapine/react-native-onboarding-ui",
-  "version": "1.17.0",
+  "version": "1.17.1",
   "description": "UI components and renderers for Rocapine Onboarding Studio - Built on top of the headless SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/onboarding/CHANGELOG.md
+++ b/packages/onboarding/CHANGELOG.md
@@ -21,6 +21,29 @@ All notable changes to `@rocapine/react-native-onboarding` are documented here.
 
 ---
 
+## [1.17.1] - 2026-05-04
+
+### Fixed
+
+- **Runtime fonts manifest** — `registerFonts` now accepts the array shape
+  returned by `onboarding-studio`
+  (`{ family: [{ weight, style, url }, ...] }`) in addition to the legacy
+  `{ family: { weightKey: url } }` map. Previously, iterating an array with
+  `Object.entries` produced numeric indices (`"0".."N"`) as weight keys and
+  passed the variant object as `url`, causing native expo-font to throw
+  `loadSingleFontAsync expected resource of type Asset` and warnings like
+  `Failed to load font "X" weight 8 from [object Object]`. The new
+  `normalizeFamilyVariants` dedupes by weight and prefers `style: "normal"`
+  variants over italic.
+
+### Added
+
+- **`FontVariantEntry`** and **`FontFamilyManifestInput`** exported types.
+  `FontsManifest` widened to `Record<string, FontFamilyManifestInput>` so
+  array-shape manifests are typed end-to-end.
+
+---
+
 ## [1.17.0] - 2026-04-30
 
 ### Added

--- a/packages/onboarding/package.json
+++ b/packages/onboarding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocapine/react-native-onboarding",
-  "version": "1.17.0",
+  "version": "1.17.1",
   "description": "Headless React Native SDK for Rocapine Onboarding Studio - Data fetching, state management, and hooks",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/onboarding/src/infra/fonts/registry.ts
+++ b/packages/onboarding/src/infra/fonts/registry.ts
@@ -1,4 +1,10 @@
-import type { FontFamilyManifest, FontsManifest, FontWeightKey } from "../../types";
+import type {
+  FontFamilyManifest,
+  FontFamilyManifestInput,
+  FontsManifest,
+  FontVariantEntry,
+  FontWeightKey,
+} from "../../types";
 
 export type FontRegistry = Record<string, Record<number, string>>;
 
@@ -36,6 +42,33 @@ const loadExpoFont = (): typeof import("expo-font") | null => {
   }
 };
 
+type NormalizedVariant = { weight: number; url: string };
+
+const normalizeFamilyVariants = (input: FontFamilyManifestInput | undefined): NormalizedVariant[] => {
+  if (!input) return [];
+
+  if (Array.isArray(input)) {
+    const byWeight = new Map<number, NormalizedVariant>();
+    for (const entry of input as FontVariantEntry[]) {
+      if (!entry || typeof entry.url !== "string" || !entry.url) continue;
+      const weight = normalizeWeight(entry.weight as FontWeightKey | number);
+      const existing = byWeight.get(weight);
+      const isNormalStyle = !entry.style || entry.style === "normal";
+      if (!existing || isNormalStyle) {
+        byWeight.set(weight, { weight, url: entry.url });
+      }
+    }
+    return Array.from(byWeight.values());
+  }
+
+  const out: NormalizedVariant[] = [];
+  for (const [weightKey, url] of Object.entries(input as FontFamilyManifest)) {
+    if (typeof url !== "string" || !url) continue;
+    out.push({ weight: normalizeWeight(weightKey as FontWeightKey), url });
+  }
+  return out;
+};
+
 export const registerFonts = async (manifest: FontsManifest | undefined): Promise<FontRegistry> => {
   const registry: FontRegistry = {};
   if (!manifest || Object.keys(manifest).length === 0) return registry;
@@ -45,13 +78,12 @@ export const registerFonts = async (manifest: FontsManifest | undefined): Promis
 
   const loads: Array<Promise<void>> = [];
 
-  for (const [family, variants] of Object.entries(manifest)) {
-    if (!variants) continue;
+  for (const [family, variantsInput] of Object.entries(manifest)) {
+    const variants = normalizeFamilyVariants(variantsInput);
+    if (variants.length === 0) continue;
     registry[family] = registry[family] ?? {};
 
-    for (const [weightKey, url] of Object.entries(variants as FontFamilyManifest)) {
-      if (!url) continue;
-      const weight = normalizeWeight(weightKey as FontWeightKey);
+    for (const { weight, url } of variants) {
       const registeredName = buildRegisteredName(family, weight);
       registry[family][weight] = registeredName;
 

--- a/packages/onboarding/src/types.ts
+++ b/packages/onboarding/src/types.ts
@@ -62,7 +62,15 @@ export type FontWeightKey =
 
 export type FontFamilyManifest = Partial<Record<FontWeightKey, string>>;
 
-export type FontsManifest = Record<string, FontFamilyManifest>;
+export interface FontVariantEntry {
+  weight: FontWeightKey | number;
+  style?: "normal" | "italic" | string;
+  url: string;
+}
+
+export type FontFamilyManifestInput = FontFamilyManifest | FontVariantEntry[];
+
+export type FontsManifest = Record<string, FontFamilyManifestInput>;
 
 export interface Onboarding<StepType extends BaseStepType = BaseStepType> {
   metadata: OnboardingMetadata;


### PR DESCRIPTION
## Summary
- Backend returns `fonts: { family: [{ weight, style, url }, ...] }`; old `registerFonts` iterated as `Record<weightKey, url>` → numeric indices + `[object Object]` urls → native expo-font threw `loadSingleFontAsync expected resource of type Asset`.
- New `normalizeFamilyVariants` handles both shapes, dedupes by weight, prefers `style: "normal"` over italic.
- Types: added `FontVariantEntry`, `FontFamilyManifestInput`; widened `FontsManifest`.
- Bumped both packages to 1.17.1, changelog entries added.

## Test plan
- [ ] Reload example app — fonts download and register without `[object Object]` warnings
- [ ] Verify weighted variants resolve (e.g. `Inter-700`) via `useResolvedFontStyle`
- [ ] Confirm legacy `{ family: { weightKey: url } }` shape still works
- [ ] `npm run build` clean
- [ ] `cd example && npm run type:check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes – v1.17.1

**Bug Fixes**
* Fixed an issue where custom fonts would fail to load correctly during onboarding setup. Font registration now properly handles all font variant configurations, ensuring consistent rendering across different backend scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->