### PR TITLE
✨ feat(composable-screen): Icon fill + fillOpacity (v1.26.0)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,7 +138,7 @@ When adding/changing a `UIElement` type in either ComposableScreen `types.ts`, *
 
 1. **Update `packages/onboarding/src/onboarding-example.ts`** — add/update example step exercising the new/changed element type so default onboarding stays in sync with schema.
 2. **Update `example/app/example/composable-screen.tsx`** — add/update element in rendered example payload.
-3. **Watch for schema duplication in UI renderers.** Some UI element renderers (notably `Pages/ComposableScreen/elements/ButtonElement.tsx`) re-declare their Zod schemas + `*Props` type in lockstep with the headless source. When changing headless `elements/*.ts`, search the UI mirror file for the same field and update it too — TS won't catch the drift because the UI re-declares its own type.
+3. **Watch for schema duplication in UI renderers.** Several UI element renderers re-declare their Zod schemas + `*Props` type in lockstep with the headless source (known mirrors: `Pages/ComposableScreen/elements/ButtonElement.tsx`, `IconElement.tsx` — grep for `IconElementPropsSchema`-style re-exports to find others). When changing headless `elements/*.ts`, update the UI mirror's field set too — TS won't catch the drift because the UI re-declares its own type.
 4. **Mirror schema docs in-repo** — update `claude-plugin/skills/{compose-screen-builder,validate-step-json,customize-onboarding-components}/SKILL.md` + `create-step-json/references/composable-archetypes.md`, and `website/docs/page-types.mdx` (Button/element prop tables). Grep these for the changed field name.
 5. **Display this prompt for `onboarding-studio` repo** (CMS backend that must mirror schema changes):
 

