### PR TITLE
docs(plugin): auto-link steps via explicit multi-path nextStep

### DIFF
--- a/claude-plugin/agents/onboarding-architect.md
+++ b/claude-plugin/agents/onboarding-architect.md
@@ -86,8 +86,12 @@ Emit one array of ComposableScreen steps. Each step:
 - `displayProgressHeader` — `false` on hook/loader/commitment, `true` otherwise
 - `customPayload: null`
 - `continueButtonLabel` — verb from app voice (note: usually unused — the actual CTA lives as a `Button` element inside `payload.elements`)
-- `nextStep` — `null` linear, or `{ defaultTargetStepId, branches }`
+- `nextStep` — **always emit as an explicit multi-path link**. For step `i` of `N`-length flow: `{ "defaultTargetStepId": "<id of step i+1>", "branches": [...] }`. Terminal step (`i === N-1`) gets `nextStep: null`. Each `branches[]` entry is `{ condition: LeafCondition | ConditionGroup | null, targetStepId }` — first matching branch wins; `defaultTargetStepId` is the catch-all. Every `targetStepId` must reference a real step `id` in the array. **Never rely on null + array-order linear fallback for multi-step flows** — explicit links survive reordering and make branching trivial to layer in.
 - `payload` — exactly `{ "elements": UIElement[] }`. **No `root` key. No `variables` key.** Variables flow at runtime via element `variableName` bindings. Writing `payload.root` causes Studio to crash with `els is not iterable`.
+
+### Auto-link the chain
+
+After Step 3 (variables) and before emitting JSON, walk the arc top-to-bottom and assign `nextStep.defaultTargetStepId` to the next step's `id`. Where a branch is needed (e.g. gender → male-track vs female-track), set `branches: [{ condition, targetStepId }]` on the deciding step; `defaultTargetStepId` stays as the common path. List branch points explicitly in the "Branching" section of the recap. Terminal step is the only `nextStep: null`.
 
 Use archetype skeletons from `../skills/create-step-json/references/composable-archetypes.md` as the basis of `payload.elements`.
 

--- a/claude-plugin/agents/step-json-reviewer.md
+++ b/claude-plugin/agents/step-json-reviewer.md
@@ -69,6 +69,12 @@ For each step:
 - All `Button.actions` entries are `"continue"` or `{type:"custom", function, variables?}` or `{type:"setVariable", name, value, valueMode?}`.
 - All `disabledWhen` conditions are valid `LeafCondition` / `ConditionGroup` referencing variables that any step actually captures (`variableName` on Input/RadioGroup/CheckboxGroup/DatePicker, or via setVariable action).
 - `nextStep.defaultTargetStepId` points at a real step ID in the array.
+- **Step chain (auto-link via multi-path)** — when reviewing a flow array:
+  - Every non-terminal step has `nextStep: { defaultTargetStepId, branches }`. Terminal step has `nextStep: null`. Non-terminal `nextStep: null` = REWORK (relies on implicit array-order linking instead of the explicit multi-path convention).
+  - Every `branches[].targetStepId` references a real step `id`.
+  - Every `branches[].condition` is `null` (unconditional catch-all) OR a valid `LeafCondition` / `ConditionGroup`. Operators must be `eq|neq|gt|lt|gte|lte|contains|in|not_in`.
+  - Variables in `branches[].condition` are captured upstream of the deciding step.
+  - Flag orphan steps (`id` never referenced as `defaultTargetStepId` or `targetStepId` AND not the entry step).
 
 ### Step 2: Design system
 
@@ -104,6 +110,8 @@ Group findings into four buckets. Each: one line, location, what's wrong, fix.
 - step "goal" / payload — uses `payload.root`; must be `payload.elements: UIElement[]`. Causes Studio "els is not iterable" crash.
 - step "goal" / payload.elements[0].children[1].id — missing. Required on every UIElement.
 - step "reflection" / payload.elements[0].children[0].props — uses `text`; must be `content` with `mode: "expression"` for `{{firstName}}` interpolation.
+- step "goal" / nextStep — `null` on a non-terminal step. Set `{ defaultTargetStepId: "experience", branches: [] }` (auto-link convention).
+- step "experience" / nextStep.branches[0].targetStepId — references "beginner-reflection" but no step with that id exists in the flow.
 
 ## Design system
 - step "hero" / payload.elements[0].children[2].props.color — uses "#FF6B35" but app brand is #27ae60 (src/design-system/tokens.ts).

