### PR TITLE
🔖 chore(release): v1.18.0 — setVariable action + branching fix

### DIFF
--- a/.claude/rules/composable-screen-runtime.md
+++ b/.claude/rules/composable-screen-runtime.md
@@ -1,0 +1,38 @@
+---
+paths:
+  - "packages/onboarding-ui/src/UI/Pages/ComposableScreen/**"
+---
+
+# ComposableScreen UIElement Runtime
+
+## Container style (BaseBoxProps)
+
+Every UIElement renderer that wraps content builds `containerStyle` from `BaseBoxProps`: `alignSelf`, `flex`, `flexShrink/Grow`, `width` (via `dim()`), `height` (via `dim()`), `min/maxWidth/Height`, `margin*`, `padding*`, `borderRadius/Width/Color`, `backgroundColor` (only when no `backgroundGradient`), `opacity`, `overflow`. Apply to outermost wrapper (`GradientBox` or `View`). Missing fields = user can't control that aspect from CMS payload.
+
+## Sizing libs needing numeric pixels
+
+`react-native-reanimated-carousel`, `react-native-video`, Lottie/Rive don't accept `"50%"` strings. Pattern:
+
+1. Pass `containerStyle` (with `dim()`) to outermost wrapper
+2. Wrap library in inner `View` with `flex: 1` + `onLayout`
+3. Render library only after first measurement (`size.width > 0 && size.height > 0`)
+4. Pass measured numeric `size.width/height` to library
+
+## Overflow gotcha
+
+Default `overflow: hidden`. Carousel `left-align` carouselType needs `visible` for peek effect. Same for shadows/badges spilling outside bounds. Don't blanket-set `hidden` in refactors.
+
+## Gradient peer dep
+
+`GradientBox` silently falls back to plain `View` if `expo-linear-gradient` not installed. If `backgroundGradient` appears unrendered, check peer dep first.
+
+## Font hook rule (Text-rendering elements)
+
+```ts
+const f = useResolvedFontStyle(props.fontFamily, props.fontWeight);
+// style: { fontFamily: f.fontFamily, fontWeight: f.resolvedToVariant ? undefined : (props.fontWeight as any) ?? <theme default> }
+```
+
+`f.resolvedToVariant === true` → registry matched concrete weighted variant (e.g. `Inter-700`); **suppress `fontWeight`** or iOS/Android applies synthetic emboldening on top of already-weighted font file.
+
+Use legacy `useResolvedFontFamily` only for elements that never set `fontWeight`.

--- a/.claude/rules/example-app.md
+++ b/.claude/rules/example-app.md
@@ -1,0 +1,30 @@
+---
+paths:
+  - "example/**"
+---
+
+# Example App
+
+Local packages via `file:../packages/onboarding` and `file:../packages/onboarding-ui`. Rebuild before reload after package changes.
+
+```bash
+cd example/
+npm install
+npm start
+npm run type:check
+npm run lint
+npm run ios
+npm run android
+```
+
+## Workspace type resolution
+
+`@rocapine/react-native-onboarding` resolves to `dist/index.d.ts` via workspace symlink + `package.json#types`. New exported symbols in `packages/onboarding/src/` are invisible to `packages/onboarding-ui/` and `example/` `tsc` runs until headless package built (or `npm run watch:headless` running). **Build before typechecking after adding exports.**
+
+## Layout
+
+- `app/example/` — individual page-type demos (registered in `app/example/index.tsx`)
+- `app/onboarding/[questionId].tsx` — full onboarding flow with real API
+- `app/onboarding_custom_screens/` — custom-component override demos
+- `app/_layout.tsx` — root layout with `OnboardingProvider` setup
+- `components/` — demo custom components (e.g., `MinimalAnswerButton`, `AnimatedAnswersList`)

--- a/.claude/rules/page-renderers.md
+++ b/.claude/rules/page-renderers.md
@@ -1,0 +1,23 @@
+---
+paths:
+  - "packages/onboarding-ui/src/UI/Pages/**"
+---
+
+# Page Renderers
+
+## Renderer rules
+
+- Wrap with `OnboardingTemplate` (safe area, progress, CTA positioning)
+- Inner `ScrollView` with `alwaysBounceVertical={false}`
+- Validate first: `const validatedData = StepTypeSchema.parse(step)`
+- Use `validatedData.continueButtonLabel` for CTA button text
+- Always `useTheme()` — never hardcode colors/typography
+- **Never add ProgressBar manually** — `OnboardingProvider` includes it
+- `onContinue(value?)` — selected value passed back (Picker, Question)
+
+## Adding a Page Type
+
+1. Zod schema + types in `packages/onboarding/src/steps/{NewType}/`
+2. `Pages/{NewType}/`: `types.ts` (re-export schema, default `continueButtonLabel: z.string().optional().default("Continue")`), `Renderer.tsx`, `index.ts`
+3. Export from `Pages/index.ts`, add to union in `UI/types.ts`, switch case in `UI/OnboardingPage.tsx`
+4. Demo in `example/app/example/`, register in `example/app/example/index.tsx`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,15 +1,20 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+Guidance for Claude Code working in this repository.
+
+Path-scoped rules auto-load from `.claude/rules/`:
+- `page-renderers.md` — page renderer rules, adding a Page Type
+- `composable-screen-runtime.md` — UIElement runtime conventions, BaseBoxProps, font hook rule, gradient peer dep
+- `example-app.md` — example app workflow, workspace type-resolution gotcha
 
 ## Project Overview
 
