### PR TITLE
feat(composable-screen): conditional button disable (v1.20.0)

### DIFF
--- a/.claude/rules/composable-screen-runtime.md
+++ b/.claude/rules/composable-screen-runtime.md
@@ -36,3 +36,16 @@ const f = useResolvedFontStyle(props.fontFamily, props.fontWeight);
 `f.resolvedToVariant === true` → registry matched concrete weighted variant (e.g. `Inter-700`); **suppress `fontWeight`** or iOS/Android applies synthetic emboldening on top of already-weighted font file.
 
 Use legacy `useResolvedFontFamily` only for elements that never set `fontWeight`.
+
+## RenderContext variables → primitive flattening
+
+`ctx.variables` is `Record<string, ComposableVariableEntry>` (each entry `{value, label?}`). Headless utils that expect primitive variables (`evaluateCondition`, `evaluateLeaf`, `resolveNextStepNumber`) want `Record<string, unknown>`. Flatten before calling:
+
+```ts
+const flatVars = useMemo(
+  () => Object.fromEntries(Object.entries(variables).map(([k, v]) => [k, v?.value])),
+  [variables]
+);
+```
+
+Skip the flatten and your condition reads the entry object, not its value — every `eq`/`neq` silently mis-evaluates.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ UI package depends on headless package as peer dependency.
 ### Root (Monorepo)
 
 ```bash
-npm run build              # Build both packages
+npm run build              # Build both packages (trailing "Missing script: build" for `example` workspace is expected — both packages still build)
 npm run build:headless     # packages/onboarding only
 npm run build:ui           # packages/onboarding-ui only (also copies src/assets → dist/assets)
 npm run watch:headless     # Watch mode for headless
@@ -138,7 +138,8 @@ When adding/changing a `UIElement` type in either ComposableScreen `types.ts`, *
 
 1. **Update `packages/onboarding/src/onboarding-example.ts`** — add/update example step exercising the new/changed element type so default onboarding stays in sync with schema.
 2. **Update `example/app/example/composable-screen.tsx`** — add/update element in rendered example payload.
-3. **Display this prompt for `onboarding-studio` repo** (CMS backend that must mirror schema changes):
+3. **Watch for schema duplication in UI renderers.** Some UI element renderers (notably `Pages/ComposableScreen/elements/ButtonElement.tsx`) re-declare their Zod schemas + `*Props` type in lockstep with the headless source. When changing headless `elements/*.ts`, search the UI mirror file for the same field and update it too — TS won't catch the drift because the UI re-declares its own type.
+4. **Display this prompt for `onboarding-studio` repo** (CMS backend that must mirror schema changes):
 
 ```
 The ComposableScreen UIElement schema in the React Native SDK has been updated.

--- a/example/app/example/composable-screen.tsx
+++ b/example/app/example/composable-screen.tsx
@@ -523,6 +523,34 @@ export default function ComposableScreenExample() {
                 },
               },
             },
+            // Disable-on-condition demo: gated continue + a setVariable companion.
+            {
+              id: 'consent-toggle',
+              type: 'Button' as const,
+              props: {
+                label: 'I agree to the terms',
+                variant: 'outlined' as const,
+                marginVertical: 8,
+                actions: [
+                  { type: 'setVariable' as const, name: 'consent_given', value: 'yes', label: 'Agreed' },
+                ],
+              },
+            },
+            {
+              id: 'gated-continue',
+              type: 'Button' as const,
+              props: {
+                label: 'Continue (gated)',
+                variant: 'filled' as const,
+                marginVertical: 4,
+                actions: ['continue' as const],
+                disabledWhen: {
+                  variable: 'consent_given',
+                  operator: 'neq' as const,
+                  value: 'yes',
+                },
+              },
+            },
             // Gradient horizontal band
             {
               id: 'gradient-band',

--- a/packages/onboarding-ui/CHANGELOG.md
+++ b/packages/onboarding-ui/CHANGELOG.md
@@ -9,6 +9,22 @@ here.
 
 ---
 
+## [1.20.0] - 2026-05-11
+
+### Added
+
+- **Disabled-state support on ComposableScreen `Button` renderer** — the
+  renderer now reads `disabledWhen`, `disabledBackgroundColor`, and
+  `disabledColor` from `ButtonElementProps`. When the condition evaluates
+  truthy against `ctx.variables` (flattened to primitive values), the
+  `TouchableOpacity` is disabled and the button renders with the disable
+  color tokens (`theme.colors.disable`, `theme.colors.text.disable`) or
+  the per-button overrides. Filled buttons with a `backgroundGradient`
+  drop the gradient in the disabled state for a clearer affordance;
+  outlined buttons swap the border to the disable color.
+
+---
+
 ## [1.19.0] - 2026-05-07
 
 ### Added

--- a/packages/onboarding-ui/package.json
+++ b/packages/onboarding-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocapine/react-native-onboarding-ui",
-  "version": "1.19.0",
+  "version": "1.20.0",
   "description": "UI components and renderers for Rocapine Onboarding Studio - Built on top of the headless SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/ButtonElement.tsx
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/ButtonElement.tsx
@@ -1,7 +1,14 @@
-import React from "react";
+import React, { useMemo } from "react";
 import { z } from "zod";
 import { Text, TouchableOpacity } from "react-native";
-import { useResolvedFontStyle } from "@rocapine/react-native-onboarding";
+import {
+  useResolvedFontStyle,
+  evaluateCondition,
+  type LeafCondition,
+  type ConditionGroup,
+  LeafConditionSchema,
+  ConditionGroupSchema,
+} from "@rocapine/react-native-onboarding";
 import { BaseBoxProps, BaseBoxPropsSchema } from "./BaseBoxProps";
 import { UIElement } from "../types";
 import { RenderContext, dim, resolveInheritedFontFamily } from "./shared";
@@ -59,6 +66,9 @@ export type ButtonElementProps = BaseBoxProps & {
   fontFamily?: string | "inherit";
   fontStyle?: "normal" | "italic";
   textAlign?: "left" | "center" | "right";
+  disabledWhen?: LeafCondition | ConditionGroup;
+  disabledBackgroundColor?: string;
+  disabledColor?: string;
 };
 
 export const ButtonElementPropsSchema = BaseBoxPropsSchema.extend({
@@ -73,6 +83,9 @@ export const ButtonElementPropsSchema = BaseBoxPropsSchema.extend({
   fontFamily: z.string().optional(),
   fontStyle: z.enum(["normal", "italic"]).optional(),
   textAlign: z.enum(["left", "center", "right"]).optional(),
+  disabledWhen: z.union([LeafConditionSchema, ConditionGroupSchema]).optional(),
+  disabledBackgroundColor: z.string().optional(),
+  disabledColor: z.string().optional(),
 });
 
 type ButtonUIElement = Extract<UIElement, { type: "Button" }>;
@@ -84,7 +97,18 @@ type Props = {
 
 export const ButtonElementComponent = ({ element, ctx }: Props): React.ReactElement => {
   const { theme, onContinue, customActions, variables, setVariable } = ctx;
+  const flatVariables = useMemo(
+    () =>
+      Object.fromEntries(
+        Object.entries(variables).map(([k, v]) => [k, v?.value])
+      ),
+    [variables]
+  );
+  const isDisabled = element.props.disabledWhen
+    ? evaluateCondition(element.props.disabledWhen, flatVariables)
+    : false;
   const handlePress = async () => {
+    if (isDisabled) return;
     const { actions, action } = element.props;
     const effective: ButtonAction[] =
       actions ?? (action === "continue" ? ["continue"] : []);
@@ -122,14 +146,27 @@ export const ButtonElementComponent = ({ element, ctx }: Props): React.ReactElem
   const variant = element.props.variant ?? "filled";
   const isFilled = variant === "filled";
   const isOutlined = variant === "outlined";
-  const bgColor = isFilled
-    ? (element.props.backgroundColor ?? theme.colors.primary)
-    : "transparent";
-  const textColor = isFilled
-    ? (element.props.color ?? theme.colors.text.opposite)
-    : (element.props.color ?? theme.colors.primary);
+  const disabledBg =
+    element.props.disabledBackgroundColor ?? theme.colors.disable;
+  const disabledText =
+    element.props.disabledColor ?? theme.colors.text.disable;
+  const bgColor = isDisabled
+    ? isFilled
+      ? disabledBg
+      : "transparent"
+    : isFilled
+      ? (element.props.backgroundColor ?? theme.colors.primary)
+      : "transparent";
+  const textColor = isDisabled
+    ? disabledText
+    : isFilled
+      ? (element.props.color ?? theme.colors.text.opposite)
+      : (element.props.color ?? theme.colors.primary);
+  const outlinedBorderColor = isDisabled
+    ? disabledBg
+    : (element.props.borderColor ?? theme.colors.primary);
 
-  const hasGradient = isFilled && !!element.props.backgroundGradient;
+  const hasGradient = isFilled && !isDisabled && !!element.props.backgroundGradient;
   const borderRadius = element.props.borderRadius ?? 90;
   const inheritedFontFamily = resolveInheritedFontFamily(
     element.props.fontFamily,
@@ -164,7 +201,7 @@ export const ButtonElementComponent = ({ element, ctx }: Props): React.ReactElem
         style={{
           borderRadius,
           borderWidth: isOutlined ? (element.props.borderWidth ?? 1) : (element.props.borderWidth ?? 0),
-          borderColor: isOutlined ? (element.props.borderColor ?? theme.colors.primary) : element.props.borderColor,
+          borderColor: isOutlined ? outlinedBorderColor : element.props.borderColor,
           width: dim(element.props.width),
           height: dim(element.props.height),
           margin: element.props.margin,
@@ -178,6 +215,7 @@ export const ButtonElementComponent = ({ element, ctx }: Props): React.ReactElem
         <TouchableOpacity
           activeOpacity={0.8}
           onPress={handlePress}
+          disabled={isDisabled}
           style={{
             flex: 1,
             padding: element.props.padding,
@@ -197,11 +235,12 @@ export const ButtonElementComponent = ({ element, ctx }: Props): React.ReactElem
     <TouchableOpacity
       activeOpacity={0.8}
       onPress={handlePress}
+      disabled={isDisabled}
       style={{
         backgroundColor: bgColor,
         borderRadius,
         borderWidth: isOutlined ? (element.props.borderWidth ?? 1) : (element.props.borderWidth ?? 0),
-        borderColor: isOutlined ? (element.props.borderColor ?? theme.colors.primary) : element.props.borderColor,
+        borderColor: isOutlined ? outlinedBorderColor : element.props.borderColor,
         padding: element.props.padding,
         paddingVertical: element.props.paddingVertical ?? 14,
         paddingHorizontal: element.props.paddingHorizontal ?? 24,

--- a/packages/onboarding/CHANGELOG.md
+++ b/packages/onboarding/CHANGELOG.md
@@ -8,6 +8,29 @@ All notable changes to `@rocapine/react-native-onboarding` are documented here.
 
 ---
 
+## [1.20.0] - 2026-05-11
+
+### Added
+
+- **`disabledWhen` on ComposableScreen `Button`** — new optional prop on
+  `ButtonElementProps` accepting a `LeafCondition | ConditionGroup` (the
+  same schema used by `Branch.condition`). When the condition evaluates
+  truthy against current onboarding variables, the button blocks all
+  press actions (continue, setVariable, custom) and renders in a disabled
+  visual style.
+- **`disabledBackgroundColor` and `disabledColor` on `Button`** — optional
+  per-button overrides for the disabled-state colors. Defaults fall back to
+  `theme.colors.disable` and `theme.colors.text.disable`.
+- **`evaluateCondition`, `evaluateLeaf`, `isConditionGroup`, `Condition`**
+  now exported from the package root so UI code (and host apps) can reuse
+  the same condition runtime that powers branching.
+
+> **Backend note:** `onboarding-studio` should mirror these `Button`
+> schema fields and reuse the existing condition-builder UI from the
+> `Branch.condition` editor.
+
+---
+
 ## [1.19.0] - 2026-05-07
 
 ### Added

--- a/packages/onboarding/package.json
+++ b/packages/onboarding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocapine/react-native-onboarding",
-  "version": "1.19.0",
+  "version": "1.20.0",
   "description": "Headless React Native SDK for Rocapine Onboarding Studio - Data fetching, state management, and hooks",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/onboarding/src/index.ts
+++ b/packages/onboarding/src/index.ts
@@ -16,6 +16,8 @@ export {
 export * from "./infra";
 // Branching
 export { resolveNextStepNumber } from "./resolveNextStepNumber";
+export { evaluateCondition, evaluateLeaf, isConditionGroup } from "./evaluateCondition";
+export type { Condition } from "./evaluateCondition";
 export type {
   LeafCondition,
   ConditionGroup,

--- a/packages/onboarding/src/onboarding-example.ts
+++ b/packages/onboarding/src/onboarding-example.ts
@@ -475,6 +475,33 @@ export const onboardingExample = {
                   },
                 },
               },
+              {
+                id: "consent-toggle",
+                type: "Button",
+                props: {
+                  label: "I agree to the terms",
+                  variant: "outlined",
+                  marginVertical: 8,
+                  actions: [
+                    { type: "setVariable", name: "consent_given", value: "yes", label: "Agreed" },
+                  ],
+                },
+              },
+              {
+                id: "gated-continue",
+                type: "Button",
+                props: {
+                  label: "Continue (gated)",
+                  variant: "filled",
+                  marginVertical: 4,
+                  actions: ["continue"],
+                  disabledWhen: {
+                    variable: "consent_given",
+                    operator: "neq",
+                    value: "yes",
+                  },
+                },
+              },
             ],
           },
             ],

--- a/packages/onboarding/src/steps/ComposableScreen/elements/ButtonElement.ts
+++ b/packages/onboarding/src/steps/ComposableScreen/elements/ButtonElement.ts
@@ -1,5 +1,11 @@
 import { z } from "zod";
 import { BaseBoxProps, BaseBoxPropsSchema } from "./BaseBoxProps";
+import {
+  type LeafCondition,
+  type ConditionGroup,
+  LeafConditionSchema,
+  ConditionGroupSchema,
+} from "../../common.types";
 
 export type CustomButtonAction = {
   type: "custom";
@@ -44,6 +50,16 @@ export type ButtonElementProps = BaseBoxProps & {
   fontFamily?: string | "inherit";
   fontStyle?: "normal" | "italic";
   textAlign?: "left" | "center" | "right";
+  /**
+   * When the condition evaluates truthy against current onboarding variables,
+   * the button blocks all press actions and renders in a disabled style. Uses
+   * the same condition schema as `Branch.condition`.
+   */
+  disabledWhen?: LeafCondition | ConditionGroup;
+  /** Override background color in the disabled state (filled variant). Defaults to `theme.colors.disable`. */
+  disabledBackgroundColor?: string;
+  /** Override text color in the disabled state. Defaults to `theme.colors.text.disable`. */
+  disabledColor?: string;
 };
 
 export const ButtonElementPropsSchema = BaseBoxPropsSchema.extend({
@@ -58,4 +74,7 @@ export const ButtonElementPropsSchema = BaseBoxPropsSchema.extend({
   fontFamily: z.string().optional(),
   fontStyle: z.enum(["normal", "italic"]).optional(),
   textAlign: z.enum(["left", "center", "right"]).optional(),
+  disabledWhen: z.union([LeafConditionSchema, ConditionGroupSchema]).optional(),
+  disabledBackgroundColor: z.string().optional(),
+  disabledColor: z.string().optional(),
 });


### PR DESCRIPTION
## Summary

- Add optional `disabledWhen: LeafCondition | ConditionGroup` to ComposableScreen `Button` — reuses the same condition schema as `Branch.condition`. When truthy against current onboarding variables, the button blocks all press actions (continue, setVariable, custom) and renders disabled.
- Disabled visuals fall back to `theme.colors.disable` / `theme.colors.text.disable`; per-button overrides via `disabledBackgroundColor` / `disabledColor`. Gradient drops in the disabled state; outlined border swaps to disable color.
- Export `evaluateCondition` / `evaluateLeaf` / `isConditionGroup` / `Condition` from headless package root so UI shares the routing condition runtime.
- Demo pair (`consent-toggle` + `gated-continue`) added to `onboarding-example.ts` and `example/app/example/composable-screen.tsx`.
- Both packages bumped to `1.20.0` with CHANGELOG entries.

## Test plan

- [x] `npm run build` — both packages compile clean
- [x] `npm test -w @rocapine/react-native-onboarding` — 75/75 pass (evaluateCondition coverage unchanged)
- [x] `npm run type:check` in `example/` — clean
- [ ] Manual: load example ComposableScreen demo, confirm `Continue (gated)` button renders with disable tokens and is non-interactive until `I agree to the terms` is tapped
- [ ] Manual: override `disabledBackgroundColor` on a button → confirm override beats theme token
- [ ] Manual: confirm gradient button drops gradient when disabled

## Backend follow-up

`onboarding-studio` must mirror the schema: add `disabledWhen` / `disabledBackgroundColor` / `disabledColor` to its Button props (type + Zod) and reuse the existing `Branch.condition` editor UI for `disabledWhen`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes v1.20.0

* **New Features**
  * Buttons now support conditional disabling via `disabledWhen` based on variable conditions
  * Customizable disabled button styling with `disabledBackgroundColor` and `disabledColor` options
  * Enables gated workflows such as requiring consent before proceeding

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Rocapine/react-native-onboarding/pull/47)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->