--- a/claude-plugin/skills/create-step-json/SKILL.md
+++ b/claude-plugin/skills/create-step-json/SKILL.md
@@ -53,8 +53,24 @@ Always set:
 - `displayProgressHeader` — `false` for hook/loader/commitment, `true` otherwise.
 - `customPayload: null`
 - `continueButtonLabel` — pick verb from app's voice (probe). Note: in ComposableScreen this is usually unused since the CTA is its own `Button` element inside `payload.elements`.
-- `nextStep` — `null` for linear, or `{ defaultTargetStepId, branches }`.
+- `nextStep` — **always emit as an explicit multi-path link** when generating a flow of > 1 step. Default-link each step to the next via `{ defaultTargetStepId: "<next-step-id>", branches: [] }`. Only the terminal step (or a true single-step generation) gets `nextStep: null`. If a branching condition applies, add `branches: [{ condition, targetStepId }]` — first match wins, `defaultTargetStepId` is the fallback. **Do not rely on the null + array-order linear fallback for multi-step flows.** Explicit links survive reordering and make adding branches trivial. (`null` still resolves linearly at runtime — see `resolveNextStepNumber.test.ts` — but explicit multi-path is the convention.)
 - `payload` — must be exactly `{ "elements": [ /* UIElement[] */ ] }`.
+
+### Auto-linking rule (when generating > 1 step)
+
+Walk the flow in order. For each step `i` of an `N`-length flow:
+
+```jsonc
+// step 0..N-2
+"nextStep": {
+  "defaultTargetStepId": "<id of step i+1>",
+  "branches": [ /* optional condition routes */ ]
+}
+// step N-1 (terminal)
+"nextStep": null
+```
+
+Branch resolution: first matching `branches[].condition` wins; otherwise `defaultTargetStepId`. Every `targetStepId` (branch or default) MUST reference a real `id` present in the flow.
 
 **Do NOT set `payload.root`. Do NOT set `payload.variables`. Those keys do not exist in the schema.** Variables flow at runtime from prior steps' `variableName` captures or from in-screen `Input` / `RadioGroup` / `CheckboxGroup` / `Button` `setVariable` actions — they are never declared in the payload.
 
@@ -91,7 +107,7 @@ Single fenced JSON block, no prose unless explanation requested.
   "displayProgressHeader": true,
   "customPayload": null,
   "continueButtonLabel": "Continue",