-This is a **monorepo** containing two npm packages for Rocapine Onboarding Studio — a CMS-driven onboarding system for React Native apps:
+**Monorepo** with two npm packages for Rocapine Onboarding Studio — CMS-driven onboarding system for React Native apps:
 
 - **`@rocapine/react-native-onboarding`** (`packages/onboarding/`) — Headless SDK: data fetching, state management, hooks, Zod schemas for step types
 - **`@rocapine/react-native-onboarding-ui`** (`packages/onboarding-ui/`) — UI layer: renderers, theme system, components, templates
 
-The UI package depends on the headless package as a peer dependency.
+UI package depends on headless package as peer dependency.
 
 ## Development Commands
 
@@ -17,54 +22,38 @@ The UI package depends on the headless package as a peer dependency.
 
 ```bash
 npm run build              # Build both packages
-npm run build:headless     # Build packages/onboarding only
-npm run build:ui           # Build packages/onboarding-ui only (also copies src/assets → dist/assets)
-npm run watch:headless     # Watch mode for headless package
-npm run watch:ui           # Watch mode for UI package
+npm run build:headless     # packages/onboarding only
+npm run build:ui           # packages/onboarding-ui only (also copies src/assets → dist/assets)
+npm run watch:headless     # Watch mode for headless
+npm run watch:ui           # Watch mode for UI
 npm run clean              # Remove all dist/ and node_modules/
-npm run publish:all        # Build and publish both packages to npm
+npm run publish:all        # Build + publish both packages to npm
 ```
 
-### Example App
-
-```bash
-cd example/
-npm install
-npm start             # Start Expo dev server
-npm run type:check    # TypeScript type checking (tsc --noEmit)
-npm run lint          # ESLint via expo lint
-npm run ios
-npm run android
-```
-
-**Important**: After modifying anything in `packages/`, run `npm run build` (or the relevant workspace build) before reloading the example app, since the example references local packages via `file:../packages/*`.
-
-**Workspace type resolution**: `@rocapine/react-native-onboarding` resolves to its `dist/index.d.ts` via the workspace symlink + `package.json#types`. Adding a new exported symbol in `packages/onboarding/src/` is invisible to `packages/onboarding-ui/` and `example/` `tsc` runs until the headless package is built (or `npm run watch:headless` is running). Build before typechecking after adding exports.
+After modifying `packages/`, run `npm run build` (or relevant workspace build) before reloading the example app — it references local packages via `file:../packages/*`.
 
 ## Architecture
 
 ### Two-Package Split
 
 **Headless SDK** (`packages/onboarding/src/`):
-- `OnboardingStudioClient.ts` — API client that fetches steps from Supabase backend. URL params: `projectId`, `platform`, `appVersion`, `locale`, `draft`. Returns step data + custom headers (`ONBS-Onboarding-Id`, `ONBS-Audience-Id`, `ONBS-Onboarding-Name`).
-- `infra/provider/` — `OnboardingProvider`: wraps app with `QueryClientProvider` + `ThemeProvider`, manages caching via AsyncStorage, and **automatically includes ProgressBar**. The internal `OnboardingDataGate` reads `useQuery({ data, error })` and **throws `error`** so a host `ErrorBoundary` catches network/parse failures — never swallow the error and fall through to `fontsFallback`.
+- `OnboardingStudioClient.ts` — API client fetching steps from Supabase backend. URL params: `projectId`, `platform`, `appVersion`, `locale`, `draft`. Returns step data + custom headers (`ONBS-Onboarding-Id`, `ONBS-Audience-Id`, `ONBS-Onboarding-Name`).
+- `infra/provider/` — `OnboardingProvider`: wraps app with `QueryClientProvider` + `ThemeProvider`, manages caching via AsyncStorage, **automatically includes ProgressBar**. Internal `OnboardingDataGate` reads `useQuery({ data, error })` and **throws `error`** so host `ErrorBoundary` catches network/parse failures — never swallow error and fall through to `fontsFallback`.
 - `infra/hooks/useOnboardingQuestions.ts` — Hook returning `{ step, isLastStep, stepsLength, onboardingMetadata, steps }`. Uses `useSuspenseQuery`; manages progress context automatically.