--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rocapine-onboarding-sdk",
-  "version": "1.25.1",
+  "version": "1.26.0",
   "description": "End-to-end workflow for building and updating Rocapine Onboarding Studio flows: author step JSON, integrate the headless + UI SDKs, customize theme/components, and review onboarding quality.",
   "author": {
     "name": "Rocapine",

--- a/claude-plugin/skills/create-step-json/references/composable-archetypes.md
+++ b/claude-plugin/skills/create-step-json/references/composable-archetypes.md
@@ -275,7 +275,7 @@ Personalized mirror of prior answers. Card-styled body wrapping a `YStack`.
 ```json
 [
   { "id": "spacer-top", "type": "YStack", "props": { "flex": 1 }, "children": [] },
-  { "id": "avatar", "type": "Icon", "props": { "name": "sparkles", "size": 48, "color": "<DP.brand.primary>" } },
+  { "id": "avatar", "type": "Icon", "props": { "name": "sparkles", "size": 48, "color": "<DP.brand.primary>", "fill": "<DP.brand.primary>", "fillOpacity": 0.2 } },
   { "id": "title", "type": "Text", "props": { "content": "{{name}}, here's your plan.", "mode": "expression", "fontFamily": "<DP.fonts.heading>", "fontSize": "<DP.typeScale.h1>", "fontWeight": "<DP.fontWeights.bold>", "color": "<DP.text.primary>", "textAlign": "center" } },
   {
     "id": "card",

--- a/example/app/example/composable-screen.tsx
+++ b/example/app/example/composable-screen.tsx
@@ -22,6 +22,11 @@ export default function ComposableScreenExample() {
           props: { flex: 1, edges: ['top', 'bottom'] as ('top' | 'right' | 'bottom' | 'left')[] },
           children: [
         {
+          id: 'scroll-root',
+          type: 'ScrollView' as const,
+          props: { flex: 1, showsVerticalScrollIndicator: false },
+          children: [
+        {
           id: 'root',
           type: 'YStack',
           props: { gap: 24, padding: 24 },
@@ -60,14 +65,16 @@ export default function ComposableScreenExample() {
                 borderRadius: 16,
               },
             },
-            // Icon element
+            // Icon element (filled — fill + fillOpacity)
             {
               id: 'hero-icon',
               type: 'Icon',
               props: {
-                name: 'Circle',
+                name: 'Star',
                 size: 48,
                 color: '#007AFF',
+                fill: '#007AFF',
+                fillOpacity: 0.25,
                 marginVertical: 8,
               },
             },
@@ -761,6 +768,8 @@ export default function ComposableScreenExample() {
               },
               children: [],
             },
+          ],
+        },
           ],
         },
           ],

--- a/packages/onboarding-ui/CHANGELOG.md
+++ b/packages/onboarding-ui/CHANGELOG.md
@@ -9,6 +9,13 @@ here.
 
 ---
 
+## [1.26.0] - 2026-05-28
+
+### Added
+- **`IconElement` filled / tinted rendering** — `IconElement.tsx` now mirrors headless `fill` + `fillOpacity` schema fields and passes them through to the underlying `lucide-react-native` SVG (extends `react-native-svg`'s `SvgProps`). Authors can render filled lucide icons or tinted overlays directly from CMS payload, e.g. `{ "fill": "#007AFF", "fillOpacity": 0.25 }`. Default behaviour unchanged — omit `fill` and icons render outlined as before.
+
+---
+
 ## [1.25.1] - 2026-05-28
 
 ### Added

--- a/packages/onboarding-ui/package.json
+++ b/packages/onboarding-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocapine/react-native-onboarding-ui",
-  "version": "1.25.1",
+  "version": "1.26.0",
   "description": "UI components and renderers for Rocapine Onboarding Studio - Built on top of the headless SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/IconElement.tsx
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/IconElement.tsx
@@ -10,6 +10,8 @@ export type IconElementProps = BaseBoxProps & {
   size?: number;
   color?: string;
   strokeWidth?: number;
+  fill?: string;
+  fillOpacity?: number;
   backgroundColor?: string;
 };
 
@@ -18,6 +20,8 @@ export const IconElementPropsSchema = BaseBoxPropsSchema.extend({
   size: z.number().nonnegative().optional(),
   color: z.string().optional(),
   strokeWidth: z.number().nonnegative().optional(),
+  fill: z.string().optional(),
+  fillOpacity: z.number().min(0).max(1).optional(),
   backgroundColor: z.string().optional(),
 });
 
@@ -35,6 +39,8 @@ export const IconElementComponent = ({ element, ctx }: Props): React.ReactElemen
     size?: number;
     color?: string;
     strokeWidth?: number;
+    fill?: string;
+    fillOpacity?: number;
   }> | undefined;
 
   return (
@@ -70,6 +76,8 @@ export const IconElementComponent = ({ element, ctx }: Props): React.ReactElemen
           size={element.props.size ?? 24}
           color={element.props.color ?? theme.colors.text.primary}
           strokeWidth={element.props.strokeWidth ?? 2}
+          fill={element.props.fill}
+          fillOpacity={element.props.fillOpacity}
         />
       ) : null}
     </GradientBox>

--- a/packages/onboarding/CHANGELOG.md
+++ b/packages/onboarding/CHANGELOG.md
@@ -8,6 +8,16 @@ All notable changes to `@rocapine/react-native-onboarding` are documented here.
 
 ---
 
+## [1.26.0] - 2026-05-28
+
+### Added
+- **`Icon` UIElement: `fill` + `fillOpacity` props** — `IconElementPropsSchema` extends with optional `fill: string` (any CSS color; omit ⇒ Lucide default `"none"` outlined) and `fillOpacity: number` (0–1, clamped). Enables filled / tinted Lucide icons (`Star`, `Heart`, `Bookmark`, `Circle`, `CheckCircle2`, …) from CMS payload.
+
+### Changed
+- **`onboarding-example.ts` ComposableScreen demo** — wrapped `root` YStack in a `ScrollView` UIElement so the payload scrolls (page renderer is intentionally a plain `View flex:1`, see `composable-screen-runtime.md`). Hero `Star` icon also showcases `fill` + `fillOpacity: 0.2` tint.
+
+---
+
 ## [1.25.1] - 2026-05-28
 
 ### Added

--- a/packages/onboarding/package.json
+++ b/packages/onboarding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocapine/react-native-onboarding",
-  "version": "1.25.1",
+  "version": "1.26.0",
   "description": "Headless React Native SDK for Rocapine Onboarding Studio - Data fetching, state management, and hooks",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/onboarding/src/onboarding-example.ts
+++ b/packages/onboarding/src/onboarding-example.ts
@@ -111,6 +111,11 @@ export const onboardingExample = {
             props: { flex: 1, edges: ["top", "bottom"] },
             children: [
           {
+            id: "scroll-root",
+            type: "ScrollView",
+            props: { flex: 1, showsVerticalScrollIndicator: false },
+            children: [
+          {
             id: "root",
             type: "YStack",
             props: { gap: 24, padding: 24 },
@@ -153,6 +158,8 @@ export const onboardingExample = {
                   name: "Star",
                   size: 48,
                   color: "#007AFF",
+                  fill: "#007AFF",
+                  fillOpacity: 0.2,
                   marginVertical: 8,
                 },
               },
@@ -737,6 +744,8 @@ export const onboardingExample = {
                 },
               },
             ],
+          },
+          ],
           },
             ],
           },

--- a/packages/onboarding/src/steps/ComposableScreen/elements/IconElement.ts
+++ b/packages/onboarding/src/steps/ComposableScreen/elements/IconElement.ts
@@ -6,6 +6,8 @@ export type IconElementProps = BaseBoxProps & {
   size?: number;
   color?: string;
   strokeWidth?: number;
+  fill?: string;
+  fillOpacity?: number;
   backgroundColor?: string;
 };
 
@@ -14,5 +16,7 @@ export const IconElementPropsSchema = BaseBoxPropsSchema.extend({
   size: z.number().nonnegative().optional(),
   color: z.string().optional(),
   strokeWidth: z.number().nonnegative().optional(),
+  fill: z.string().optional(),
+  fillOpacity: z.number().min(0).max(1).optional(),
   backgroundColor: z.string().optional(),
 });

--- a/website/docs/page-types.mdx
+++ b/website/docs/page-types.mdx
@@ -908,8 +908,10 @@ copy, optional sections). Pick `Branch.condition` to skip whole steps.
 |------|------|-------|
 | `name` | `string` | **Required** — Lucide icon name e.g. `"Star"`, `"Heart"`, `"CheckCircle"` |
 | `size` | `number` | Icon width & height in dp; defaults to `24` |
-| `color` | `string` | Defaults to `theme.colors.text.primary` |
+| `color` | `string` | Stroke color; defaults to `theme.colors.text.primary` |
 | `strokeWidth` | `number` | Line stroke weight; defaults to `2` |
+| `fill` | `string` | Fill color (any CSS color). Omit ⇒ Lucide default `"none"` (outlined). Set to the same value as `color` for a fully filled icon, or to a tinted color for a soft look. Works best with closed-path icons (`Star`, `Heart`, `Bookmark`, `Circle`, `CheckCircle2`). |
+| `fillOpacity` | `number` | 0–1. Lower values tint the fill against the stroke. Defaults to `1`. |
 | `width` / `height` | `number` | Wrapper `View` dimensions |
 | `margin` / `marginHorizontal` / `marginVertical` | `number` | |
 | `padding` / `paddingHorizontal` / `paddingVertical` | `number` | |


### PR DESCRIPTION
## Summary

- Add optional `fill` and `fillOpacity` props to the `Icon` UIElement (headless + UI schemas), passed through to `lucide-react-native` (extends `react-native-svg`'s `SvgProps`). Authors can render filled or tinted Lucide icons directly from CMS payload — works best with closed-path icons (`Star`, `Heart`, `Bookmark`, `Circle`, `CheckCircle2`). Outlined behaviour preserved when `fill` omitted.
- Wrap ComposableScreen demo payloads (`onboarding-example.ts`, `example/app/example/composable-screen.tsx`) in a `ScrollView` UIElement so they scroll again — page renderer is intentionally a plain `View flex:1` (see `.claude/rules/composable-screen-runtime.md`).
- Update docs: `website/docs/page-types.mdx` Icon props table and the `create-step-json` composable-archetypes reference.
- Bump headless + UI packages and plugin manifest to **1.26.0**.

## Studio sync needed

Mirror the `Icon` schema change in `onboarding-studio`:
- Add optional `fill: string` and `fillOpacity: number` (0–1) to the `IconElement` Zod schema / discriminated union.
- Surface a color picker for `fill` and a 0–1 slider for `fillOpacity` in the Icon editor.
- Round-trip both fields in JSON serialization.

## Test plan

- [ ] `npm run build:headless && npm run build:ui` — clean
- [ ] `cd example && npm run type:check` — clean
- [ ] Reload example app → open Composable Screen demo:
  - [ ] Screen scrolls again
  - [ ] Hero `Star` icon renders with tinted fill (`#007AFF` @ 25% opacity over stroke)
  - [ ] Other icons (no `fill`) still render outlined
- [ ] Onboarding-studio CMS preview matches once schema mirrored

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes v1.26.0

* **New Features**
  * Icons now support `fill` and `fillOpacity` styling properties for enhanced color and transparency rendering.
  * Example composable screen wrapped in ScrollView for improved content scrolling.

* **Documentation**
  * Updated icon element props documentation with new fill and fillOpacity configuration options.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Rocapine/react-native-onboarding/pull/56?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->