-  "nextStep": null,
+  "nextStep": { "defaultTargetStepId": "experience", "branches": [] },
   "payload": {
     "elements": [
       {

--- a/claude-plugin/skills/onboarding-best-practices/SKILL.md
+++ b/claude-plugin/skills/onboarding-best-practices/SKILL.md
@@ -81,6 +81,24 @@ Total: 8–12 screens. > 15 = measurable drop-off.
 - 3–5 slides max. More than 5 = swipe fatigue.
 - Show progress dots.
 
+## Step linking (auto-link via multi-path)
+
+Every step in a multi-step flow uses the explicit multi-path link form:
+
+```jsonc
+"nextStep": {
+  "defaultTargetStepId": "<next step id>",
+  "branches": []          // empty when linear; populated when conditional routing applies
+}
+```
+
+- **Linear by default**: each step's `defaultTargetStepId` points at the next step's `id`. Terminal step is the only `nextStep: null`.
+- **Branching where needed**: when routing depends on a captured variable, add `branches: [{ condition, targetStepId }]`. First matching branch wins; `defaultTargetStepId` is the catch-all.
+- **Why explicit, not `null` linear fallback**: `nextStep: null` resolves to "next in array" at runtime (`resolveNextStepNumber.test.ts`) but that couples flow order to array index — reordering silently re-routes the flow. Explicit links survive reordering and make branching trivial to layer in.
+- Branch `condition` is a `LeafCondition` (`{ variable, operator, value }`) or `ConditionGroup` (`{ logic: "and" | "or", conditions: [...] }`). Operators: `eq`, `neq`, `gt`, `lt`, `gte`, `lte`, `contains`, `in`, `not_in`.
+- Variables referenced in conditions MUST be captured upstream (`Input` / `RadioGroup` / `CheckboxGroup` / `DatePicker` `variableName`, or a `setVariable` action).
+- Every `targetStepId` (branch + default) MUST exist in the flow.
+
 ## Branching
 
 - Branch on highest-cardinality variable first (gender, goal).

--- a/claude-plugin/skills/validate-step-json/SKILL.md
+++ b/claude-plugin/skills/validate-step-json/SKILL.md
@@ -47,6 +47,13 @@ Run: `npx tsx scripts/_validate-composable.ts "$(cat step.json)"`
    - `Button.props.pressedStyle` / `disabledStyle` (if present) are objects — `Partial` of overridable Button props; must NOT nest `pressedStyle`/`disabledStyle`. `transitionDurationMs` is a non-negative number.
    - Shadow fields (any element): `shadowColor` string; `shadowOffset` is `{width, height}` (NOT a number); `shadowOpacity` 0–1; `shadowRadius`/`elevation` non-negative numbers
    - `SafeAreaView.props.edges` is an array of `"top"|"right"|"bottom"|"left"` OR an object with edge mode `"off"|"additive"|"maximum"` — NEVER `"always"`
+   - **Flow-level chain integrity (when input is an array of steps)**:
+     - Every non-terminal step has `nextStep: { defaultTargetStepId, branches }`. Terminal step has `nextStep: null`. Flag steps that rely on `null` linear fallback in the middle of a flow as a warning ("implicit linear link — prefer explicit defaultTargetStepId").
+     - `nextStep.defaultTargetStepId` is a string and references a real step `id` in the flow.
+     - Every `branches[].targetStepId` is a string and references a real step `id` in the flow.
+     - Every `branches[].condition` is `null` (unconditional catch-all) OR a valid `LeafCondition` / `ConditionGroup`.
+     - Every variable referenced in a `branches[].condition` is captured upstream (by an Input / RadioGroup / CheckboxGroup / DatePicker `variableName` or a `setVariable` action) — warn if not.
+     - For multi-step flows, every step except the terminal one must define an explicit `defaultTargetStepId` (auto-link convention).
 5. Report ALL errors at once with path + reason. Don't stop on first.
 
 ## Common failure modes
@@ -70,6 +77,10 @@ Run: `npx tsx scripts/_validate-composable.ts "$(cat step.json)"`
 - `RadioGroup` / `CheckboxGroup` / `Input` / `DatePicker` without `variableName` — element renders but variable never captured.
 - Nested `SafeAreaView`.
 - `nextStep.defaultTargetStepId` referencing nonexistent step ID.
+- `nextStep: null` on a non-terminal step in a multi-step flow (relies on implicit array-order linking; prefer explicit `defaultTargetStepId`).
+- `branches[].targetStepId` referencing nonexistent step ID.
+- `branches[].condition` referencing a variable never captured upstream.
+- Branch with non-null condition that lists an unknown `operator` (must be `eq|neq|gt|lt|gte|lte|contains|in|not_in`).
 - `customPayload: {}` instead of `null` (both validate; prefer `null`).
 - `Carousel` with empty `children`.
 


### PR DESCRIPTION
## Summary

Update `rocapine-onboarding-sdk` plugin skills + agents so generated onboarding flows **auto-link each step to the next** via an explicit `nextStep.defaultTargetStepId` (linear by default), and add `branches` where a routing condition applies — instead of relying on the implicit `null` + array-order fallback.

Linear by default, branching where a condition is present.

## Changes

- **create-step-json**: `nextStep` field guidance rewritten + new "Auto-linking rule" section + example JSON updated to explicit link.
- **onboarding-architect** (agent): Step 4 link guidance + new "Auto-link the chain" section.
- **onboarding-best-practices**: new "Step linking (auto-link via multi-path)" section.
- **validate-step-json**: flow-level chain-integrity checks + new failure modes (non-terminal `null`, dangling `targetStepId`, unknown operators, condition vars not captured upstream).
- **step-json-reviewer** (agent): chain-integrity review bullets + finding examples; non-terminal `null` flagged REWORK.

Docs-only. No SDK code or schema change — relies on existing `NextStepSchema` (`{ defaultTargetStepId, branches }`) and `resolveNextStepNumber`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated step linking requirements to use explicit multi-path definitions with default target IDs and conditional branches
  * Enhanced validation rules for flow integrity and step chaining
  * Clarified payload structure specifications and terminal step handling
  * Expanded guidance on multi-step flow design patterns and branch condition syntax

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Rocapine/react-native-onboarding/pull/52?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->