-- `infra/fonts/` — Runtime font registry (see "Runtime Fonts" section).
-- `steps/` — Zod schemas and TypeScript types for each step variant (source of truth for data shapes)
-- `types.ts` — Core types; `index.ts` — public exports. **CHANGELOG entries describing union/enum members are illustrative** — when in doubt, check the actual exported type (e.g. `FontWeightKey`) for the canonical set.
+- `infra/fonts/` — Runtime font registry.
+- `steps/` — Zod schemas + TypeScript types for each step variant (source of truth)
+- `types.ts` — Core types; `index.ts` — public exports. **CHANGELOG entries describing union/enum members are illustrative** — check actual exported type (e.g. `FontWeightKey`) for canonical set.
 
 **UI Package** (`packages/onboarding-ui/src/`):
-- `UI/OnboardingPage.tsx` — Central router: switch on `step.type` → delegates to specific Renderer
-- `UI/Pages/` — One directory per step type; each has `types.ts` (Zod schema), `Renderer.tsx`, `index.ts`
-- `UI/Templates/OnboardingTemplate.tsx` — Reusable layout: safe area insets, progress header, CTA button at bottom
-- `UI/Components/` — Shared components: `ProgressBar`, `CircularProgress`, `StaggeredTextList`
-- `UI/Theme/` — Theme context, hooks, deep-merge utils, `tokens/lightTokens.ts`, `tokens/darkTokens.ts`, `tokens/typography.ts`
+- `UI/OnboardingPage.tsx` — Central router: switch on `step.type` → specific Renderer
+- `UI/Pages/` — One dir per step type (each with `types.ts`, `Renderer.tsx`, `index.ts`)
+- `UI/Templates/OnboardingTemplate.tsx` — Reusable layout: safe area, progress header, CTA at bottom
+- `UI/Components/` — `ProgressBar`, `CircularProgress`, `StaggeredTextList`
+- `UI/Theme/` — Theme context, hooks, deep-merge utils, `tokens/lightTokens.ts`, `darkTokens.ts`, `typography.ts`
 - `UI/Provider/` — `OnboardingProgressProvider`
 - `UI/ErrorBoundary/` — HOC for error handling
 
 ### Page Types
-
-Available step types (each in `UI/Pages/{Type}/`):
 
 | Type | Key Behavior |
 |------|-------------|
@@ -83,80 +72,13 @@ Available step types (each in `UI/Pages/{Type}/`):
 - Back button appears when `router.canGoBack()` is true (uses expo-router)
 - Control back nav: use `router.push()` vs `router.replace()` in `onContinue` handlers
 
-## Adding a New Page Type
-
-1. Add Zod schema + TypeScript type in `packages/onboarding/src/steps/{NewType}/` (source of truth)
-2. Create `packages/onboarding-ui/src/UI/Pages/{NewType}/`:
-   - `types.ts` — re-export or re-define schema; include `continueButtonLabel: z.string().optional().default("Continue")`
-   - `Renderer.tsx` — use `OnboardingTemplate`, validate with Zod, use `useTheme()`, **no ProgressBar**
-   - `index.ts` — export both
-3. Export from `packages/onboarding-ui/src/UI/Pages/index.ts`
-4. Add to union in `packages/onboarding-ui/src/UI/types.ts`
-5. Add case to switch in `packages/onboarding-ui/src/UI/OnboardingPage.tsx`
-6. Add example to `example/app/example/` and register in `example/app/example/index.tsx`
-
-### Renderer Guidelines
-
-- Use `OnboardingTemplate` for consistent layout and CTA positioning
-- Wrap content in `ScrollView` with `alwaysBounceVertical={false}`
-- Always `const validatedData = StepTypeSchema.parse(step)` before use
-- Use `validatedData.continueButtonLabel` for button text
-- Use `useTheme()` for all colors and typography — never hardcode values
-- `onContinue` receives selected value as parameter (for types like Picker, Question)
-
-## ComposableScreen UIElement Conventions
-
-### Container style (BaseBoxProps)
-
-Every UIElement renderer that wraps content must build a `containerStyle` from `BaseBoxProps` covering: `alignSelf`, `flex`, `flexShrink`, `flexGrow`, `width` (via `dim()`), `height` (via `dim()`), `minWidth/maxWidth/minHeight/maxHeight`, `margin*`, `padding*`, `borderRadius/Width/Color`, `backgroundColor` (only if no `backgroundGradient`), `opacity`, `overflow`. Apply to outermost wrapper (`GradientBox` or `View`). Missing fields = user can't control that aspect from CMS payload.
-
-### Sizing libraries that need numeric pixels
-
-`react-native-reanimated-carousel`, `react-native-video`, Lottie/Rive components don't accept `"50%"` strings. When wrapping such a library in a UIElement:
-
-1. Pass `containerStyle` (with `dim()`) to the outermost wrapper
-2. Wrap the library in an inner `View` with `flex: 1` + `onLayout`
-3. Render the library only after first measurement (`size.width > 0 && size.height > 0`)
-4. Pass measured numeric `size.width/height` to the library
-
-### Overflow gotcha
-
-Default `overflow` is `hidden`. Carousel's `left-align` carouselType needs `visible` for the peek effect. Same for shadows/badges spilling outside bounds. Don't blanket-set `hidden` in refactors.
-
-### Gradient peer dep
-
-`GradientBox` silently falls back to plain `View` if `expo-linear-gradient` isn't installed. If `backgroundGradient` appears unrendered, check the peer dep first.
-
-## Runtime Fonts
-
-The `Onboarding` response carries an optional `fonts?: FontsManifest` field — `Record<family, Partial<Record<FontWeightKey, url>>>`. Files are downloaded and registered via `expo-font` (optional peer) by `FontLoaderGate`, which mounts a `FontRegistryContext`.
-
-### `FontLoaderGate` state convention
-
-- `registry === null` is the **loading sentinel** — gate renders `fallback`.
-- `registry === {}` is **ready, no fonts** — gate renders children.
-- Async registration must `setRegistry(null)` before the call and `.catch(() => setRegistry({}))` so a fetch failure doesn't strand the gate.
-
-### Hook choice rule (Text-rendering elements)
-
-For any UIElement that renders `<Text>` or `<TextInput>` and accepts `fontWeight`:
-
-```ts
-const f = useResolvedFontStyle(props.fontFamily, props.fontWeight);
-// style: { fontFamily: f.fontFamily, fontWeight: f.resolvedToVariant ? undefined : (props.fontWeight as any) ?? <theme default> }
-```
-
-When `f.resolvedToVariant === true`, the registry matched a concrete weighted variant (e.g. `Inter-700`) — **suppress `fontWeight`**, otherwise iOS/Android will apply synthetic emboldening on top of an already-weighted font file.
-
-Use the legacy `useResolvedFontFamily` only for elements that never set `fontWeight`.
-
 ## Custom Components System
 
 `OnboardingProvider` accepts `customComponents` prop to replace UI components while keeping SDK data flow.
 
 **Context**: `src/infra/provider/CustomComponentsContext.tsx` → `useCustomComponents()` hook
 
