### PR TITLE
feat(composable-screen): renderWhen on any UIElement (v1.23.0)

### DIFF
--- a/.claude/rules/composable-screen-runtime.md
+++ b/.claude/rules/composable-screen-runtime.md
@@ -49,3 +49,18 @@ const flatVars = useMemo(
 ```
 
 Skip the flatten and your condition reads the entry object, not its value — every `eq`/`neq` silently mis-evaluates.
+
+## `renderWhen` gating
+
+Every UIElement variant accepts optional `renderWhen?: LeafCondition | ConditionGroup`. Single gating point at top of `elements/renderElement.tsx`: flatten `ctx.variables`, call `evaluateCondition`, return `null` if false. Covers all 15 variants — container subtrees skip naturally because the bail-out runs before `renderChildren`.
+
+## Element-default overlay (Renderer.tsx)
+
+`Renderer.tsx` builds `effectiveVariables = { ...collectElementDefaults(elements), ...composableVariables }` so `renderWhen` + `{{var}}` interpolation see element-declared defaults (`Carousel.defaultIndex`, `RadioGroup.defaultValue`, etc.) on first render. `composableVariables` wins over defaults — never invert the spread. Per-element seeding effects still own persistence (full label entries).
+
+## Adding a new defaulted element
+
+When introducing a new element type with a `defaultValue` / `defaultIndex`:
+
+1. Add a case in `elements/collectDefaults.ts` returning `{value, label?}`.
+2. If the element clamps/coerces the raw default at runtime (like `CarouselElementComponent.clampIndex`), mirror the same logic in `collectDefaults.ts` — otherwise the overlaid value disagrees with the rendered index.

--- a/example/app/_layout.tsx
+++ b/example/app/_layout.tsx
@@ -9,7 +9,10 @@ import * as SplashScreen from "expo-splash-screen";
 import { useEffect } from "react";
 import { OnboardingProgressProvider } from "@rocapine/react-native-onboarding-ui";
 import { Dimensions } from "react-native";
+import { configureReanimatedLogger, ReanimatedLogLevel } from "react-native-reanimated";
 import { LocaleProvider, useLocale } from "../contexts/locale-context";
+
+configureReanimatedLogger({ level: ReanimatedLogLevel.warn, strict: false });
 
 // Keep splash screen visible while fonts load
 SplashScreen.preventAutoHideAsync();

--- a/example/app/example/composable-screen.tsx
+++ b/example/app/example/composable-screen.tsx
@@ -551,6 +551,23 @@ export default function ComposableScreenExample() {
                 },
               },
             },
+            // renderWhen demo — text only renders once consent is given
+            {
+              id: 'consent-confirmation',
+              renderWhen: {
+                variable: 'consent_given',
+                operator: 'eq' as const,
+                value: 'yes',
+              },
+              type: 'Text' as const,
+              props: {
+                content: '✅ Consent recorded — you may continue',
+                fontSize: 14,
+                fontWeight: '600' as const,
+                textAlign: 'center' as const,
+                marginVertical: 4,
+              },
+            },
             // Gradient horizontal band
             {
               id: 'gradient-band',

--- a/package-lock.json
+++ b/package-lock.json
@@ -14692,7 +14692,7 @@
     },
     "packages/onboarding": {
       "name": "@rocapine/react-native-onboarding",
-      "version": "1.12.0",
+      "version": "1.22.0",
       "license": "MIT",
       "dependencies": {
         "@react-native-async-storage/async-storage": "^2.1.0",
@@ -14707,13 +14707,19 @@
         "vitest": "^4.1.5"
       },
       "peerDependencies": {
+        "expo-font": "*",
         "react": "*",
         "react-native": "*"
+      },
+      "peerDependenciesMeta": {
+        "expo-font": {
+          "optional": true
+        }
       }
     },
     "packages/onboarding-ui": {
       "name": "@rocapine/react-native-onboarding-ui",
-      "version": "1.12.0",
+      "version": "1.22.0",
       "license": "MIT",
       "dependencies": {
         "lucide-react-native": "^0.545.0",
@@ -14741,7 +14747,7 @@
       "peerDependencies": {
         "@react-native-community/datetimepicker": "*",
         "@react-native-picker/picker": "*",
-        "@rocapine/react-native-onboarding": "^1.11.1",
+        "@rocapine/react-native-onboarding": "^1.17.0",
         "@shopify/react-native-skia": ">=1.0.0",
         "@tanstack/react-query": ">=5.0.0",
         "@types/react": "*",

--- a/packages/onboarding-ui/CHANGELOG.md
+++ b/packages/onboarding-ui/CHANGELOG.md
@@ -9,6 +9,41 @@ here.
 
 ---
 
+## [1.23.0] - 2026-05-26
+
+### Added
+
+- **`renderWhen` runtime gating in ComposableScreen** — `renderElement`
+  evaluates the new optional `renderWhen` field on every UIElement against
+  flattened `ctx.variables` and returns `null` (skipping the element and
+  its subtree) when the condition is false. Single gating point covers all
+  15 element types; container subtrees are skipped naturally because the
+  bail-out runs before `renderChildren` is invoked.
+
+### Changed
+
+- **Element defaults overlaid into `ctx.variables`** — `Renderer.tsx` now
+  computes element-declared defaults (`Carousel.defaultIndex`,
+  `RadioGroup.defaultValue`, `CheckboxGroup.defaultValues`,
+  `Input.defaultValue`, `DatePicker.defaultValue`) via a tree walk and
+  overlays them onto `RenderContext.variables` synchronously on first
+  render. `composableVariables` keeps precedence so user-driven updates
+  aren't clobbered. Makes `renderWhen` and `{{var}}` interpolation see
+  defaults from the very first frame, before per-element seeding effects
+  persist them into the variable store.
+- **`CarouselElement` persists default index** — when `variableName` is set
+  and the variable has no value yet, the carousel writes its clamped
+  `defaultIndex` into `composableVariables` on mount, matching the seeding
+  pattern used by RadioGroup / Input / DatePicker.
+
+### Internal
+
+- New `elements/collectDefaults.ts` module — pure recursive walk over the
+  UIElement tree returning `Record<variableName, ComposableVariableEntry>`
+  for defaulted variables. Consumed by `Renderer.tsx`.
+
+---
+
 ## [1.22.0] - 2026-05-11
 
 ### Added

--- a/packages/onboarding-ui/package.json
+++ b/packages/onboarding-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocapine/react-native-onboarding-ui",
-  "version": "1.22.0",
+  "version": "1.23.0",
   "description": "UI components and renderers for Rocapine Onboarding Studio - Built on top of the headless SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -46,7 +46,7 @@
   "peerDependencies": {
     "@react-native-community/datetimepicker": "*",
     "@react-native-picker/picker": "*",
-    "@rocapine/react-native-onboarding": "^1.17.0",
+    "@rocapine/react-native-onboarding": "^1.23.0",
     "@shopify/react-native-skia": ">=1.0.0",
     "@tanstack/react-query": ">=5.0.0",
     "@types/react": "*",

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/Renderer.tsx
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/Renderer.tsx
@@ -8,6 +8,7 @@ import { OnboardingProgressContext, ComposableVariableEntry } from "../../Provid
 import { useTheme } from "../../Theme/useTheme";
 import { RenderContext } from "./elements/shared";
 import { renderElement } from "./elements/renderElement";
+import { collectElementDefaults } from "./elements/collectDefaults";
 
 type ContentProps = {
   step: ComposableScreenStepType;
@@ -29,12 +30,22 @@ const ComposableScreenRendererBase = ({ step, onContinue }: ContentProps) => {
     [setComposableVariable, setHeadlessVariable]
   );
 
+  // Defaults declared inline on UIElements (Carousel.defaultIndex, RadioGroup.defaultValue, etc.)
+  // are overlaid onto ctx.variables so renderWhen / expressions see them on first render —
+  // before per-element seeding effects (which persist into composableVariables) run.
+  // composableVariables wins over defaults so user-driven updates aren't clobbered.
+  const elementDefaults = useMemo(() => collectElementDefaults(elements), [elements]);
+  const effectiveVariables = useMemo(
+    () => ({ ...elementDefaults, ...composableVariables }),
+    [elementDefaults, composableVariables]
+  );
+
   const renderChildren = (children: UIElement[], parentType: "XStack" | "YStack" | "ZStack") =>
     children.map((child) => renderElement(child, ctx, parentType));
 
   const ctx: RenderContext = {
     theme,
-    variables: composableVariables,
+    variables: effectiveVariables,
     setVariable: setVariableAndSync,
     onContinue,
     customActions,

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/CarouselElement.tsx
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/CarouselElement.tsx
@@ -82,6 +82,15 @@ export function CarouselElementComponent({ element, ctx }: Props): React.ReactEl
     ref.current?.scrollTo({ count: target - progress.value, animated: true });
   }, [variableName, variableValue, childrenCount]);
 
+  // Persist the initial index into ctx.variables when no value exists yet, so the
+  // default reaches downstream renderWhen / interpolation across renders.
+  useEffect(() => {
+    if (!variableName) return;
+    if (variableValue !== undefined) return;
+    if (props.defaultIndex == null) return;
+    ctx.setVariable(variableName, { value: String(clampIndex(props.defaultIndex)) });
+  }, [variableName, variableValue, props.defaultIndex, childrenCount]);
+
   const onLayout = (e: LayoutChangeEvent) => {
     const { width, height } = e.nativeEvent.layout;
     if (!size || size.width !== width || size.height !== height) {

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/collectDefaults.ts
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/collectDefaults.ts
@@ -17,7 +17,13 @@ export function collectElementDefaults(
       case "Carousel": {
         const name = el.props.variableName;
         if (name && el.props.defaultIndex != null) {
-          out[name] = { value: String(el.props.defaultIndex) };
+          // Mirror CarouselElementComponent's clampIndex so the overlaid default
+          // matches the index the carousel actually mounts at.
+          const raw = Number(el.props.defaultIndex);
+          const safe = Number.isFinite(raw) ? raw : 0;
+          const maxIdx = Math.max(0, el.children.length - 1);
+          const clamped = Math.max(0, Math.min(safe, maxIdx));
+          out[name] = { value: String(clamped) };
         }
         el.children.forEach(visit);
         break;

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/collectDefaults.ts
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/collectDefaults.ts
@@ -1,0 +1,70 @@
+import { UIElement } from "../types";
+import { ComposableVariableEntry } from "../../../Provider/OnboardingProgressProvider";
+
+/**
+ * Walks the element tree and returns the initial variable map declared via
+ * element-level defaults (`defaultIndex`, `defaultValue`, `defaultValues`).
+ * Used by `Renderer` to overlay defaults onto `ctx.variables` so
+ * `renderWhen` / expressions evaluate against them on first render — before
+ * per-element seeding effects run.
+ */
+export function collectElementDefaults(
+  elements: UIElement[]
+): Record<string, ComposableVariableEntry> {
+  const out: Record<string, ComposableVariableEntry> = {};
+  const visit = (el: UIElement) => {
+    switch (el.type) {
+      case "Carousel": {
+        const name = el.props.variableName;
+        if (name && el.props.defaultIndex != null) {
+          out[name] = { value: String(el.props.defaultIndex) };
+        }
+        el.children.forEach(visit);
+        break;
+      }
+      case "RadioGroup": {
+        const name = el.props.variableName;
+        const dv = el.props.defaultValue;
+        if (name && dv !== undefined) {
+          const item = el.props.items.find((i) => i.value === dv);
+          out[name] = { value: dv, label: item?.label };
+        }
+        break;
+      }
+      case "CheckboxGroup": {
+        const name = el.props.variableName;
+        const dvs = el.props.defaultValues;
+        if (name && dvs !== undefined) {
+          const labels = dvs.map(
+            (dv) => el.props.items.find((i) => i.value === dv)?.label ?? dv
+          );
+          out[name] = { value: JSON.stringify(dvs), label: labels.join(", ") };
+        }
+        break;
+      }
+      case "Input": {
+        const name = el.props.variableName;
+        if (name && el.props.defaultValue !== undefined) {
+          out[name] = { value: el.props.defaultValue };
+        }
+        break;
+      }
+      case "DatePicker": {
+        const name = el.props.variableName;
+        if (name && el.props.defaultValue !== undefined) {
+          const d = new Date(el.props.defaultValue);
+          if (!isNaN(d.getTime())) out[name] = { value: d.toISOString() };
+        }
+        break;
+      }
+      case "YStack":
+      case "XStack":
+      case "ZStack":
+      case "SafeAreaView":
+        el.children.forEach(visit);
+        break;
+    }
+  };
+  elements.forEach(visit);
+  return out;
+}

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/renderElement.tsx
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/renderElement.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { evaluateCondition } from "@rocapine/react-native-onboarding";
 import { UIElement } from "../types";
 import { RenderContext } from "./shared";
 import { StackElementComponent } from "./StackElement";
@@ -22,6 +23,13 @@ export const renderElement = (
   ctx: RenderContext,
   parentType?: "XStack" | "YStack" | "ZStack"
 ): React.ReactNode => {
+  if (element.renderWhen) {
+    const flatVars = Object.fromEntries(
+      Object.entries(ctx.variables).map(([k, v]) => [k, v?.value])
+    );
+    if (!evaluateCondition(element.renderWhen, flatVars)) return null;
+  }
+
   if (element.type === "YStack" || element.type === "XStack") {
     return <StackElementComponent key={element.id} element={element} ctx={ctx} parentType={parentType} />;
   }

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/types.ts
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/types.ts
@@ -1,4 +1,10 @@
 import { z } from "zod";
+import {
+  type LeafCondition,
+  type ConditionGroup,
+  LeafConditionSchema,
+  ConditionGroupSchema,
+} from "@rocapine/react-native-onboarding";
 import { CustomPayloadSchema } from "../types";
 import { type StackElementProps, StackElementPropsSchema } from "./elements/StackElement";
 import { type TextElementProps, TextElementPropsSchema } from "./elements/TextElement";
@@ -40,6 +46,7 @@ export type UIElement =
   | {
       id: string;
       name?: string;
+      renderWhen?: LeafCondition | ConditionGroup;
       type: "YStack" | "XStack";
       props: StackElementProps;
       children: UIElement[];
@@ -47,72 +54,84 @@ export type UIElement =
   | {
       id: string;
       name?: string;
+      renderWhen?: LeafCondition | ConditionGroup;
       type: "Text";
       props: TextElementProps;
     }
   | {
       id: string;
       name?: string;
+      renderWhen?: LeafCondition | ConditionGroup;
       type: "Image";
       props: ImageElementProps;
     }
   | {
       id: string;
       name?: string;
+      renderWhen?: LeafCondition | ConditionGroup;
       type: "Lottie";
       props: LottieElementProps;
     }
   | {
       id: string;
       name?: string;
+      renderWhen?: LeafCondition | ConditionGroup;
       type: "Rive";
       props: RiveElementProps;
     }
   | {
       id: string;
       name?: string;
+      renderWhen?: LeafCondition | ConditionGroup;
       type: "Icon";
       props: IconElementProps;
     }
   | {
       id: string;
       name?: string;
+      renderWhen?: LeafCondition | ConditionGroup;
       type: "Video";
       props: VideoElementProps;
     }
   | {
       id: string;
       name?: string;
+      renderWhen?: LeafCondition | ConditionGroup;
       type: "Input";
       props: InputElementProps;
     }
   | {
       id: string;
       name?: string;
+      renderWhen?: LeafCondition | ConditionGroup;
       type: "Button";
       props: ButtonElementProps;
     }
   | {
       id: string;
       name?: string;
+      renderWhen?: LeafCondition | ConditionGroup;
       type: "RadioGroup";
       props: RadioGroupElementProps;
     }
   | {
       id: string;
       name?: string;
+      renderWhen?: LeafCondition | ConditionGroup;
       type: "CheckboxGroup";
       props: CheckboxGroupElementProps;
     }
   | {
       id: string;
       name?: string;
+      renderWhen?: LeafCondition | ConditionGroup;
       type: "DatePicker";
       props: DatePickerElementProps;
     }
   | {
       id: string;
       name?: string;
+      renderWhen?: LeafCondition | ConditionGroup;
       type: "Carousel";
       props: CarouselElementProps;
       children: UIElement[];
@@ -120,6 +139,7 @@ export type UIElement =
   | {
       id: string;
       name?: string;
+      renderWhen?: LeafCondition | ConditionGroup;
       type: "ZStack";
       props: ZStackElementProps;
       children: UIElement[];
@@ -127,6 +147,7 @@ export type UIElement =
   | {
       id: string;
       name?: string;
+      renderWhen?: LeafCondition | ConditionGroup;
       type: "SafeAreaView";
       props: SafeAreaViewElementProps;
       children: UIElement[];
@@ -137,6 +158,7 @@ export const UIElementSchema: z.ZodType<UIElement> = z.lazy(() =>
     z.object({
       id: z.string(),
       name: z.string().optional(),
+      renderWhen: z.union([LeafConditionSchema, ConditionGroupSchema]).optional(),
       type: z.union([z.literal("YStack"), z.literal("XStack")]),
       props: StackElementPropsSchema,
       children: z.array(UIElementSchema),
@@ -144,72 +166,84 @@ export const UIElementSchema: z.ZodType<UIElement> = z.lazy(() =>
     z.object({
       id: z.string(),
       name: z.string().optional(),
+      renderWhen: z.union([LeafConditionSchema, ConditionGroupSchema]).optional(),
       type: z.literal("Text"),
       props: TextElementPropsSchema,
     }),
     z.object({
       id: z.string(),
       name: z.string().optional(),
+      renderWhen: z.union([LeafConditionSchema, ConditionGroupSchema]).optional(),
       type: z.literal("Image"),
       props: ImageElementPropsSchema,
     }),
     z.object({
       id: z.string(),
       name: z.string().optional(),
+      renderWhen: z.union([LeafConditionSchema, ConditionGroupSchema]).optional(),
       type: z.literal("Lottie"),
       props: LottieElementPropsSchema,
     }),
     z.object({
       id: z.string(),
       name: z.string().optional(),
+      renderWhen: z.union([LeafConditionSchema, ConditionGroupSchema]).optional(),
       type: z.literal("Rive"),
       props: RiveElementPropsSchema,
     }),
     z.object({
       id: z.string(),
       name: z.string().optional(),
+      renderWhen: z.union([LeafConditionSchema, ConditionGroupSchema]).optional(),
       type: z.literal("Icon"),
       props: IconElementPropsSchema,
     }),
     z.object({
       id: z.string(),
       name: z.string().optional(),
+      renderWhen: z.union([LeafConditionSchema, ConditionGroupSchema]).optional(),
       type: z.literal("Video"),
       props: VideoElementPropsSchema,
     }),
     z.object({
       id: z.string(),
       name: z.string().optional(),
+      renderWhen: z.union([LeafConditionSchema, ConditionGroupSchema]).optional(),
       type: z.literal("Input"),
       props: InputElementPropsSchema,
     }),
     z.object({
       id: z.string(),
       name: z.string().optional(),
+      renderWhen: z.union([LeafConditionSchema, ConditionGroupSchema]).optional(),
       type: z.literal("Button"),
       props: ButtonElementPropsSchema,
     }),
     z.object({
       id: z.string(),
       name: z.string().optional(),
+      renderWhen: z.union([LeafConditionSchema, ConditionGroupSchema]).optional(),
       type: z.literal("RadioGroup"),
       props: RadioGroupElementPropsSchema,
     }),
     z.object({
       id: z.string(),
       name: z.string().optional(),
+      renderWhen: z.union([LeafConditionSchema, ConditionGroupSchema]).optional(),
       type: z.literal("CheckboxGroup"),
       props: CheckboxGroupElementPropsSchema,
     }),
     z.object({
       id: z.string(),
       name: z.string().optional(),
+      renderWhen: z.union([LeafConditionSchema, ConditionGroupSchema]).optional(),
       type: z.literal("DatePicker"),
       props: DatePickerElementPropsSchema,
     }),
     z.object({
       id: z.string(),
       name: z.string().optional(),
+      renderWhen: z.union([LeafConditionSchema, ConditionGroupSchema]).optional(),
       type: z.literal("Carousel"),
       props: CarouselElementPropsSchema,
       children: z.array(UIElementSchema),
@@ -217,6 +251,7 @@ export const UIElementSchema: z.ZodType<UIElement> = z.lazy(() =>
     z.object({
       id: z.string(),
       name: z.string().optional(),
+      renderWhen: z.union([LeafConditionSchema, ConditionGroupSchema]).optional(),
       type: z.literal("ZStack"),
       props: ZStackElementPropsSchema,
       children: z.array(UIElementSchema),
@@ -224,6 +259,7 @@ export const UIElementSchema: z.ZodType<UIElement> = z.lazy(() =>
     z.object({
       id: z.string(),
       name: z.string().optional(),
+      renderWhen: z.union([LeafConditionSchema, ConditionGroupSchema]).optional(),
       type: z.literal("SafeAreaView"),
       props: SafeAreaViewElementPropsSchema,
       children: z.array(UIElementSchema),

--- a/packages/onboarding/CHANGELOG.md
+++ b/packages/onboarding/CHANGELOG.md
@@ -8,6 +8,29 @@ All notable changes to `@rocapine/react-native-onboarding` are documented here.
 
 ---
 
+## [1.23.0] - 2026-05-26
+
+### Added
+
+- **`renderWhen` on every UIElement variant** — optional
+  `renderWhen?: LeafCondition | ConditionGroup` field on every entry of the
+  `UIElement` discriminated union (Stack, Text, Image, Lottie, Rive, Icon,
+  Video, Input, Button, RadioGroup, CheckboxGroup, DatePicker, Carousel,
+  ZStack, SafeAreaView). Reuses the existing `LeafConditionSchema` /
+  `ConditionGroupSchema` from `common.types` — no new condition types. When
+  the condition evaluates falsy against current ComposableScreen variables,
+  the runtime skips rendering the element and its entire subtree. Companion
+  to `Button.disabledWhen` (visual disabled state) and `Branch.condition`
+  (flow-level next-step selection); use `renderWhen` for in-screen
+  conditional visibility (validation errors, variable-gated sections, etc.).
+
+> **Backend note:** `onboarding-studio` should mirror the optional
+> `renderWhen` field on every UIElement variant and surface a "Render when"
+> condition picker in the element properties panel, reusing the Branch
+> condition builder. JSON serialization passes through unchanged.
+
+---
+
 ## [1.22.0] - 2026-05-11
 
 ### Added

--- a/packages/onboarding/package.json
+++ b/packages/onboarding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocapine/react-native-onboarding",
-  "version": "1.22.0",
+  "version": "1.23.0",
   "description": "Headless React Native SDK for Rocapine Onboarding Studio - Data fetching, state management, and hooks",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/onboarding/src/onboarding-example.ts
+++ b/packages/onboarding/src/onboarding-example.ts
@@ -275,6 +275,22 @@ export const onboardingExample = {
                 },
               },
               {
+                id: "lifetime-badge",
+                renderWhen: {
+                  variable: "plan",
+                  operator: "eq",
+                  value: "lifetime",
+                },
+                type: "Text",
+                props: {
+                  content: "🎉 Best value — lifetime access!",
+                  fontSize: 14,
+                  fontWeight: "600",
+                  textAlign: "center",
+                  marginVertical: 4,
+                },
+              },
+              {
                 id: "hero-checkbox",
                 type: "CheckboxGroup",
                 props: {

--- a/packages/onboarding/src/steps/ComposableScreen/types.ts
+++ b/packages/onboarding/src/steps/ComposableScreen/types.ts
@@ -1,5 +1,11 @@
 import { z } from "zod";
-import { BaseStepTypeSchema } from "../common.types";
+import {
+  BaseStepTypeSchema,
+  type LeafCondition,
+  type ConditionGroup,
+  LeafConditionSchema,
+  ConditionGroupSchema,
+} from "../common.types";
 import { type StackElementProps, StackElementPropsSchema } from "./elements/StackElement";
 import { type TextElementProps, TextElementPropsSchema } from "./elements/TextElement";
 import { type ImageElementProps, ImageElementPropsSchema } from "./elements/ImageElement";
@@ -58,6 +64,7 @@ type UIElement =
   | {
       id: string;
       name?: string;
+      renderWhen?: LeafCondition | ConditionGroup;
       type: "YStack" | "XStack";
       props: StackElementProps;
       children: UIElement[];
@@ -65,72 +72,84 @@ type UIElement =
   | {
       id: string;
       name?: string;
+      renderWhen?: LeafCondition | ConditionGroup;
       type: "Text";
       props: TextElementProps;
     }
   | {
       id: string;
       name?: string;
+      renderWhen?: LeafCondition | ConditionGroup;
       type: "Image";
       props: ImageElementProps;
     }
   | {
       id: string;
       name?: string;
+      renderWhen?: LeafCondition | ConditionGroup;
       type: "Lottie";
       props: LottieElementProps;
     }
   | {
       id: string;
       name?: string;
+      renderWhen?: LeafCondition | ConditionGroup;
       type: "Rive";
       props: RiveElementProps;
     }
   | {
       id: string;
       name?: string;
+      renderWhen?: LeafCondition | ConditionGroup;
       type: "Icon";
       props: IconElementProps;
     }
   | {
       id: string;
       name?: string;
+      renderWhen?: LeafCondition | ConditionGroup;
       type: "Video";
       props: VideoElementProps;
     }
   | {
       id: string;
       name?: string;
+      renderWhen?: LeafCondition | ConditionGroup;
       type: "Input";
       props: InputElementProps;
     }
   | {
       id: string;
       name?: string;
+      renderWhen?: LeafCondition | ConditionGroup;
       type: "Button";
       props: ButtonElementProps;
     }
   | {
       id: string;
       name?: string;
+      renderWhen?: LeafCondition | ConditionGroup;
       type: "RadioGroup";
       props: RadioGroupElementProps;
     }
   | {
       id: string;
       name?: string;
+      renderWhen?: LeafCondition | ConditionGroup;
       type: "CheckboxGroup";
       props: CheckboxGroupElementProps;
     }
   | {
       id: string;
       name?: string;
+      renderWhen?: LeafCondition | ConditionGroup;
       type: "DatePicker";
       props: DatePickerElementProps;
     }
   | {
       id: string;
       name?: string;
+      renderWhen?: LeafCondition | ConditionGroup;
       type: "Carousel";
       props: CarouselElementProps;
       children: UIElement[];
@@ -138,6 +157,7 @@ type UIElement =
   | {
       id: string;
       name?: string;
+      renderWhen?: LeafCondition | ConditionGroup;
       type: "ZStack";
       props: ZStackElementProps;
       children: UIElement[];
@@ -145,6 +165,7 @@ type UIElement =
   | {
       id: string;
       name?: string;
+      renderWhen?: LeafCondition | ConditionGroup;
       type: "SafeAreaView";
       props: SafeAreaViewElementProps;
       children: UIElement[];
@@ -155,6 +176,7 @@ const UIElementSchema: z.ZodType<UIElement> = z.lazy(() =>
     z.object({
       id: z.string(),
       name: z.string().optional(),
+      renderWhen: z.union([LeafConditionSchema, ConditionGroupSchema]).optional(),
       type: z.union([z.literal("YStack"), z.literal("XStack")]),
       props: StackElementPropsSchema,
       children: z.array(UIElementSchema),
@@ -162,72 +184,84 @@ const UIElementSchema: z.ZodType<UIElement> = z.lazy(() =>
     z.object({
       id: z.string(),
       name: z.string().optional(),
+      renderWhen: z.union([LeafConditionSchema, ConditionGroupSchema]).optional(),
       type: z.literal("Text"),
       props: TextElementPropsSchema,
     }),
     z.object({
       id: z.string(),
       name: z.string().optional(),
+      renderWhen: z.union([LeafConditionSchema, ConditionGroupSchema]).optional(),
       type: z.literal("Image"),
       props: ImageElementPropsSchema,
     }),
     z.object({
       id: z.string(),
       name: z.string().optional(),
+      renderWhen: z.union([LeafConditionSchema, ConditionGroupSchema]).optional(),
       type: z.literal("Lottie"),
       props: LottieElementPropsSchema,
     }),
     z.object({
       id: z.string(),
       name: z.string().optional(),
+      renderWhen: z.union([LeafConditionSchema, ConditionGroupSchema]).optional(),
       type: z.literal("Rive"),
       props: RiveElementPropsSchema,
     }),
     z.object({
       id: z.string(),
       name: z.string().optional(),
+      renderWhen: z.union([LeafConditionSchema, ConditionGroupSchema]).optional(),
       type: z.literal("Icon"),
       props: IconElementPropsSchema,
     }),
     z.object({
       id: z.string(),
       name: z.string().optional(),
+      renderWhen: z.union([LeafConditionSchema, ConditionGroupSchema]).optional(),
       type: z.literal("Video"),
       props: VideoElementPropsSchema,
     }),
     z.object({
       id: z.string(),
       name: z.string().optional(),
+      renderWhen: z.union([LeafConditionSchema, ConditionGroupSchema]).optional(),
       type: z.literal("Input"),
       props: InputElementPropsSchema,
     }),
     z.object({
       id: z.string(),
       name: z.string().optional(),
+      renderWhen: z.union([LeafConditionSchema, ConditionGroupSchema]).optional(),
       type: z.literal("Button"),
       props: ButtonElementPropsSchema,
     }),
     z.object({
       id: z.string(),
       name: z.string().optional(),
+      renderWhen: z.union([LeafConditionSchema, ConditionGroupSchema]).optional(),
       type: z.literal("RadioGroup"),
       props: RadioGroupElementPropsSchema,
     }),
     z.object({
       id: z.string(),
       name: z.string().optional(),
+      renderWhen: z.union([LeafConditionSchema, ConditionGroupSchema]).optional(),
       type: z.literal("CheckboxGroup"),
       props: CheckboxGroupElementPropsSchema,
     }),
     z.object({
       id: z.string(),
       name: z.string().optional(),
+      renderWhen: z.union([LeafConditionSchema, ConditionGroupSchema]).optional(),
       type: z.literal("DatePicker"),
       props: DatePickerElementPropsSchema,
     }),
     z.object({
       id: z.string(),
       name: z.string().optional(),
+      renderWhen: z.union([LeafConditionSchema, ConditionGroupSchema]).optional(),
       type: z.literal("Carousel"),
       props: CarouselElementPropsSchema,
       children: z.array(UIElementSchema),
@@ -235,6 +269,7 @@ const UIElementSchema: z.ZodType<UIElement> = z.lazy(() =>
     z.object({
       id: z.string(),
       name: z.string().optional(),
+      renderWhen: z.union([LeafConditionSchema, ConditionGroupSchema]).optional(),
       type: z.literal("ZStack"),
       props: ZStackElementPropsSchema,
       children: z.array(UIElementSchema),
@@ -242,6 +277,7 @@ const UIElementSchema: z.ZodType<UIElement> = z.lazy(() =>
     z.object({
       id: z.string(),
       name: z.string().optional(),
+      renderWhen: z.union([LeafConditionSchema, ConditionGroupSchema]).optional(),
       type: z.literal("SafeAreaView"),
       props: SafeAreaViewElementPropsSchema,
       children: z.array(UIElementSchema),

--- a/website/docs/page-types.mdx
+++ b/website/docs/page-types.mdx
@@ -411,6 +411,7 @@ Build arbitrary onboarding screens entirely from CMS data — no custom renderer
 - Text color defaults to `theme.colors.text.primary`
 - Lottie, Rive, Video, and DatePicker as optional peer deps — graceful fallback if not installed
 - **Variable context** — `Input`, `RadioGroup`, `CheckboxGroup`, and `DatePicker` elements write into shared state; `Text` elements interpolate those values with `{{variableName}}` expressions
+- **Conditional rendering** — every UIElement accepts `renderWhen?: LeafCondition | ConditionGroup`; the renderer skips the element and its subtree when the condition is false
 
 **Element types:**
 
@@ -809,6 +810,67 @@ export default function RootLayout() {
 ```
 
 Without the provider the context falls back to its default (empty variables, no-op setter) — Input values will not be saved and expression Text will render blank for any `{{variable}}`.
+:::
+
+**Conditional rendering (`renderWhen`)**
+
+Every UIElement variant accepts an optional `renderWhen` field — a
+`LeafCondition` or `ConditionGroup` evaluated against the live variable
+map. When the condition is **false** the element (and its entire subtree
+for containers) is skipped — no node mounts, no layout cost, no
+side-effects from Lottie / Video / Input.
+
+Same condition schema as `Button.disabledWhen` and `nextStep.branches[].condition`:
+
+```jsonc
+{
+  "id": "lifetime-badge",
+  "renderWhen": {
+    "variable": "plan",
+    "operator": "eq",
+    "value": "lifetime"
+  },
+  "type": "Text",
+  "props": {
+    "content": "🎉 Best value — lifetime access!",
+    "fontSize": 14,
+    "fontWeight": "600",
+    "textAlign": "center"
+  }
+}
+```
+
+Use `ConditionGroup` for AND / OR composition:
+
+```jsonc
+{
+  "id": "yearly-or-lifetime-note",
+  "renderWhen": {
+    "logic": "or",
+    "conditions": [
+      { "variable": "plan", "operator": "eq", "value": "yearly" },
+      { "variable": "plan", "operator": "eq", "value": "lifetime" }
+    ]
+  },
+  "type": "Text",
+  "props": { "content": "Best long-term value" }
+}
+```
+
+Element-level defaults (`Carousel.defaultIndex`, `RadioGroup.defaultValue`,
+`CheckboxGroup.defaultValues`, `Input.defaultValue`,
+`DatePicker.defaultValue`) are overlaid onto the variable map
+synchronously on first render — so `renderWhen` and `{{var}}`
+interpolation see defaults from the very first frame, before any user
+interaction.
+
+:::tip `renderWhen` vs `Branch.condition`
+- `renderWhen` — hides a single element *inside* a screen.
+- `Branch.condition` (`step.nextStep.branches[].condition`) — picks the
+  *next step* in the flow when continue is pressed.
+
+Pick `renderWhen` for in-screen toggles (validation text, plan-specific
+copy, optional sections). Pick `Branch.condition` to skip whole steps.
 :::
 
 **Icon props:**


### PR DESCRIPTION
## Summary
- Every `UIElement` variant now accepts optional `renderWhen?: LeafCondition | ConditionGroup`; `renderElement` evaluates against `ctx.variables` and returns `null` (skipping element + subtree) when false. Reuses existing condition schemas — no new types.
- `Renderer.tsx` overlays element-declared defaults (`Carousel.defaultIndex`, `RadioGroup.defaultValue`, `CheckboxGroup.defaultValues`, `Input.defaultValue`, `DatePicker.defaultValue`) onto `RenderContext.variables` synchronously on first render so `renderWhen` + `{{var}}` interpolation see defaults from the very first frame. `composableVariables` keeps precedence for user-driven updates.
- `CarouselElement` now persists its clamped `defaultIndex` into `composableVariables` on mount, matching the seeding pattern of RadioGroup / Input / DatePicker.
- Demo `renderWhen` element added to `onboarding-example.ts` and `example/app/example/composable-screen.tsx`.
- Reanimated strict-mode warning from `react-native-reanimated-carousel` silenced in example app via `configureReanimatedLogger`.
- Packages bumped 1.22.0 → 1.23.0; UI peer on headless bumped to `^1.23.0`. CHANGELOGs + `website/docs/page-types.mdx` updated.

Closes Notion OS-159.

## Test plan
- [x] `npm run build:headless` + `npm run build:ui` clean
- [x] `cd example && npm run type:check` clean
- [x] `cd example && npm run lint` — 0 errors
- [ ] Manual: open `/example/composable-screen`, toggle `consent-toggle` button, verify `consent-confirmation` Text appears
- [ ] Manual: default onboarding (`onboardingExample`) renders `lifetime-badge` only when `plan = lifetime`
- [ ] Manual: Carousel with `defaultIndex: 2` + `variableName: "page"` — confirm `{{page}}` interpolation reads `"2"` on first render

## Backend follow-up
`onboarding-studio` must mirror `renderWhen` on every UIElement variant (schema + element-properties panel reusing the Branch condition builder).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Conditional rendering for all UI elements via `renderWhen` field
  * Element default values automatically collected and applied on initial render
  * Carousel default index persistence to composable variables

* **Documentation**
  * Added documentation for conditional rendering with examples and best practices
  * Updated changelog entries

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Rocapine/react-native-onboarding/pull/50?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->