### PR TITLE
fix(composable-screen): layout + shadow + Rive + schema (v1.25.1)

### DIFF
--- a/.claude/rules/composable-screen-runtime.md
+++ b/.claude/rules/composable-screen-runtime.md
@@ -68,3 +68,19 @@ When introducing a new element type with a `defaultValue` / `defaultIndex`:
 
 1. Add a case in `elements/collectDefaults.ts` returning `{value, label?}`.
 2. If the element clamps/coerces the raw default at runtime (like `CarouselElementComponent.clampIndex`), mirror the same logic in `collectDefaults.ts` — otherwise the overlaid value disagrees with the rendered index.
+
+## iOS shadow needs no overflow clip
+
+A view with `overflow: hidden` (default for `Image`, gradient wrappers, many container styles) clips its own shadow on iOS, so the shadow renders invisible. For elements that want a shadow, build a wrapper View that carries `shadow*` + layout (no overflow clip) and let the inner content carry `borderRadius` + `overflow: hidden` for corner clipping. See `ImageElement.tsx` / `ButtonElement.tsx`. Also: when only `shadowColor` is set, default `shadowOpacity:1`, `shadowRadius:4` — iOS defaults opacity to 0 so a lone `shadowColor` does nothing.
+
+## RN treats `padding` and `padding{Horizontal,Vertical}` independently
+
+`style={{ padding: eff.padding, paddingHorizontal: eff.paddingHorizontal ?? 24 }}` will still apply 24 when payload sets `padding: 0`, because the axis prop's `??` fallback ignores the shorthand. Gate axis defaults on `eff.padding != null ? undefined : <default>` so explicit `padding:0` actually wins. Same gotcha for `margin`.
+
+## Don't wrap ComposableScreen payload in a page-level ScrollView
+
+Page Renderer is intentionally a plain `View flex:1` inside `KeyboardAvoidingView` — `contentContainerStyle: { flexGrow: 1 }` leaves inner `flex:1` children unbounded vertically, so a `Carousel`/`flex:1` payload grows with its intrinsic content and pushes siblings off-screen. Payloads needing scroll must use the `ScrollView` UIElement.
+
+## Rive intrinsic = artboard pixel size
+
+`rive-react-native` doesn't expose the artboard ratio to JS, so a Rive view with no `height` / `flex` / `aspectRatio` reports the raw artboard pixels as its intrinsic — fills the screen. `RiveElement` falls back to `aspectRatio: 1` when unsized; authors with a known ratio override via `aspectRatio`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,3 +170,9 @@ npm run publish:all
 cd packages/onboarding && npm run patch    # bump + build + publish
 cd packages/onboarding-ui && npm run patch # bump + build + publish
 ```
+
+## Debugging ComposableScreen schema parse errors
+
+- Fetch a project's draft payload directly: `curl "$EXPO_PUBLIC_ONBOARDING_BASE_URL/get-onboarding-steps?projectId=$PID&platform=ios&appVersion=1.0.0&draft=true&locale=en"`.
+- Validate against the schema in Node using the **headless** dist only (`require('./packages/onboarding/dist/steps/ComposableScreen/types.js')`) — the UI dist imports `react-native` and won't load under Node.
+- Zod v4 `invalid_union` paths are cumulative across nested variant errors; walk the issue tree and concatenate `prefix + it.path` recursively to surface the real failing path.

--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rocapine-onboarding-sdk",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "description": "End-to-end workflow for building and updating Rocapine Onboarding Studio flows: author step JSON, integrate the headless + UI SDKs, customize theme/components, and review onboarding quality.",
   "author": {
     "name": "Rocapine",

--- a/example/app/example/composable-screen.tsx
+++ b/example/app/example/composable-screen.tsx
@@ -37,15 +37,16 @@ export default function ComposableScreenExample() {
                 loop: true,
               },
             },
-            // Rive animation
+            // Rive animation — width:100% + aspectRatio scales to artboard
             {
               id: 'hero-rive',
               type: 'Rive',
               props: {
                 url: 'https://cdn.rive.app/animations/vehicles.riv',
-                height: 180,
+                width: '100%',
+                aspectRatio: 16 / 9,
                 autoPlay: true,
-                fit: 'Contain',
+                fit: 'FitWidth',
               },
             },
             // Hero image

--- a/package-lock.json
+++ b/package-lock.json
@@ -14692,7 +14692,7 @@
     },
     "packages/onboarding": {
       "name": "@rocapine/react-native-onboarding",
-      "version": "1.22.0",
+      "version": "1.25.0",
       "license": "MIT",
       "dependencies": {
         "@react-native-async-storage/async-storage": "^2.1.0",
@@ -14719,7 +14719,7 @@
     },
     "packages/onboarding-ui": {
       "name": "@rocapine/react-native-onboarding-ui",
-      "version": "1.22.0",
+      "version": "1.25.0",
       "license": "MIT",
       "dependencies": {
         "lucide-react-native": "^0.545.0",
@@ -14747,7 +14747,7 @@
       "peerDependencies": {
         "@react-native-community/datetimepicker": "*",
         "@react-native-picker/picker": "*",
-        "@rocapine/react-native-onboarding": "^1.17.0",
+        "@rocapine/react-native-onboarding": "^1.23.0",
         "@shopify/react-native-skia": ">=1.0.0",
         "@tanstack/react-query": ">=5.0.0",
         "@types/react": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14692,7 +14692,7 @@
     },
     "packages/onboarding": {
       "name": "@rocapine/react-native-onboarding",
-      "version": "1.25.0",
+      "version": "1.25.1",
       "license": "MIT",
       "dependencies": {
         "@react-native-async-storage/async-storage": "^2.1.0",
@@ -14719,7 +14719,7 @@
     },
     "packages/onboarding-ui": {
       "name": "@rocapine/react-native-onboarding-ui",
-      "version": "1.25.0",
+      "version": "1.25.1",
       "license": "MIT",
       "dependencies": {
         "lucide-react-native": "^0.545.0",

--- a/packages/onboarding-ui/CHANGELOG.md
+++ b/packages/onboarding-ui/CHANGELOG.md
@@ -25,6 +25,13 @@ here.
   with its intrinsic content and pushed siblings off-screen. Payloads
   needing scroll should use the `ScrollView` UIElement (added in 1.25.0).
   `KeyboardAvoidingView` still wraps the page root.
+
+  **Migration:** if your existing payload relied on the implicit page
+  scroll (content taller than the viewport with no `ScrollView`
+  UIElement), wrap your top-level container in a `ScrollView` element to
+  restore the previous behavior. Layouts where the root container is
+  `flex: 1` (the common case) are unaffected — and now render
+  correctly when the inner tree uses `flex` to share space.
 - **Rive default size** — wrapper height defaults to undefined (was
   `200`); when neither `height` / `flex` / `aspectRatio` / `min-height` /
   `max-height` is set, falls back to `aspectRatio: 1` so the artboard

--- a/packages/onboarding-ui/CHANGELOG.md
+++ b/packages/onboarding-ui/CHANGELOG.md
@@ -9,6 +9,49 @@ here.
 
 ---
 
+## [1.25.1] - 2026-05-28
+
+### Added
+
+- **`aspectRatio` on every UIElement (via `BaseBoxProps`)** — wired into
+  the Rive renderer's wrapper; other element renderers can opt-in by
+  reading `p.aspectRatio`.
+
+### Changed
+
+- **ComposableScreen page no longer wraps content in a `ScrollView`** —
+  the wrapper container's `flexGrow: 1` left inner `flex: 1` children
+  unbounded vertically, so a `Carousel` (or any `flex: 1` element) grew
+  with its intrinsic content and pushed siblings off-screen. Payloads
+  needing scroll should use the `ScrollView` UIElement (added in 1.25.0).
+  `KeyboardAvoidingView` still wraps the page root.
+- **Rive default size** — wrapper height defaults to undefined (was
+  `200`); when neither `height` / `flex` / `aspectRatio` / `min-height` /
+  `max-height` is set, falls back to `aspectRatio: 1` so the artboard
+  doesn't fill the screen via its native intrinsic.
+
+### Fixed
+
+- **`Button` honors explicit `padding: 0`** — sub-axis defaults
+  (`paddingHorizontal: 24`, `paddingVertical: 14`) used to apply even
+  when `padding` was set to 0, because RN treats the shorthand and
+  axis props independently. Axis defaults now apply only when `padding`
+  itself is unset.
+- **`Button` honors `textAlign`** — Pressable's `alignItems: "center"`
+  constrained the label `Text` to its intrinsic width, neutralizing
+  `textAlign`. Removed the constraint so the label stretches and
+  `left | center | right` applies (default still centered).
+- **`Button` shadow visible from `shadowColor` alone** — iOS defaults
+  `shadowOpacity` to 0; the renderer now fills in `shadowOpacity: 1`
+  and `shadowRadius: 4` when only `shadowColor` is set.
+- **`Image` shadow renders** — iOS clipped image shadows because the
+  `Image` host had `overflow: hidden`. When `shadowColor` / `elevation`
+  is set, the renderer now wraps the image in a shadow-carrying `View`
+  (or `GradientBox`) and lets the inner `Image` clip its own rounded
+  corners.
+
+---
+
 ## [1.25.0] - 2026-05-27
 
 ### Added

--- a/packages/onboarding-ui/package.json
+++ b/packages/onboarding-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocapine/react-native-onboarding-ui",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "description": "UI components and renderers for Rocapine Onboarding Studio - Built on top of the headless SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/Renderer.tsx
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/Renderer.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useContext, useMemo } from "react";
-import { KeyboardAvoidingView, Platform, ScrollView, StyleSheet } from "react-native";
+import { KeyboardAvoidingView, Platform, StyleSheet, View } from "react-native";
 import { OnboardingProgressContext as HeadlessProgressContext } from "@rocapine/react-native-onboarding";
 import { ComposableScreenStepType, ComposableScreenStepTypeSchema, UIElement } from "./types";
 import { withErrorBoundary } from "../../ErrorBoundary";
@@ -63,14 +63,9 @@ const ComposableScreenRendererBase = ({ step, onContinue }: ContentProps) => {
         style={styles.flex}
         behavior={Platform.OS === "ios" ? "padding" : "height"}
       >
-        <ScrollView
-          contentContainerStyle={styles.scrollContent}
-          showsVerticalScrollIndicator={false}
-          alwaysBounceVertical={false}
-          keyboardShouldPersistTaps="handled"
-        >
+        <View style={styles.flex}>
           {elements.map((element) => renderElement(element, ctx))}
-        </ScrollView>
+        </View>
       </KeyboardAvoidingView>
     </OnboardingTemplate>
   );
@@ -79,9 +74,6 @@ const ComposableScreenRendererBase = ({ step, onContinue }: ContentProps) => {
 const styles = StyleSheet.create({
   flex: {
     flex: 1,
-  },
-  scrollContent: {
-    flexGrow: 1,
   },
 });
 

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/BaseBoxProps.ts
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/BaseBoxProps.ts
@@ -60,6 +60,7 @@ export type BaseBoxProps = {
   flex?: number;
   flexShrink?: number;
   flexGrow?: number;
+  aspectRatio?: number;
   alignSelf?: "auto" | "flex-start" | "flex-end" | "center" | "stretch" | "baseline";
   opacity?: number;
   backgroundColor?: string;
@@ -91,6 +92,7 @@ export const BaseBoxPropsSchema = z.object({
   flex: z.number().min(0).optional(),
   flexShrink: z.number().min(0).optional(),
   flexGrow: z.number().min(0).optional(),
+  aspectRatio: z.number().positive().optional(),
   alignSelf: z.enum(["auto", "flex-start", "flex-end", "center", "stretch", "baseline"]).optional(),
   opacity: z.number().min(0).max(1).optional(),
   backgroundColor: z.string().optional(),

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/ButtonElement.tsx
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/ButtonElement.tsx
@@ -375,8 +375,8 @@ export const ButtonElementComponent = ({ element, ctx }: Props): React.ReactElem
         disabled={isDisabled}
         style={{
           padding: eff.padding,
-          paddingVertical: eff.paddingVertical ?? 14,
-          paddingHorizontal: eff.paddingHorizontal ?? 24,
+          paddingVertical: eff.paddingVertical ?? (eff.padding != null ? undefined : 14),
+          paddingHorizontal: eff.paddingHorizontal ?? (eff.padding != null ? undefined : 24),
           alignItems: "center",
           justifyContent: "center",
           borderRadius,

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/ButtonElement.tsx
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/ButtonElement.tsx
@@ -12,7 +12,7 @@ import {
 } from "@rocapine/react-native-onboarding";
 import { BaseBoxProps, BaseBoxPropsSchema } from "./BaseBoxProps";
 import { UIElement } from "../types";
-import { RenderContext, dim, resolveInheritedFontFamily } from "./shared";
+import { RenderContext, buildShadowStyle, dim, resolveInheritedFontFamily } from "./shared";
 import { GradientBox } from "./GradientBox";
 import { ComposableVariableEntry } from "../../../Provider/OnboardingProgressProvider";
 import { evaluateSetVariableExpression } from "./expression";
@@ -139,20 +139,6 @@ type ButtonUIElement = Extract<UIElement, { type: "Button" }>;
 type Props = {
   element: ButtonUIElement;
   ctx: RenderContext;
-};
-
-const buildShadowStyle = (p: Pick<BaseBoxProps, "shadowColor" | "shadowOffset" | "shadowOpacity" | "shadowRadius" | "elevation">) => {
-  // iOS defaults shadowOpacity to 0 (invisible). When shadowColor is set we
-  // assume the author wants a visible shadow and fill in sensible defaults
-  // for opacity/radius. Android uses `elevation` independently.
-  const hasShadow = p.shadowColor != null;
-  return {
-    shadowColor: p.shadowColor,
-    shadowOffset: p.shadowOffset,
-    shadowOpacity: p.shadowOpacity ?? (hasShadow ? 1 : undefined),
-    shadowRadius: p.shadowRadius ?? (hasShadow ? 4 : undefined),
-    elevation: p.elevation,
-  };
 };
 
 export const ButtonElementComponent = ({ element, ctx }: Props): React.ReactElement => {
@@ -344,8 +330,8 @@ export const ButtonElementComponent = ({ element, ctx }: Props): React.ReactElem
             style={{
               flex: 1,
               padding: eff.padding,
-              paddingVertical: eff.paddingVertical ?? 14,
-              paddingHorizontal: eff.paddingHorizontal ?? 24,
+              paddingVertical: eff.paddingVertical ?? (eff.padding != null ? undefined : 14),
+              paddingHorizontal: eff.paddingHorizontal ?? (eff.padding != null ? undefined : 24),
               justifyContent: "center",
             }}
           >

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/ButtonElement.tsx
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/ButtonElement.tsx
@@ -141,13 +141,19 @@ type Props = {
   ctx: RenderContext;
 };
 
-const buildShadowStyle = (p: Pick<BaseBoxProps, "shadowColor" | "shadowOffset" | "shadowOpacity" | "shadowRadius" | "elevation">) => ({
-  shadowColor: p.shadowColor,
-  shadowOffset: p.shadowOffset,
-  shadowOpacity: p.shadowOpacity,
-  shadowRadius: p.shadowRadius,
-  elevation: p.elevation,
-});
+const buildShadowStyle = (p: Pick<BaseBoxProps, "shadowColor" | "shadowOffset" | "shadowOpacity" | "shadowRadius" | "elevation">) => {
+  // iOS defaults shadowOpacity to 0 (invisible). When shadowColor is set we
+  // assume the author wants a visible shadow and fill in sensible defaults
+  // for opacity/radius. Android uses `elevation` independently.
+  const hasShadow = p.shadowColor != null;
+  return {
+    shadowColor: p.shadowColor,
+    shadowOffset: p.shadowOffset,
+    shadowOpacity: p.shadowOpacity ?? (hasShadow ? 1 : undefined),
+    shadowRadius: p.shadowRadius ?? (hasShadow ? 4 : undefined),
+    elevation: p.elevation,
+  };
+};
 
 export const ButtonElementComponent = ({ element, ctx }: Props): React.ReactElement => {
   const { theme, onContinue, customActions, variables, setVariable } = ctx;

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/ButtonElement.tsx
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/ButtonElement.tsx
@@ -340,7 +340,6 @@ export const ButtonElementComponent = ({ element, ctx }: Props): React.ReactElem
               padding: eff.padding,
               paddingVertical: eff.paddingVertical ?? 14,
               paddingHorizontal: eff.paddingHorizontal ?? 24,
-              alignItems: "center",
               justifyContent: "center",
             }}
           >
@@ -377,7 +376,6 @@ export const ButtonElementComponent = ({ element, ctx }: Props): React.ReactElem
           padding: eff.padding,
           paddingVertical: eff.paddingVertical ?? (eff.padding != null ? undefined : 14),
           paddingHorizontal: eff.paddingHorizontal ?? (eff.padding != null ? undefined : 24),
-          alignItems: "center",
           justifyContent: "center",
           borderRadius,
         }}

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/ImageElement.tsx
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/ImageElement.tsx
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { Image, View } from "react-native";
 import { BaseBoxProps, BaseBoxPropsSchema } from "./BaseBoxProps";
 import { UIElement } from "../types";
-import { RenderContext, dim } from "./shared";
+import { RenderContext, buildShadowStyle, dim } from "./shared";
 import { GradientBox } from "./GradientBox";
 
 export type ImageElementProps = BaseBoxProps & {
@@ -30,16 +30,8 @@ export const ImageElementComponent = ({ element }: Props): React.ReactElement =>
   const hasShadow = p.shadowColor != null || p.elevation != null;
   // iOS clips shadows when overflow:hidden, so a shadow-bearing Image needs a
   // wrapper View carrying the shadow (no overflow clip) and the Image inside
-  // with the rounded clip. Mirrors ButtonElement shadow defaults.
-  const shadowStyle = hasShadow
-    ? {
-        shadowColor: p.shadowColor,
-        shadowOffset: p.shadowOffset,
-        shadowOpacity: p.shadowOpacity ?? (p.shadowColor != null ? 1 : undefined),
-        shadowRadius: p.shadowRadius ?? (p.shadowColor != null ? 4 : undefined),
-        elevation: p.elevation,
-      }
-    : null;
+  // with the rounded clip.
+  const shadowStyle = hasShadow ? buildShadowStyle(p) : null;
 
   if (p.backgroundGradient || hasShadow) {
     const wrapperStyle = {

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/ImageElement.tsx
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/ImageElement.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { z } from "zod";
-import { Image } from "react-native";
+import { Image, View } from "react-native";
 import { BaseBoxProps, BaseBoxPropsSchema } from "./BaseBoxProps";
 import { UIElement } from "../types";
 import { RenderContext, dim } from "./shared";
@@ -26,45 +26,66 @@ type Props = {
 };
 
 export const ImageElementComponent = ({ element }: Props): React.ReactElement => {
-  const hasExplicitHeight = element.props.height !== undefined;
-
   const p = element.props;
+  const hasShadow = p.shadowColor != null || p.elevation != null;
+  // iOS clips shadows when overflow:hidden, so a shadow-bearing Image needs a
+  // wrapper View carrying the shadow (no overflow clip) and the Image inside
+  // with the rounded clip. Mirrors ButtonElement shadow defaults.
+  const shadowStyle = hasShadow
+    ? {
+        shadowColor: p.shadowColor,
+        shadowOffset: p.shadowOffset,
+        shadowOpacity: p.shadowOpacity ?? (p.shadowColor != null ? 1 : undefined),
+        shadowRadius: p.shadowRadius ?? (p.shadowColor != null ? 4 : undefined),
+        elevation: p.elevation,
+      }
+    : null;
 
-  if (p.backgroundGradient) {
-    return (
-      <GradientBox
-        gradient={p.backgroundGradient}
+  if (p.backgroundGradient || hasShadow) {
+    const wrapperStyle = {
+      flex: p.flex,
+      flexShrink: p.flexShrink,
+      flexGrow: p.flexGrow,
+      alignSelf: p.alignSelf,
+      aspectRatio: p.aspectRatio,
+      width: dim(p.width),
+      height: dim(p.height),
+      minWidth: p.minWidth,
+      maxWidth: p.maxWidth,
+      minHeight: p.minHeight,
+      maxHeight: p.maxHeight,
+      borderRadius: p.borderRadius,
+      borderWidth: p.borderWidth,
+      borderColor: p.borderColor,
+      opacity: p.opacity,
+      margin: p.margin,
+      marginHorizontal: p.marginHorizontal,
+      marginVertical: p.marginVertical,
+      padding: p.padding,
+      paddingHorizontal: p.paddingHorizontal,
+      paddingVertical: p.paddingVertical,
+      ...(shadowStyle ?? {}),
+    };
+    const innerImage = (
+      <Image
+        source={{ uri: p.url }}
+        resizeMode={p.resizeMode}
         style={{
-          flex: p.flex,
-          flexShrink: p.flexShrink,
-          flexGrow: p.flexGrow,
-          alignSelf: p.alignSelf,
-          width: dim(p.width),
-          height: dim(p.height),
-          minWidth: p.minWidth,
-          maxWidth: p.maxWidth,
-          minHeight: p.minHeight,
-          maxHeight: p.maxHeight,
-          overflow: (p.overflow ?? "hidden") as any,
+          width: "100%",
+          height: "100%",
           borderRadius: p.borderRadius,
-          borderWidth: p.borderWidth,
-          borderColor: p.borderColor,
-          opacity: p.opacity,
-          margin: p.margin,
-          marginHorizontal: p.marginHorizontal,
-          marginVertical: p.marginVertical,
-          padding: p.padding,
-          paddingHorizontal: p.paddingHorizontal,
-          paddingVertical: p.paddingVertical,
+          overflow: (p.overflow ?? "hidden") as any,
         }}
-      >
-        <Image
-          source={{ uri: p.url }}
-          resizeMode={p.resizeMode}
-          style={{ width: "100%", height: "100%" }}
-        />
-      </GradientBox>
+      />
     );
+    if (p.backgroundGradient) {
+      return (
+        <GradientBox gradient={p.backgroundGradient} style={wrapperStyle as any}>
+          {innerImage}
+        </GradientBox>
+      );
+    }
+    return <View style={wrapperStyle as any}>{innerImage}</View>;
   }
 
   return (
@@ -76,6 +97,7 @@ export const ImageElementComponent = ({ element }: Props): React.ReactElement =>
         flexShrink: p.flexShrink,
         flexGrow: p.flexGrow,
         alignSelf: p.alignSelf,
+        aspectRatio: p.aspectRatio,
         width: dim(p.width),
         height: dim(p.height),
         minWidth: p.minWidth,

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/RiveElement.tsx
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/RiveElement.tsx
@@ -61,6 +61,7 @@ export const RiveElementRenderer = ({ element, ctx }: Props): React.ReactElement
     flex: p.flex,
     flexShrink: p.flexShrink,
     flexGrow: p.flexGrow,
+    aspectRatio: p.aspectRatio,
     alignSelf: p.alignSelf,
     width: dim(p.width) ?? ("100%" as `${number}%`),
     height: dim(p.height),

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/RiveElement.tsx
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/RiveElement.tsx
@@ -57,11 +57,22 @@ type Props = {
 export const RiveElementRenderer = ({ element, ctx }: Props): React.ReactElement => {
   const { theme } = ctx;
   const p = element.props;
+  // rive-react-native doesn't report artboard intrinsic to JS, so a Rive view
+  // with no height/flex/aspectRatio reports its native artboard pixel size as
+  // intrinsic — which fills the screen. Fall back to aspectRatio:1 (square)
+  // so width:100% bounds the box deterministically when the author hasn't
+  // sized it.
+  const hasExplicitSize =
+    p.height != null ||
+    p.flex != null ||
+    p.aspectRatio != null ||
+    p.minHeight != null ||
+    p.maxHeight != null;
   const wrapperStyle = {
     flex: p.flex,
     flexShrink: p.flexShrink,
     flexGrow: p.flexGrow,
-    aspectRatio: p.aspectRatio,
+    aspectRatio: p.aspectRatio ?? (hasExplicitSize ? undefined : 1),
     alignSelf: p.alignSelf,
     width: dim(p.width) ?? ("100%" as `${number}%`),
     height: dim(p.height),

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/RiveElement.tsx
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/RiveElement.tsx
@@ -63,7 +63,7 @@ export const RiveElementRenderer = ({ element, ctx }: Props): React.ReactElement
     flexGrow: p.flexGrow,
     alignSelf: p.alignSelf,
     width: dim(p.width) ?? ("100%" as `${number}%`),
-    height: dim(p.height ?? 200),
+    height: dim(p.height),
     minWidth: p.minWidth,
     maxWidth: p.maxWidth,
     minHeight: p.minHeight,

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/shared.ts
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/shared.ts
@@ -3,6 +3,7 @@ import { CustomActions } from "@rocapine/react-native-onboarding";
 import { UIElement } from "../types";
 import { Theme } from "../../../Theme/types";
 import { ComposableVariableEntry } from "../../../Provider/OnboardingProgressProvider";
+import type { BaseBoxProps } from "./BaseBoxProps";
 
 export type RenderContext = {
   theme: Theme;
@@ -19,6 +20,25 @@ export const interpolate = (template: string, variables: Record<string, Composab
 // Cast number | string dimension values to DimensionValue for React Native style props
 export const dim = (v: number | string | undefined): import("react-native").DimensionValue | undefined =>
   v as import("react-native").DimensionValue | undefined;
+
+// Build a RN shadow style with sensible iOS defaults. iOS defaults
+// `shadowOpacity` to 0 and `shadowRadius` to 0, so an author setting only
+// `shadowColor` would see no shadow. Fill in 1 / 4 when those are unset.
+// Android shadows go through `elevation` independently.
+export type ShadowStyleInput = Pick<
+  BaseBoxProps,
+  "shadowColor" | "shadowOffset" | "shadowOpacity" | "shadowRadius" | "elevation"
+>;
+export const buildShadowStyle = (p: ShadowStyleInput) => {
+  const hasShadow = p.shadowColor != null;
+  return {
+    shadowColor: p.shadowColor,
+    shadowOffset: p.shadowOffset,
+    shadowOpacity: p.shadowOpacity ?? (hasShadow ? 1 : undefined),
+    shadowRadius: p.shadowRadius ?? (hasShadow ? 4 : undefined),
+    elevation: p.elevation,
+  };
+};
 
 // Resolve element fontFamily against theme `typography.defaultFontFamily`.
 // Returns the theme default when element omits fontFamily or sets it to "inherit".

--- a/packages/onboarding/CHANGELOG.md
+++ b/packages/onboarding/CHANGELOG.md
@@ -8,6 +8,17 @@ All notable changes to `@rocapine/react-native-onboarding` are documented here.
 
 ---
 
+## [1.25.1] - 2026-05-28
+
+### Added
+
+- **`aspectRatio` on `BaseBoxProps`** — every UIElement now accepts an
+  optional positive `aspectRatio` number, mirroring the React Native
+  style prop. Pair with `width` / `height` to derive the other dimension
+  instead of hard-coding both.
+
+---
+
 ## [1.25.0] - 2026-05-27
 
 ### Added

--- a/packages/onboarding/package.json
+++ b/packages/onboarding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocapine/react-native-onboarding",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "description": "Headless React Native SDK for Rocapine Onboarding Studio - Data fetching, state management, and hooks",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/onboarding/src/onboarding-example.ts
+++ b/packages/onboarding/src/onboarding-example.ts
@@ -130,9 +130,10 @@ export const onboardingExample = {
                 type: "Rive",
                 props: {
                   url: "https://cdn.rive.app/animations/vehicles.riv",
-                  height: 180,
+                  width: "100%",
+                  aspectRatio: 16 / 9,
                   autoPlay: true,
-                  fit: "Contain",
+                  fit: "FitWidth",
                 },
               },
               {

--- a/packages/onboarding/src/steps/ComposableScreen/elements/BaseBoxProps.ts
+++ b/packages/onboarding/src/steps/ComposableScreen/elements/BaseBoxProps.ts
@@ -60,6 +60,7 @@ export type BaseBoxProps = {
   flex?: number;
   flexShrink?: number;
   flexGrow?: number;
+  aspectRatio?: number;
   alignSelf?: "auto" | "flex-start" | "flex-end" | "center" | "stretch" | "baseline";
   opacity?: number;
   backgroundColor?: string;
@@ -91,6 +92,7 @@ export const BaseBoxPropsSchema = z.object({
   flex: z.number().min(0).optional(),
   flexShrink: z.number().min(0).optional(),
   flexGrow: z.number().min(0).optional(),
+  aspectRatio: z.number().positive().optional(),
   alignSelf: z.enum(["auto", "flex-start", "flex-end", "center", "stretch", "baseline"]).optional(),
   opacity: z.number().min(0).max(1).optional(),
   backgroundColor: z.string().optional(),

--- a/website/docs/page-types.mdx
+++ b/website/docs/page-types.mdx
@@ -951,7 +951,8 @@ If `lottie-react-native` is not installed, the element renders a placeholder vie
 |------|------|-------|
 | `url` | `string` | **Required** — remote `.riv` URL |
 | `width` | `number` | Defaults to `"100%"` |
-| `height` | `number` | Defaults to `200` |
+| `height` | `number` | Optional. When omitted, `aspectRatio` sizes the box |
+| `aspectRatio` | `number` | Used when `height` is absent; falls back to `1` if neither `height` / `flex` / `aspectRatio` / `minHeight` / `maxHeight` is set, because `rive-react-native` doesn't expose the artboard's intrinsic ratio to JS |
 | `autoplay` | `boolean` | Defaults to `true` |
 | `fit` | `"Contain" \| "Cover" \| "Fill" \| "FitWidth" \| "FitHeight" \| "None" \| "ScaleDown" \| "Layout"` | |
 | `alignment` | `"TopLeft" \| "TopCenter" \| "TopRight" \| "CenterLeft" \| "Center" \| "CenterRight" \| "BottomLeft" \| "BottomCenter" \| "BottomRight"` | |


### PR DESCRIPTION
## Summary

Patch release `1.25.1` addressing ComposableScreen layout + style gotchas surfaced from real onboardings.

- **Page Renderer**: drop wrapper `ScrollView` — `flexGrow:1` left inner `flex:1` (e.g. `Carousel`) unbounded vertically and pushed siblings off-screen. Payloads use the `ScrollView` UIElement (1.25.0) when scroll is needed.
- **Button**: respect explicit `padding:0` (axis defaults no longer override the shorthand), honor `textAlign` (removed `alignItems:"center"` constraint), default `shadowOpacity:1` / `shadowRadius:4` when only `shadowColor` is set.
- **Image**: shadows now render via a wrapper `View` (or `GradientBox`) since iOS clips shadows when the host has `overflow:hidden`.
- **Rive**: drop `?? 200` height fallback; fall back to `aspectRatio:1` when no `height`/`flex`/`aspectRatio`/`min/maxHeight` is set, so unsized payloads don't fill the screen via the native artboard intrinsic.
- **`aspectRatio` on `BaseBoxProps`** (headless + UI mirror) — every UIElement can derive one dimension from the other.
- **Docs**: new `composable-screen-runtime.md` notes for iOS shadow/overflow, padding axis independence, page-level ScrollView trap, Rive intrinsic. `CLAUDE.md` schema-debug recipe.

## Test plan

- [ ] Composable welcome-carousel: Discover button + footer fully visible on iPhone 17 Pro
- [ ] Symptoms-Reversed (Rive `fit:FitWidth`, no height): renders as square (or honors author `aspectRatio`)
- [ ] Button with `padding:0` sits tight; `textAlign:"left|right"` reflows label
- [ ] Button with `shadowColor` only — shadow visible
- [ ] Image with `shadowColor` — shadow visible, rounded corners still clip image
- [ ] Existing payloads (Cycle length, Period length, Health Permission, Notifications) still render

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `aspectRatio` support to all UI elements for flexible sizing control.
  * Rive elements now default to 1:1 aspect ratio when unsized.

* **Bug Fixes**
  * Fixed ComposableScreen layout by removing outer ScrollView wrapper.
  * Improved shadow rendering on iOS when only shadow color is specified.
  * Fixed image shadow clipping behavior.
  * Refined button and image padding defaults.

* **Documentation**
  * Added ComposableScreen runtime rules and debugging guides.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Rocapine/react-native-onboarding/pull/54?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->