-**Customizable components**: `QuestionAnswerButton`, `QuestionAnswersList` (more can be added following the same pattern)
+**Customizable components**: `QuestionAnswerButton`, `QuestionAnswersList` (more can be added following same pattern)
 
 **Resolution order**: Custom List → Custom Button → Default implementation
 
@@ -167,11 +89,11 @@ const customComponents = useCustomComponents();
 const AnswersList = customComponents.QuestionAnswersList || DefaultQuestionAnswersList;
 ```
 
-**Adding new customizable components**: define props interface → create default implementation → add to `CustomComponents` interface → use in renderer → export from module.
+**Adding new customizable components**: define props interface → create default impl → add to `CustomComponents` interface → use in renderer → export from module.
 
 ## Theme Customization
 
-`OnboardingProvider` accepts `theme`, `lightTheme`, `darkTheme`, and `initialColorScheme` props.
+`OnboardingProvider` accepts `theme`, `lightTheme`, `darkTheme`, `initialColorScheme` props.
 
 ### Available Tokens
 
@@ -184,7 +106,7 @@ colors.surface.{ lowest..highest, opposite }
 colors.text.{ primary, secondary, tertiary, opposite, disable }
 
 // Typography
-typography.fontFamily.{ title, text, tagline }   // Names only; you must load fonts via expo-font
+typography.fontFamily.{ title, text, tagline }   // Names only; load fonts via expo-font
 typography.fontSize.{ xs, sm, md, lg, xl, "2xl", "3xl", "4xl" }
 typography.fontWeight.{ regular, medium, semibold, bold, extrabold }
 typography.lineHeight.{ tight, normal, relaxed }
@@ -195,7 +117,7 @@ typography.textStyles.{ heading1, heading2, heading3, body, bodyMedium, label, c
 ```typescript
 import { useTheme, getTextStyle } from "@rocapine/react-native-onboarding-ui";
 const { theme } = useTheme();
-// Use: theme.colors.*, theme.typography.textStyles.*, getTextStyle(theme, "heading1")
+// theme.colors.*, theme.typography.textStyles.*, getTextStyle(theme, "heading1")
 ```
 
 **Import default tokens for extension**:
@@ -205,20 +127,18 @@ import { lightTokens, darkTokens, typography } from "@rocapine/react-native-onbo
 
 ## Peer Dependencies
 
-The UI package has these **optional** peer dependencies (install only if using the feature):
-- `@react-native-picker/picker` — required by Picker step type
-- `@shopify/react-native-skia` — required by specific visual components
-- `expo-store-review` — required by Ratings step type
+UI package optional peer deps (install only if using feature):
+- `@react-native-picker/picker` — Picker step type
+- `@shopify/react-native-skia` — specific visual components
+- `expo-store-review` — Ratings step type
 
 ## Updating ComposableScreen UIElement Schema
 
-When adding or changing a `UIElement` type in either ComposableScreen `types.ts` file, **always**:
+When adding/changing a `UIElement` type in either ComposableScreen `types.ts`, **always**:
 
-1. **Update `packages/onboarding/src/onboarding-example.ts`** — add or update an example step that exercises the new/changed element type so the default onboarding stays in sync with the schema.
-
-2. **Update `example/app/example/composable-screen.tsx`** — add or update the element in the rendered example payload.
-
-3. **Display the following prompt for the `onboarding-studio` repository** (the CMS backend that must mirror these schema changes) after completing the changes:
+1. **Update `packages/onboarding/src/onboarding-example.ts`** — add/update example step exercising the new/changed element type so default onboarding stays in sync with schema.
+2. **Update `example/app/example/composable-screen.tsx`** — add/update element in rendered example payload.
+3. **Display this prompt for `onboarding-studio` repo** (CMS backend that must mirror schema changes):
 
 ```
 The ComposableScreen UIElement schema in the React Native SDK has been updated.
