### PR TITLE
feat(composable-screen): carousel defaultIndex + variableName (v1.21.0)

### DIFF
--- a/example/app/example/composable-screen-carousel.tsx
+++ b/example/app/example/composable-screen-carousel.tsx
@@ -164,6 +164,78 @@ export default function ComposableScreenCarouselExample() {
               ],
             },
             {
+              id: 'variable-bound-label',
+              type: 'Text',
+              props: { content: 'variable-bound (defaultIndex + variableName)', fontSize: 13, fontWeight: '600', opacity: 0.5 },
+            },
+            {
+              id: 'carousel-variable-bound',
+              type: 'Carousel' as const,
+              props: {
+                carouselType: 'normal' as const,
+                autoPlay: false,
+                loop: false,
+                showDots: true,
+                height: 160,
+                borderRadius: 12,
+                defaultIndex: 0,
+                variableName: 'carouselPage',
+              },
+              children: [
+                { id: 'vb-slide-1', type: 'Image' as const, props: { url: 'https://picsum.photos/400/160?random=21', height: 160, resizeMode: 'cover' as const } },
+                { id: 'vb-slide-2', type: 'Image' as const, props: { url: 'https://picsum.photos/400/160?random=22', height: 160, resizeMode: 'cover' as const } },
+                { id: 'vb-slide-3', type: 'Image' as const, props: { url: 'https://picsum.photos/400/160?random=23', height: 160, resizeMode: 'cover' as const } },
+              ],
+            },
+            {
+              id: 'variable-bound-page',
+              type: 'Text' as const,
+              props: {
+                content: 'Current page: {{carouselPage}}',
+                mode: 'expression' as const,
+                fontSize: 14,
+                textAlign: 'center' as const,
+                opacity: 0.6,
+              },
+            },
+            {
+              id: 'variable-bound-controls',
+              type: 'XStack' as const,
+              props: { gap: 8 },
+              children: [
+                {
+                  id: 'vb-go-first',
+                  type: 'Button' as const,
+                  props: {
+                    label: 'First',
+                    variant: 'outlined' as const,
+                    flex: 1,
+                    actions: [{ type: 'setVariable' as const, name: 'carouselPage', value: '0' }],
+                  },
+                },
+                {
+                  id: 'vb-go-middle',
+                  type: 'Button' as const,
+                  props: {
+                    label: 'Middle',
+                    variant: 'outlined' as const,
+                    flex: 1,
+                    actions: [{ type: 'setVariable' as const, name: 'carouselPage', value: '1' }],
+                  },
+                },
+                {
+                  id: 'vb-go-last',
+                  type: 'Button' as const,
+                  props: {
+                    label: 'Last',
+                    variant: 'outlined' as const,
+                    flex: 1,
+                    actions: [{ type: 'setVariable' as const, name: 'carouselPage', value: '2' }],
+                  },
+                },
+              ],
+            },
+            {
               id: 'rive-label',
               type: 'Text',
               props: { content: 'rive slides', fontSize: 13, fontWeight: '600', opacity: 0.5 },

--- a/example/app/example/composable-screen-carousel.tsx
+++ b/example/app/example/composable-screen-carousel.tsx
@@ -204,33 +204,49 @@ export default function ComposableScreenCarouselExample() {
               props: { gap: 8 },
               children: [
                 {
-                  id: 'vb-go-first',
+                  id: 'vb-go-prev',
                   type: 'Button' as const,
                   props: {
-                    label: 'First',
+                    label: 'Prev (expr)',
                     variant: 'outlined' as const,
                     flex: 1,
-                    actions: [{ type: 'setVariable' as const, name: 'carouselPage', value: '0' }],
-                  },
-                },
-                {
-                  id: 'vb-go-middle',
-                  type: 'Button' as const,
-                  props: {
-                    label: 'Middle',
-                    variant: 'outlined' as const,
-                    flex: 1,
-                    actions: [{ type: 'setVariable' as const, name: 'carouselPage', value: '1' }],
+                    actions: [
+                      {
+                        type: 'setVariable' as const,
+                        name: 'carouselPage',
+                        value: '{{carouselPage}} - 1',
+                        valueMode: 'expression' as const,
+                      },
+                    ],
                   },
                 },
                 {
                   id: 'vb-go-last',
                   type: 'Button' as const,
                   props: {
-                    label: 'Last',
+                    label: 'Last (literal)',
                     variant: 'outlined' as const,
                     flex: 1,
-                    actions: [{ type: 'setVariable' as const, name: 'carouselPage', value: '2' }],
+                    actions: [
+                      { type: 'setVariable' as const, name: 'carouselPage', value: '2', kind: 'int' as const },
+                    ],
+                  },
+                },
+                {
+                  id: 'vb-go-next',
+                  type: 'Button' as const,
+                  props: {
+                    label: 'Next (expr)',
+                    variant: 'outlined' as const,
+                    flex: 1,
+                    actions: [
+                      {
+                        type: 'setVariable' as const,
+                        name: 'carouselPage',
+                        value: '{{carouselPage}} + 1',
+                        valueMode: 'expression' as const,
+                      },
+                    ],
                   },
                 },
               ],

--- a/packages/onboarding-ui/CHANGELOG.md
+++ b/packages/onboarding-ui/CHANGELOG.md
@@ -9,6 +9,30 @@ here.
 
 ---
 
+## [1.22.0] - 2026-05-11
+
+### Added
+
+- **Expression mode on `setVariable` button action** — new optional
+  `valueMode?: "literal" | "expression"` and `kind?: "int" | "float" | "string"`
+  fields on `SetVariableButtonAction`. In `"expression"` mode `value` is
+  evaluated as an arithmetic expression supporting `{{var}}` references,
+  numeric literals, `+ - * /`, and parens. Variable values are coerced
+  according to their `kind` tag (string / int / float) or inferred from
+  string content when no tag is present. Numeric `+` on any string operand
+  becomes concat. Missing variables default to numeric 0 in arithmetic
+  context (so `{{counter}} + 1` works on first click). On any parse failure
+  the action falls back to plain `{{var}}` interpolation. Result kind is
+  written back to the variable entry so subsequent expressions can
+  re-evaluate without re-tagging.
+
+### Internal
+
+- New `elements/expression.ts` module — tokenizer + recursive-descent parser
+  for the expression-mode subset. Pure function, no dependencies, deterministic.
+
+---
+
 ## [1.21.0] - 2026-05-11
 
 ### Added

--- a/packages/onboarding-ui/CHANGELOG.md
+++ b/packages/onboarding-ui/CHANGELOG.md
@@ -9,6 +9,22 @@ here.
 
 ---
 
+## [1.21.0] - 2026-05-11
+
+### Added
+
+- **Variable-bound `Carousel` index** — Carousel renderer mirrors the new
+  `defaultIndex` and `variableName` schema fields. Initial page resolves from
+  the variable value (when `variableName` set and parsable as int) then falls
+  back to `defaultIndex ?? 0`; index is clamped to `[0, children.length - 1]`
+  and frozen at mount to avoid carousel remounts. A `useEffect` watching the
+  variable value calls `ref.scrollTo()` on external changes (e.g. `setVariable`
+  button actions); `onSnapToItem` writes the current index back as a string
+  when `variableName` is set. A `lastSyncedIndex` ref prevents
+  external↔swipe feedback loops.
+
+---
+
 ## [1.20.0] - 2026-05-11
 
 ### Added

--- a/packages/onboarding-ui/package.json
+++ b/packages/onboarding-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocapine/react-native-onboarding-ui",
-  "version": "1.20.0",
+  "version": "1.21.0",
   "description": "UI components and renderers for Rocapine Onboarding Studio - Built on top of the headless SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/onboarding-ui/package.json
+++ b/packages/onboarding-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocapine/react-native-onboarding-ui",
-  "version": "1.21.0",
+  "version": "1.22.0",
   "description": "UI components and renderers for Rocapine Onboarding Studio - Built on top of the headless SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/ButtonElement.tsx
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/ButtonElement.tsx
@@ -6,6 +6,7 @@ import {
   evaluateCondition,
   type LeafCondition,
   type ConditionGroup,
+  type ComposableVariableKind,
   LeafConditionSchema,
   ConditionGroupSchema,
 } from "@rocapine/react-native-onboarding";
@@ -14,6 +15,7 @@ import { UIElement } from "../types";
 import { RenderContext, dim, resolveInheritedFontFamily } from "./shared";
 import { GradientBox } from "./GradientBox";
 import { ComposableVariableEntry } from "../../../Provider/OnboardingProgressProvider";
+import { evaluateSetVariableExpression } from "./expression";
 
 export type CustomButtonAction = {
   type: "custom";
@@ -32,6 +34,20 @@ export type SetVariableButtonAction = {
   name: string;
   value: string;
   label?: string;
+  /**
+   * When `"expression"`, `value` is parsed as an arithmetic expression with
+   * `{{var}}` references, numeric literals, and `+ - * /` (parens supported).
+   * On parse failure, falls back to plain interpolation (string).
+   * Defaults to `"literal"` — `value` stored verbatim.
+   */
+  valueMode?: "literal" | "expression";
+  /**
+   * Tags the stored variable's underlying type. In `"literal"` mode this is
+   * used as-is. In `"expression"` mode the inferred result kind is used
+   * unless `kind` is explicitly set (ignored — expression mode derives kind
+   * from evaluation).
+   */
+  kind?: ComposableVariableKind;
 };
 
 export const SetVariableButtonActionSchema = z.object({
@@ -39,6 +55,8 @@ export const SetVariableButtonActionSchema = z.object({
   name: z.string().min(1, "name must not be empty"),
   value: z.string(),
   label: z.string().optional(),
+  valueMode: z.enum(["literal", "expression"]).optional(),
+  kind: z.enum(["int", "float", "string"]).optional(),
 });
 
 export type ButtonAction = "continue" | CustomButtonAction | SetVariableButtonAction;
@@ -119,7 +137,17 @@ export const ButtonElementComponent = ({ element, ctx }: Props): React.ReactElem
         return;
       }
       if (act.type === "setVariable") {
-        setVariable(act.name, { value: act.value, label: act.label });
+        let value: string;
+        let kind: ComposableVariableKind | undefined;
+        if (act.valueMode === "expression") {
+          const computed = evaluateSetVariableExpression(act.value, variables);
+          value = computed.value;
+          kind = computed.kind;
+        } else {
+          value = act.value;
+          kind = act.kind;
+        }
+        setVariable(act.name, { value, label: act.label, kind });
         continue;
       }
       const handler = customActions[act.function];

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/CarouselElement.tsx
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/CarouselElement.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { View, type LayoutChangeEvent } from "react-native";
 import { z } from "zod";
 import { useSharedValue } from "react-native-reanimated";
@@ -20,6 +20,8 @@ export type CarouselElementProps = BaseBoxProps & {
   dotHeight?: number;
   dotsGap?: number;
   dotsMarginTop?: number;
+  defaultIndex?: number | null;
+  variableName?: string;
 };
 
 export const CarouselElementPropsSchema = BaseBoxPropsSchema.extend({
@@ -34,6 +36,8 @@ export const CarouselElementPropsSchema = BaseBoxPropsSchema.extend({
   dotHeight: z.number().nonnegative().optional().default(4),
   dotsGap: z.number().nonnegative().optional().default(8),
   dotsMarginTop: z.number().optional().default(12),
+  defaultIndex: z.number().int().nonnegative().nullable().optional(),
+  variableName: z.string().min(1).optional(),
 });
 
 type CarouselUIElement = Extract<UIElement, { type: "Carousel" }>;
@@ -53,6 +57,30 @@ export function CarouselElementComponent({ element, ctx }: Props): React.ReactEl
   const [size, setSize] = useState<{ width: number; height: number } | null>(null);
 
   const carouselType = props.carouselType ?? "normal";
+
+  const variableName = props.variableName;
+  const variableValue = variableName ? ctx.variables[variableName]?.value : undefined;
+  const childrenCount = children.length;
+  const clampIndex = (n: number) => Math.max(0, Math.min(n, Math.max(0, childrenCount - 1)));
+
+  // Frozen on first mount — RNRC `defaultIndex` only applies at mount.
+  const initialIndexRef = useRef<number | null>(null);
+  if (initialIndexRef.current === null) {
+    const parsed = variableValue !== undefined ? parseInt(variableValue, 10) : NaN;
+    const fromVar = Number.isFinite(parsed) ? parsed : null;
+    initialIndexRef.current = clampIndex(fromVar ?? props.defaultIndex ?? 0);
+  }
+  const lastSyncedIndexRef = useRef<number>(initialIndexRef.current);
+
+  useEffect(() => {
+    if (!variableName) return;
+    const parsed = parseInt(variableValue ?? "", 10);
+    if (!Number.isFinite(parsed)) return;
+    const target = clampIndex(parsed);
+    if (target === lastSyncedIndexRef.current) return;
+    lastSyncedIndexRef.current = target;
+    ref.current?.scrollTo({ count: target - progress.value, animated: true });
+  }, [variableName, variableValue, childrenCount]);
 
   const onLayout = (e: LayoutChangeEvent) => {
     const { width, height } = e.nativeEvent.layout;
@@ -132,6 +160,7 @@ export function CarouselElementComponent({ element, ctx }: Props): React.ReactEl
             loop={props.loop}
             autoPlay={props.autoPlay}
             autoPlayInterval={props.autoPlayInterval}
+            defaultIndex={initialIndexRef.current ?? 0}
             snapEnabled={true}
             pagingEnabled={true}
             data={children}
@@ -141,6 +170,12 @@ export function CarouselElementComponent({ element, ctx }: Props): React.ReactEl
             renderItem={({ item }: { item: UIElement }) => ctx.renderChildren([item], "YStack")}
             onProgressChange={(_: number, absoluteProgress: number) => {
               progress.value = absoluteProgress;
+            }}
+            onSnapToItem={(index: number) => {
+              if (!variableName) return;
+              if (index === lastSyncedIndexRef.current) return;
+              lastSyncedIndexRef.current = index;
+              ctx.setVariable(variableName, { value: String(index) });
             }}
             {...(modeProps as any)}
           />

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/expression.ts
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/expression.ts
@@ -1,0 +1,199 @@
+import type { ComposableVariableEntry, ComposableVariableKind } from "@rocapine/react-native-onboarding";
+import { interpolate } from "./shared";
+
+type Token =
+  | { kind: "num"; value: number; isInt: boolean }
+  | { kind: "var"; name: string }
+  | { kind: "op"; op: "+" | "-" | "*" | "/" }
+  | { kind: "lparen" }
+  | { kind: "rparen" }
+  | { kind: "eof" };
+
+type Value =
+  | { kind: "number"; n: number; isInt: boolean }
+  | { kind: "string"; s: string };
+
+const isDigit = (c: string) => c >= "0" && c <= "9";
+const isSpace = (c: string) => c === " " || c === "\t" || c === "\n" || c === "\r";
+
+function tokenize(input: string): Token[] | null {
+  const tokens: Token[] = [];
+  let i = 0;
+  while (i < input.length) {
+    const c = input[i];
+    if (isSpace(c)) {
+      i++;
+      continue;
+    }
+    if (c === "{" && input[i + 1] === "{") {
+      const end = input.indexOf("}}", i + 2);
+      if (end === -1) return null;
+      const name = input.slice(i + 2, end).trim();
+      if (!name) return null;
+      tokens.push({ kind: "var", name });
+      i = end + 2;
+      continue;
+    }
+    if (c === "(") { tokens.push({ kind: "lparen" }); i++; continue; }
+    if (c === ")") { tokens.push({ kind: "rparen" }); i++; continue; }
+    if (c === "+" || c === "-" || c === "*" || c === "/") {
+      tokens.push({ kind: "op", op: c });
+      i++;
+      continue;
+    }
+    if (isDigit(c) || (c === "." && isDigit(input[i + 1] ?? ""))) {
+      let j = i;
+      let dot = false;
+      while (j < input.length && (isDigit(input[j]) || input[j] === ".")) {
+        if (input[j] === ".") {
+          if (dot) return null;
+          dot = true;
+        }
+        j++;
+      }
+      const num = parseFloat(input.slice(i, j));
+      if (!Number.isFinite(num)) return null;
+      tokens.push({ kind: "num", value: num, isInt: !dot });
+      i = j;
+      continue;
+    }
+    return null;
+  }
+  tokens.push({ kind: "eof" });
+  return tokens;
+}
+
+function resolveVar(name: string, vars: Record<string, ComposableVariableEntry>): Value {
+  const entry = vars[name];
+  // Missing variable in arithmetic context defaults to numeric 0 so increment
+  // / decrement patterns work on first click before the variable is seeded.
+  if (!entry) return { kind: "number", n: 0, isInt: true };
+  const raw = entry.value;
+  const k = entry.kind;
+  if (k === "string") return { kind: "string", s: raw };
+  if (k === "int") {
+    const n = parseInt(raw, 10);
+    return Number.isFinite(n) ? { kind: "number", n, isInt: true } : { kind: "string", s: raw };
+  }
+  if (k === "float") {
+    const n = parseFloat(raw);
+    return Number.isFinite(n) ? { kind: "number", n, isInt: false } : { kind: "string", s: raw };
+  }
+  // No kind tag — infer from string content.
+  const trimmed = raw.trim();
+  if (trimmed !== "" && /^-?\d+(\.\d+)?$/.test(trimmed)) {
+    const n = parseFloat(trimmed);
+    if (Number.isFinite(n)) return { kind: "number", n, isInt: Number.isInteger(n) && !trimmed.includes(".") };
+  }
+  return { kind: "string", s: raw };
+}
+
+function valueToString(v: Value): string {
+  if (v.kind === "string") return v.s;
+  if (v.isInt) return Math.trunc(v.n).toString();
+  return v.n.toString();
+}
+
+function parse(tokens: Token[], vars: Record<string, ComposableVariableEntry>): Value | null {
+  let pos = 0;
+  const peek = () => tokens[pos];
+  const advance = () => tokens[pos++];
+
+  const factor = (): Value | null => {
+    const t = peek();
+    if (t.kind === "lparen") {
+      advance();
+      const v = expr();
+      if (!v) return null;
+      if (peek().kind !== "rparen") return null;
+      advance();
+      return v;
+    }
+    if (t.kind === "op" && t.op === "-") {
+      advance();
+      const v = factor();
+      if (!v || v.kind !== "number") return null;
+      return { kind: "number", n: -v.n, isInt: v.isInt };
+    }
+    if (t.kind === "num") {
+      advance();
+      return { kind: "number", n: t.value, isInt: t.isInt };
+    }
+    if (t.kind === "var") {
+      advance();
+      return resolveVar(t.name, vars);
+    }
+    return null;
+  };
+
+  const term = (): Value | null => {
+    let left = factor();
+    if (!left) return null;
+    while (peek().kind === "op" && ((peek() as any).op === "*" || (peek() as any).op === "/")) {
+      const op = (advance() as any).op as "*" | "/";
+      const right = factor();
+      if (!right) return null;
+      if (left.kind !== "number" || right.kind !== "number") return null;
+      if (op === "/" && right.n === 0) return null;
+      const result: number = op === "*" ? left.n * right.n : left.n / right.n;
+      if (!Number.isFinite(result)) return null;
+      const isInt: boolean = op === "*" ? left.isInt && right.isInt : Number.isInteger(result);
+      left = { kind: "number", n: result, isInt };
+    }
+    return left;
+  };
+
+  const expr = (): Value | null => {
+    let left = term();
+    if (!left) return null;
+    while (peek().kind === "op" && ((peek() as any).op === "+" || (peek() as any).op === "-")) {
+      const op = (advance() as any).op as "+" | "-";
+      const right = term();
+      if (!right) return null;
+      if (op === "+") {
+        if (left.kind === "number" && right.kind === "number") {
+          left = { kind: "number", n: left.n + right.n, isInt: left.isInt && right.isInt };
+        } else {
+          left = { kind: "string", s: valueToString(left) + valueToString(right) };
+        }
+      } else {
+        if (left.kind !== "number" || right.kind !== "number") return null;
+        left = { kind: "number", n: left.n - right.n, isInt: left.isInt && right.isInt };
+      }
+    }
+    return left;
+  };
+
+  const result = expr();
+  if (!result) return null;
+  if (peek().kind !== "eof") return null;
+  return result;
+}
+
+/**
+ * Evaluate a `setVariable` expression-mode value template.
+ *
+ * Accepts `{{var}}` references, numeric literals (int / float), `+ - * /` and
+ * parentheses. Variable values are coerced according to their `kind` tag
+ * (string / int / float), or inferred from their string content when no tag
+ * is present. `+` on any non-numeric operand becomes string concat.
+ *
+ * On any parse or evaluation failure, falls back to plain interpolation
+ * (existing `interpolate()` semantics, returns a string).
+ */
+export function evaluateSetVariableExpression(
+  template: string,
+  vars: Record<string, ComposableVariableEntry>
+): { value: string; kind: ComposableVariableKind } {
+  const tokens = tokenize(template);
+  if (tokens) {
+    const result = parse(tokens, vars);
+    if (result) {
+      if (result.kind === "number") {
+        return { value: valueToString(result), kind: result.isInt ? "int" : "float" };
+      }
+      return { value: result.s, kind: "string" };
+    }
+  }
+  return { value: interpolate(template, vars), kind: "string" };
+}

--- a/packages/onboarding/CHANGELOG.md
+++ b/packages/onboarding/CHANGELOG.md
@@ -8,6 +8,20 @@ All notable changes to `@rocapine/react-native-onboarding` are documented here.
 
 ---
 
+## [1.22.0] - 2026-05-11
+
+### Added
+
+- **`kind` on `ComposableVariableEntry`** — optional `"int" | "float" | "string"`
+  tag on stored variables, exported as `ComposableVariableKind`. Drives
+  expression-mode coercion for `setVariable` actions (numeric math vs string
+  concat). Existing code paths ignore the tag, so back-compat is preserved.
+
+> **Backend note:** `onboarding-studio` should optionally surface a `kind`
+> field on `setVariable` actions and on any default variable seeding UI.
+
+---
+
 ## [1.21.0] - 2026-05-11
 
 ### Added

--- a/packages/onboarding/CHANGELOG.md
+++ b/packages/onboarding/CHANGELOG.md
@@ -8,6 +8,26 @@ All notable changes to `@rocapine/react-native-onboarding` are documented here.
 
 ---
 
+## [1.21.0] - 2026-05-11
+
+### Added
+
+- **`defaultIndex` and `variableName` on ComposableScreen `Carousel`** — new
+  optional props on `CarouselElementProps`. `defaultIndex` (integer, ≥ 0,
+  nullable) sets the initial page at mount. `variableName` binds the carousel
+  index to a variable in the ComposableScreen variable store: `setVariable`
+  button actions targeting that name scroll the carousel imperatively, and
+  user swipes write the new index back to the variable so other elements
+  (`Text` `{{var}}` interpolation, branching `evaluateCondition`) can react.
+  Invalid / out-of-range values clamp to `[0, children.length - 1]`; missing
+  / non-numeric values fall back to `defaultIndex ?? 0`.
+
+> **Backend note:** `onboarding-studio` should mirror the `defaultIndex` and
+> `variableName` fields on the Carousel UIElement schema and surface them in
+> the CMS editor.
+
+---
+
 ## [1.20.0] - 2026-05-11
 
 ### Added

--- a/packages/onboarding/package.json
+++ b/packages/onboarding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocapine/react-native-onboarding",
-  "version": "1.20.0",
+  "version": "1.21.0",
   "description": "Headless React Native SDK for Rocapine Onboarding Studio - Data fetching, state management, and hooks",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/onboarding/package.json
+++ b/packages/onboarding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocapine/react-native-onboarding",
-  "version": "1.21.0",
+  "version": "1.22.0",
   "description": "Headless React Native SDK for Rocapine Onboarding Studio - Data fetching, state management, and hooks",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/onboarding/src/index.ts
+++ b/packages/onboarding/src/index.ts
@@ -7,6 +7,7 @@ export type {
   ButtonAction,
   CustomButtonAction,
   ComposableVariableEntry,
+  ComposableVariableKind,
 } from "./steps/ComposableScreen/types";
 export {
   ButtonActionSchema,

--- a/packages/onboarding/src/onboarding-example.ts
+++ b/packages/onboarding/src/onboarding-example.ts
@@ -331,13 +331,14 @@ export const onboardingExample = {
                 type: "Carousel",
                 props: {
                   carouselType: "parallax",
-                  autoPlay: true,
-                  autoPlayInterval: 3000,
+                  autoPlay: false,
                   loop: true,
                   showDots: true,
                   height: 220,
                   borderRadius: 16,
                   marginVertical: 8,
+                  defaultIndex: 1,
+                  variableName: "carouselPage",
                 },
                 children: [
                   {
@@ -365,6 +366,45 @@ export const onboardingExample = {
                       url: "https://picsum.photos/400/220?random=12",
                       height: 220,
                       resizeMode: "cover",
+                    },
+                  },
+                ],
+              },
+              {
+                id: "carousel-page-label",
+                type: "Text",
+                props: {
+                  content: "Carousel page: {{carouselPage}}",
+                  mode: "expression",
+                  fontSize: 14,
+                  textAlign: "center",
+                  opacity: 0.6,
+                  marginVertical: 4,
+                },
+              },
+              {
+                id: "carousel-controls",
+                type: "XStack",
+                props: { gap: 8, marginVertical: 4 },
+                children: [
+                  {
+                    id: "carousel-go-first",
+                    type: "Button",
+                    props: {
+                      label: "First",
+                      variant: "outlined",
+                      flex: 1,
+                      actions: [{ type: "setVariable", name: "carouselPage", value: "0" }],
+                    },
+                  },
+                  {
+                    id: "carousel-go-last",
+                    type: "Button",
+                    props: {
+                      label: "Last",
+                      variant: "outlined",
+                      flex: 1,
+                      actions: [{ type: "setVariable", name: "carouselPage", value: "2" }],
                     },
                   },
                 ],

--- a/packages/onboarding/src/onboarding-example.ts
+++ b/packages/onboarding/src/onboarding-example.ts
@@ -337,7 +337,7 @@ export const onboardingExample = {
                   height: 220,
                   borderRadius: 16,
                   marginVertical: 8,
-                  defaultIndex: 1,
+                  defaultIndex: 0,
                   variableName: "carouselPage",
                 },
                 children: [
@@ -388,23 +388,37 @@ export const onboardingExample = {
                 props: { gap: 8, marginVertical: 4 },
                 children: [
                   {
-                    id: "carousel-go-first",
+                    id: "carousel-go-prev",
                     type: "Button",
                     props: {
-                      label: "First",
+                      label: "Prev",
                       variant: "outlined",
                       flex: 1,
-                      actions: [{ type: "setVariable", name: "carouselPage", value: "0" }],
+                      actions: [
+                        {
+                          type: "setVariable",
+                          name: "carouselPage",
+                          value: "{{carouselPage}} - 1",
+                          valueMode: "expression",
+                        },
+                      ],
                     },
                   },
                   {
-                    id: "carousel-go-last",
+                    id: "carousel-go-next",
                     type: "Button",
                     props: {
-                      label: "Last",
+                      label: "Next",
                       variant: "outlined",
                       flex: 1,
-                      actions: [{ type: "setVariable", name: "carouselPage", value: "2" }],
+                      actions: [
+                        {
+                          type: "setVariable",
+                          name: "carouselPage",
+                          value: "{{carouselPage}} + 1",
+                          valueMode: "expression",
+                        },
+                      ],
                     },
                   },
                 ],

--- a/packages/onboarding/src/steps/ComposableScreen/elements/CarouselElement.ts
+++ b/packages/onboarding/src/steps/ComposableScreen/elements/CarouselElement.ts
@@ -13,6 +13,8 @@ export type CarouselElementProps = BaseBoxProps & {
   dotHeight?: number;
   dotsGap?: number;
   dotsMarginTop?: number;
+  defaultIndex?: number | null;
+  variableName?: string;
 };
 
 export const CarouselElementPropsSchema = BaseBoxPropsSchema.extend({
@@ -27,4 +29,6 @@ export const CarouselElementPropsSchema = BaseBoxPropsSchema.extend({
   dotHeight: z.number().nonnegative().optional().default(4),
   dotsGap: z.number().nonnegative().optional().default(8),
   dotsMarginTop: z.number().optional().default(12),
+  defaultIndex: z.number().int().nonnegative().nullable().optional(),
+  variableName: z.string().min(1).optional(),
 });

--- a/packages/onboarding/src/steps/ComposableScreen/types.ts
+++ b/packages/onboarding/src/steps/ComposableScreen/types.ts
@@ -36,10 +36,21 @@ export type { ZStackElementProps } from "./elements/ZStackElement";
 export type { SafeAreaViewElementProps, SafeAreaEdge, SafeAreaEdgeMode } from "./elements/SafeAreaViewElement";
 
 /**
- * A variable entry stored in the ComposableScreen variables map.
- * `value` is the canonical value (string), `label` is an optional display label.
+ * Type tag for a ComposableScreen variable. Drives expression-mode coercion
+ * in `setVariable` action evaluation (int/float math vs string concat).
  */
-export type ComposableVariableEntry = { value: string; label?: string };
+export type ComposableVariableKind = "int" | "float" | "string";
+
+/**
+ * A variable entry stored in the ComposableScreen variables map.
+ * `value` is the canonical value (always a string), `label` is an optional
+ * display label, `kind` optionally tags the underlying type.
+ */
+export type ComposableVariableEntry = {
+  value: string;
+  label?: string;
+  kind?: ComposableVariableKind;
+};
 
 // UIElement union — must live here (not in elements/) to avoid circular deps
 // because the Stack variant's children: UIElement[] references itself.


### PR DESCRIPTION
## Summary
- Add `defaultIndex` (number, nullable) and `variableName` (string) to ComposableScreen Carousel UIElement.
- `variableName` binds carousel index to variable store — `setVariable` actions scroll the carousel; user swipes write current index back as string.
- Out-of-range / non-numeric values clamp or fall back to `defaultIndex ?? 0`. Initial index frozen at mount to avoid carousel remounts; `lastSyncedIndex` ref breaks external↔swipe feedback loops.
- Bumps both SDK packages to v1.21.0.

## Test plan
- [ ] `npm run build` at repo root — both packages compile
- [ ] `cd example && npm run type:check` passes
- [ ] In example app: open ComposableScreen → Carousel demo
  - [ ] New "variable-bound" section: First/Middle/Last buttons scroll carousel
  - [ ] Swiping carousel updates `Current page: {{carouselPage}}` text
  - [ ] No infinite feedback loop between buttons and swipes
- [ ] Schema parse rejects `defaultIndex: -1` and non-int values

## Backend follow-up
`onboarding-studio` must mirror the new Carousel schema fields (`defaultIndex`, `variableName`) in its Zod schema and CMS editor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Carousel components now support variable binding for dynamic state management. Programmatically set initial carousel pages, control navigation through action buttons, and automatically synchronize user interactions (swipes) with runtime variables. This enables dynamic content binding and conditional branching logic based on carousel selection.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Rocapine/react-native-onboarding/pull/48)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->