### PR TITLE
🐛 fix(ci): repair publish workflow (provenance + build order)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -60,7 +60,13 @@ jobs:
 
       - name: Build package
         if: steps.check.outputs.should_publish == 'true'
-        run: npm run ${{ matrix.build }}
+        # UI package's tsc resolves @rocapine/react-native-onboarding types
+        # from the headless package's dist/, so build headless first.
+        run: |
+          npm run build:headless
+          if [ "${{ matrix.build }}" != "build:headless" ]; then
+            npm run ${{ matrix.build }}
+          fi
 
       - name: Publish to npm (OIDC trusted publisher)
         if: steps.check.outputs.should_publish == 'true'

--- a/packages/onboarding-ui/package.json
+++ b/packages/onboarding-ui/package.json
@@ -94,7 +94,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/rocapine/react-native-onboarding-studio.git",
+    "url": "https://github.com/Rocapine/react-native-onboarding.git",
     "directory": "packages/onboarding-ui"
   }
 }

--- a/packages/onboarding/package.json
+++ b/packages/onboarding/package.json
@@ -51,7 +51,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/rocapine/react-native-onboarding-studio.git",
+    "url": "https://github.com/Rocapine/react-native-onboarding.git",
     "directory": "packages/onboarding"
   }
 }


### PR DESCRIPTION
## Problem

The last Publish run (#56, v1.26.0) failed both matrix jobs:

1. **Headless → npm `E422`** — OIDC provenance check rejected publish:
   > `repository.url` is `git+https://github.com/rocapine/react-native-onboarding-studio.git`, expected to match `https://github.com/Rocapine/react-native-onboarding` from provenance

2. **UI → `tsc` `TS2307`** — `Cannot find module '@rocapine/react-native-onboarding'`. The matrix job built only the UI package, but its types resolve from the headless package's `dist/index.d.ts`, which doesn't exist on a fresh `npm ci`.

## Fix

1. Correct `repository.url` (wrong repo name + casing) in both `packages/onboarding/package.json` and `packages/onboarding-ui/package.json` so provenance validates.
2. In `publish.yml`, build headless first before the matrix package's own build (mirrors `build.yml` order).

## Verification

- `build:headless` → `build:ui` passes locally (exit 0).
- Confirmed headless `types` points at `dist/index.d.ts` — must exist before UI `tsc`.
- v1.26.0 is already on npm (published manually after CI failed), so the next run skips publish; these fixes protect the next version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)