@@ -248,13 +168,3 @@ npm run publish:all
 cd packages/onboarding && npm run patch    # bump + build + publish
 cd packages/onboarding-ui && npm run patch # bump + build + publish
 ```
-
-## Example App
-
-Located in `example/`. Uses local packages via `"file:../packages/onboarding"` and `"file:../packages/onboarding-ui"`.
-
-- `app/example/` — Individual page type demos; registered in `app/example/index.tsx`
-- `app/onboarding/[questionId].tsx` — Full onboarding flow with real API
-- `app/onboarding_custom_screens/` — Custom component override demos
-- `app/_layout.tsx` — Root layout with `OnboardingProvider` setup
-- `components/` — Demo custom components (e.g., `MinimalAnswerButton`, `AnimatedAnswersList`)

--- a/example/app/_layout.tsx
+++ b/example/app/_layout.tsx
@@ -9,6 +9,7 @@ import * as SplashScreen from "expo-splash-screen";
 import { useEffect } from "react";
 import { OnboardingProgressProvider } from "@rocapine/react-native-onboarding-ui";
 import { Dimensions } from "react-native";
+import { LocaleProvider, useLocale } from "../contexts/locale-context";
 
 // Keep splash screen visible while fonts load
 SplashScreen.preventAutoHideAsync();
@@ -41,9 +42,18 @@ export default function RootLayout() {
   }
 
   return (
+    <LocaleProvider>
+      <OnboardingProviderWithLocale />
+    </LocaleProvider>
+  );
+}
+
+function OnboardingProviderWithLocale() {
+  const { locale } = useLocale();
+  return (
     <OnboardingProvider
       client={client}
-      locale="en"
+      locale={locale}
       customAudienceParams={{
       }}
       customActions={{

--- a/example/app/index.tsx
+++ b/example/app/index.tsx
@@ -2,6 +2,7 @@ import { View, Text, StyleSheet, Pressable } from "react-native";
 import { useRouter } from "expo-router";
 import { useOnboarding } from "@rocapine/react-native-onboarding";
 import { useTheme } from "@rocapine/react-native-onboarding-ui";
+import { SUPPORTED_LOCALES, useLocale } from "../contexts/locale-context";
 
 export const unstable_settings = {
   anchor: "(tabs)",
@@ -11,6 +12,7 @@ export default function RootLayout() {
   const router = useRouter();
   const { theme, colorScheme, toggleTheme } = useTheme();
   const { } = useOnboarding();
+  const { locale, setLocale } = useLocale();
 
   const handleStartOnboarding = () => {
     router.push("/onboarding/1");
@@ -24,6 +26,34 @@ export default function RootLayout() {
 
       <Text style={[styles.title, { color: theme.colors.text.primary }]}>Welcome to Onboarding</Text>
       <Text style={[styles.subtitle, { color: theme.colors.text.secondary }]}>Get started with your journey</Text>
+
+      <View style={styles.localeRow}>
+        {SUPPORTED_LOCALES.map((loc) => {
+          const active = loc === locale;
+          return (
+            <Pressable
+              key={loc}
+              onPress={() => setLocale(loc)}
+              style={[
+                styles.localeChip,
+                {
+                  backgroundColor: active ? theme.colors.primary : "transparent",
+                  borderColor: active ? theme.colors.primary : theme.colors.neutral.medium,
+                },
+              ]}
+            >
+              <Text
+                style={[
+                  styles.localeChipText,
+                  { color: active ? theme.colors.text.opposite : theme.colors.text.primary },
+                ]}
+              >
+                {loc.toUpperCase()}
+              </Text>
+            </Pressable>
+          );
+        })}
+      </View>
 
       <Pressable style={[styles.button, { backgroundColor: theme.colors.primary }]} onPress={handleStartOnboarding}>
         <Text style={[styles.buttonText, { color: theme.colors.text.opposite }]}>Start the onboarding</Text>
@@ -69,8 +99,25 @@ const styles = StyleSheet.create({
   },
   subtitle: {
     fontSize: 16,
-    marginBottom: 40,
+    marginBottom: 24,
     textAlign: "center",
+  },
+  localeRow: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    justifyContent: "center",
+    gap: 8,
+    marginBottom: 32,
+  },
+  localeChip: {
+    paddingHorizontal: 14,
+    paddingVertical: 8,
+    borderRadius: 999,
+    borderWidth: 1,
+  },
+  localeChipText: {
+    fontSize: 14,
+    fontWeight: "600",
   },
   button: {
     paddingHorizontal: 30,

--- a/example/app/onboarding/[questionId].tsx
+++ b/example/app/onboarding/[questionId].tsx
@@ -17,21 +17,20 @@ export default function QuestionPage() {
     stepNumber: parseInt(questionId as string, 10),
   });
 
-  const { variables, setVariable } = useContext(OnboardingProgressContext);
+  const { setVariable, getVariables } = useContext(OnboardingProgressContext);
   const router = useRouter();
 
   const onContinue = (value?: any) => {
     const variableName = (step as any).variableName as string | undefined;
 
-    // Build updated vars synchronously — setVariable is async (state update)
-    const updatedVars =
-      variableName && value !== undefined
-        ? { ...variables, [variableName]: value }
-        : variables;
-
     if (variableName && value !== undefined) {
       setVariable(variableName, value);
     }
+
+    const updatedVars =
+      variableName && value !== undefined
+        ? { ...getVariables(), [variableName]: value }
+        : getVariables();
 
     const nextNumber = resolveNextStepNumber(step, updatedVars, steps);
     if (nextNumber === null) {

--- a/example/contexts/locale-context.tsx
+++ b/example/contexts/locale-context.tsx
@@ -1,0 +1,32 @@
+import { createContext, useContext, useState, type ReactNode } from "react";
+
+export const SUPPORTED_LOCALES = ["en", "fr", "es", "de", "it"] as const;
+export type Locale = (typeof SUPPORTED_LOCALES)[number];
+
+type LocaleContextValue = {
+  locale: Locale;
+  setLocale: (locale: Locale) => void;
+};
+
+const LocaleContext = createContext<LocaleContextValue | null>(null);
+
+export function LocaleProvider({
+  children,
+  initialLocale = "en",
+}: {
+  children: ReactNode;
+  initialLocale?: Locale;
+}) {
+  const [locale, setLocale] = useState<Locale>(initialLocale);
+  return (
+    <LocaleContext.Provider value={{ locale, setLocale }}>
+      {children}
+    </LocaleContext.Provider>
+  );
+}
+
+export function useLocale() {
+  const ctx = useContext(LocaleContext);
+  if (!ctx) throw new Error("useLocale must be used within LocaleProvider");
+  return ctx;
+}

--- a/packages/onboarding-ui/CHANGELOG.md
+++ b/packages/onboarding-ui/CHANGELOG.md
@@ -7,6 +7,10 @@ here.
 
 ## [Unreleased]
 
+---
+
+## [1.18.0] - 2026-05-06
+
 ### Added
 
 - **`fontStyle` rendering** on `TextElement`, `ButtonElement`,
@@ -14,6 +18,12 @@ here.
   `CheckboxGroupElement` (`itemFontStyle`). Renderers pass the value through
   to the underlying `<Text>` / `<TextInput>` style, alongside `fontFamily` and
   `fontWeight`.
+- **`setVariable` `Button` action** — `ButtonElement` handles a new action
+  variant `{ type: "setVariable", name, value, label? }`. The handler writes
+  to the ComposableScreen variable map (and syncs the headless variable map)
+  before any subsequent action in the chain runs, so a following
+  `"continue"` sees the updated value when `resolveNextStepNumber` evaluates
+  branch conditions.
 
 ### Changed
 

--- a/packages/onboarding-ui/package.json
+++ b/packages/onboarding-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocapine/react-native-onboarding-ui",
-  "version": "1.17.1",
+  "version": "1.18.0",
   "description": "UI components and renderers for Rocapine Onboarding Studio - Built on top of the headless SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/ButtonElement.tsx
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/ButtonElement.tsx
@@ -20,11 +20,26 @@ export const CustomButtonActionSchema = z.object({
   variables: z.array(z.string()).optional(),
 });
 
-export type ButtonAction = "continue" | CustomButtonAction;
+export type SetVariableButtonAction = {
+  type: "setVariable";
+  name: string;
+  value: string;
+  label?: string;
+};
+
+export const SetVariableButtonActionSchema = z.object({
+  type: z.literal("setVariable"),
+  name: z.string().min(1, "name must not be empty"),
+  value: z.string(),
+  label: z.string().optional(),
+});
+
+export type ButtonAction = "continue" | CustomButtonAction | SetVariableButtonAction;
 
 export const ButtonActionSchema = z.union([
   z.literal("continue"),
   CustomButtonActionSchema,
+  SetVariableButtonActionSchema,
 ]);
 
 export type ButtonElementProps = BaseBoxProps & {
@@ -68,7 +83,7 @@ type Props = {
 };
 
 export const ButtonElementComponent = ({ element, ctx }: Props): React.ReactElement => {
-  const { theme, onContinue, customActions, variables } = ctx;
+  const { theme, onContinue, customActions, variables, setVariable } = ctx;
   const handlePress = async () => {
     const { actions, action } = element.props;
     const effective: ButtonAction[] =
@@ -78,6 +93,10 @@ export const ButtonElementComponent = ({ element, ctx }: Props): React.ReactElem
       if (act === "continue") {
         onContinue();
         return;
+      }
+      if (act.type === "setVariable") {
+        setVariable(act.name, { value: act.value, label: act.label });
+        continue;
       }
       const handler = customActions[act.function];
       if (!handler) {

--- a/packages/onboarding/CHANGELOG.md
+++ b/packages/onboarding/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to `@rocapine/react-native-onboarding` are documented here.
 
 ## [Unreleased]
 
+---
+
+## [1.18.0] - 2026-05-06
+
 ### Added
 
 - **`fontStyle: "normal" | "italic"`** on Text-rendering ComposableScreen
@@ -13,11 +17,29 @@ All notable changes to `@rocapine/react-native-onboarding` are documented here.
   `InputElementProps`. Per-item prop `itemFontStyle` on
   `RadioGroupElementProps` and `CheckboxGroupElementProps`. All optional;
   Zod-validated as `z.enum(["normal", "italic"]).optional()`.
+- **`setVariable` button action** — `Button.actions` accepts a new entry
+  `{ type: "setVariable", name: string, value: string, label?: string }`
+  that writes directly into the variable map. Useful to capture which
+  branch a user chose before `"continue"` triggers `resolveNextStepNumber`.
+  Stored shape matches existing element writes (`{ value, label }`).
+- **`OnboardingProgressContext.getVariables()`** — synchronous getter that
+  returns the latest variable snapshot from a ref. Use it inside
+  `onContinue` handlers to feed `resolveNextStepNumber` with values just
+  written by `setVariable`, since React state reads are stale within the
+  same tick.
+
+### Fixed
+
+- **Branching with same-tick `setVariable` + `continue`** — variables were
+  read from React state in the handler that just wrote them, so branch
+  conditions evaluated against pre-set values and fell through to the
+  default target. `setVariable` now updates a ref synchronously alongside
+  the state setter; `getVariables()` exposes the fresh snapshot.
 
 > **Backend note:** The `onboarding-studio` server must mirror the new
 > `fontStyle` (and `itemFontStyle` for RadioGroup/CheckboxGroup) field on the
-> affected UIElement schemas and expose it in the CMS editor wherever
-> `fontWeight`/`fontFamily` are configurable.
+> affected UIElement schemas, and the new `setVariable` button action variant
+> in the `ButtonAction` union and CMS editor.
 
 ---
 

--- a/packages/onboarding/package.json
+++ b/packages/onboarding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocapine/react-native-onboarding",
-  "version": "1.17.1",
+  "version": "1.18.0",
   "description": "Headless React Native SDK for Rocapine Onboarding Studio - Data fetching, state management, and hooks",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/onboarding/src/infra/provider/OnboardingProvider.tsx
+++ b/packages/onboarding/src/infra/provider/OnboardingProvider.tsx
@@ -1,4 +1,4 @@
-import { createContext, useCallback, useState } from "react";
+import { createContext, useCallback, useRef, useState } from "react";
 import { QueryClient, QueryClientProvider, useQuery } from "@tanstack/react-query";
 import { OnboardingStudioClient } from "../../OnboardingStudioClient";
 import { getOnboardingQuery } from "../queries/getOnboarding.query";
@@ -87,9 +87,12 @@ export const OnboardingProvider = ({
   const [totalSteps, setTotalSteps] = useState(0);
   const [onboarding, setOnboarding] = useState<Onboarding<OnboardingStepType> | null>(null);
   const [variables, setVariables] = useState<Record<string, any>>({});
+  const variablesRef = useRef<Record<string, any>>(variables);
   const setVariable = useCallback((name: string, value: any) => {
-    setVariables((prev) => ({ ...prev, [name]: value }));
+    variablesRef.current = { ...variablesRef.current, [name]: value };
+    setVariables(variablesRef.current);
   }, []);
+  const getVariables = useCallback(() => variablesRef.current, []);
 
   return (
     <QueryClientProvider client={queryClient}>
@@ -106,6 +109,7 @@ export const OnboardingProvider = ({
           setOnboarding,
           variables,
           setVariable,
+          getVariables,
           customActions,
         }}
       >
@@ -135,6 +139,7 @@ export const OnboardingProgressContext = createContext<{
   setOnboarding: (onboarding: Onboarding<OnboardingStepType>) => void;
   variables: Record<string, any>;
   setVariable: (name: string, value: any) => void;
+  getVariables: () => Record<string, any>;
   customActions: CustomActions;
 }>({
   activeStep: { number: 0, displayProgressHeader: false },
@@ -148,5 +153,6 @@ export const OnboardingProgressContext = createContext<{
   setOnboarding: () => { },
   variables: {},
   setVariable: () => { },
+  getVariables: () => ({}),
   customActions: {},
 });

--- a/website/docs/customization/custom-actions.mdx
+++ b/website/docs/customization/custom-actions.mdx
@@ -12,6 +12,7 @@ Each `Button` element in a `ComposableScreen` carries an ordered `actions` array
 
 - `"continue"` — advances the onboarding (terminal — anything after is ignored).
 - `{ type: "custom", function: "<name>", variables?: ["<key>", ...] }` — invokes a handler you registered on `OnboardingProvider.customActions`. Listed variables are read from the live ComposableScreen variable map and forwarded to the handler.
+- `{ type: "setVariable", name: "<key>", value: "<value>", label?: "<label>" }` — writes directly to the variable map (`{ value, label }` shape, matching `Input` / `RadioGroup` / `CheckboxGroup` / `DatePicker`). Useful to capture which branch a user chose before a following `"continue"` triggers `resolveNextStepNumber`.
 
 Handlers may be async — the chain awaits each `Promise` before proceeding.
 
@@ -20,7 +21,8 @@ Handlers may be async — the chain awaits each `Promise` before proceeding.
 ```typescript
 type ButtonAction =
   | "continue"
-  | { type: "custom"; function: string; variables?: string[] };
+  | { type: "custom"; function: string; variables?: string[] }
+  | { type: "setVariable"; name: string; value: string; label?: string };
 ```
 
 ```jsonc
@@ -166,6 +168,19 @@ customActions={{
   "actions": [
     { "type": "custom", "function": "trackCta" },
     { "type": "custom", "function": "syncProfile", "variables": ["name", "plan"] },
+    "continue"
+  ]
+}
+```
+
+### Branch on a button-chosen value
+
+Pair `setVariable` with `"continue"` to set a discriminator a downstream `nextStep` rule can branch on. The handler reads from a ref under the hood, so the branch evaluation in the same tick sees the value just written.
+
+```jsonc
+{
+  "actions": [
+    { "type": "setVariable", "name": "plan", "value": "monthly", "label": "Monthly" },
     "continue"
   ]
 }

--- a/website/docs/page-types.mdx
+++ b/website/docs/page-types.mdx
@@ -643,6 +643,7 @@ As of 1.15.0, `OnboardingTemplate` does not apply safe-area insets. Built-in pag
 
 - `"continue"` — advances to the next onboarding step (calls the `onContinue` callback wired to the renderer).
 - `{ type: "custom", function: string, variables?: string[] }` — invokes a developer-injected handler registered on `OnboardingProvider.customActions`. `variables` lists the keys to read from the live ComposableScreen variable map and forward to the handler.
+- `{ type: "setVariable", name: string, value: string, label?: string }` — writes to the variable map (`{ value, label }`). Pair with `"continue"` to set a discriminator a downstream `nextStep` rule can branch on; the value is visible to the same-tick branch evaluation.
 
 Execution rules:
 


### PR DESCRIPTION
## Summary
- Bump `@rocapine/react-native-onboarding` and `@rocapine/react-native-onboarding-ui` to **1.18.0**
- New `Button.actions` variant `{ type: \"setVariable\", name, value, label? }` writes directly to the variable map
- Fix branching: `OnboardingProvider` now backs variables with a ref + exposes `getVariables()` so same-tick `setVariable` + `continue` evaluates branch conditions against the post-set snapshot (previously read stale React state and fell through to default target)
- Roll up the existing `Unreleased` entries (`fontStyle` on typography elements) into the 1.18.0 changelog
- Document the new action variant in `website/docs/customization/custom-actions.mdx` and `website/docs/page-types.mdx`
- Example app: locale picker on the home screen via a new `LocaleProvider`

## Backend mirror (onboarding-studio)
The CMS must add the `setVariable` variant to its `ButtonAction` union, the matching Zod schema (`{ type: "setVariable", name: string (non-empty), value: string, label?: string }`), and surface the new variant in the action-picker UI.

## Test plan
- [ ] `npm run build` builds both SDK packages cleanly at 1.18.0
- [ ] Example app: ComposableScreen with a Button whose `actions` is `[{ type: "setVariable", name: "plan", value: "monthly" }, "continue"]` and a `nextStep` branch on `plan == "monthly"` routes to the matching target (not the default fallback)
- [ ] Existing `"continue"` and `{ type: "custom", ... }` actions still work and run in declared order
- [ ] Branching from Question step (`onContinue(value)`) still resolves correctly via `getVariables()` merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added language/locale selection support to example app
  * Introduced "setVariable" button action to capture user input before navigation
  * Added font styling (italic/normal) support for text, buttons, and input elements
  * Added method to access current variables during onboarding navigation

* **Bug Fixes**
  * Improved font weight resolution
  * Fixed carousel sizing issues
  * Enhanced error handling and variable state consistency during branching

* **Documentation**
  * Expanded guides for runtime rules, page renderers, and custom components
  * Added publishing workflow and schema update instructions
  * New examples for button actions and variable-based branching

* **Chores**
  * Version bumped to 1.18.0 for both packages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->