### PR TITLE
✨ showTick toggle for RadioGroup/CheckboxGroup (v1.28.0)

### DIFF
--- a/.claude/rules/example-app.md
+++ b/.claude/rules/example-app.md
@@ -25,6 +25,8 @@ npm run android
 
 Fresh worktree has no `example/node_modules` — `tsc` **and `npm run build:ui`** resolve `@rocapine/*` via the **main** repo's symlink (main packages' stale `dist`, not the worktree), giving false type errors / building against the wrong source. Two fixes: `npm install --workspaces --include-workspace-root` from worktree root, or symlink directly — `mkdir -p node_modules/@rocapine && ln -sfn ../../packages/onboarding node_modules/@rocapine/react-native-onboarding && ln -sfn ../../packages/onboarding-ui node_modules/@rocapine/react-native-onboarding-ui` — then `build:headless` + `build:ui` before `type:check`.
 
+Local `main` ref is **stale** in a worktree (branched from `origin/main`, which is usually ahead). For release/scope diffs (`/bump-version`, `git diff main...HEAD`) use `origin/main` as the base, else already-merged commits leak in and the version-bump scope is wrong. A worktree `npm install` also rewrites `package-lock.json`'s version field — don't bundle that into a feature commit (causes rebase conflicts; resolve with `git checkout --ours package-lock.json`).
+
 ## Native module autolinking (peer-dep elements)
 
 A UIElement that renders an optional peer dep (e.g. `@react-native-picker/picker` for `Picker` / `WheelPicker`) needs that dep in **`example/package.json`** — workspace hoisting satisfies JS resolution but autolinking only sees declared example deps, so the native module is missing at runtime (`Unimplemented component: RNCPicker`). After adding, rebuild the dev client (`npx expo run:ios`) — reloading Metro is not enough.

--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rocapine-onboarding-sdk",
-  "version": "1.27.0",
+  "version": "1.28.0",
   "description": "End-to-end workflow for building and updating Rocapine Onboarding Studio flows: author step JSON, integrate the headless + UI SDKs, customize theme/components, and review onboarding quality.",
   "author": {
     "name": "Rocapine",

--- a/claude-plugin/skills/create-step-json/references/composable-archetypes.md
+++ b/claude-plugin/skills/create-step-json/references/composable-archetypes.md
@@ -524,7 +524,7 @@ Signature-style: title + 3 commitment checkboxes (forced-tap) + big CTA.
 | `Rive` | `url` (string URL) | |
 | `Input` | — | `variableName`, `keyboardType`, `autoCapitalize`, `maxLength`, `textAlign`. No `suffix`/`autoFocus`. |
 | `Button` | `label` | `actions: ButtonAction[]`; `disabledWhen` (LeafCondition/Group); `pressedStyle`/`disabledStyle` (Partial overrides) + `transitionDurationMs`; shadow (`shadowColor`/`shadowOffset`/`shadowOpacity`/`shadowRadius`/`elevation`); explicit `backgroundColor`/`color`/`fontFamily`/`borderRadius` from Design Profile. `disabledStyle` supersedes deprecated `disabledBackgroundColor`/`disabledColor` |
-| `RadioGroup` / `CheckboxGroup` | `items: [{label,value}]` | Wire `itemBackgroundColor`, `itemSelectedBackgroundColor`, `itemBorderColor`, `itemBorderRadius`, `itemFontFamily`, etc., from Design Profile |
+| `RadioGroup` / `CheckboxGroup` | `items: [{label,value}]` | Wire `itemBackgroundColor`, `itemSelectedBackgroundColor`, `itemBorderColor`, `itemBorderRadius`, `itemFontFamily`, etc., from Design Profile; `showTick` (boolean, default `true`) hides the radio circle / checkbox box indicator when `false` |
 | `DatePicker` | — | `variableName`; see `DatePickerElement.ts` |
 | `WheelPicker` | exactly one of `items: [{label,value}]` or `range: {min,max,step?,unit?}` | `variableName`; `defaultValue` must match an available value; `range.unit` appends to labels (`"70 kg"`); wire `itemColor`/`itemFontSize`/`itemFontFamily` from Design Profile; needs `@react-native-picker/picker`; see `WheelPickerElement.ts` |
 | `Carousel` | — | slides in `children` at element top-level |

--- a/claude-plugin/skills/customize-onboarding-components/SKILL.md
+++ b/claude-plugin/skills/customize-onboarding-components/SKILL.md
@@ -29,6 +29,7 @@ Every styled UIElement (`Button`, `RadioGroup`, `CheckboxGroup`, `Input`, `Wheel
 - `itemColor`, `itemSelectedColor`
 - `itemFontFamily`, `itemFontSize`, `itemFontWeight`, `itemFontStyle`
 - `itemPadding`, `itemPaddingVertical`, `itemPaddingHorizontal`
+- `showTick` — show/hide the radio circle (checkbox box) indicator. Default: `true`
 
 `Input`:
 - `backgroundColor`, `color`, `placeholderColor`, `borderRadius`

--- a/example/app/example/composable-screen.tsx
+++ b/example/app/example/composable-screen.tsx
@@ -320,6 +320,7 @@ export default function ComposableScreenExample() {
               props: {
                 variableName: 'plan',
                 defaultValue: 'monthly',
+                showTick: true,
                 gap: 8,
                 marginVertical: 8,
                 items: [
@@ -349,6 +350,7 @@ export default function ComposableScreenExample() {
               props: {
                 variableName: 'goals',
                 defaultValues: ['health', 'fitness'],
+                showTick: false,
                 gap: 8,
                 marginVertical: 8,
                 items: [

--- a/packages/onboarding-ui/CHANGELOG.md
+++ b/packages/onboarding-ui/CHANGELOG.md
@@ -9,6 +9,13 @@ here.
 
 ---
 
+## [1.28.0] - 2026-05-29
+
+### Added
+- **`RadioGroupElement` / `CheckboxGroupElement`: `showTick` support** — both renderers mirror the headless `showTick` field and gate the indicator on `showTick !== false`. With `showTick: false` the radio circle / checkbox `✓` box is not rendered, leaving label + selected background/border to convey state; default (`true` / omitted) is unchanged. `composable-screen.tsx` + `onboarding-example.ts` demos exercise both states (radio shows the tick, checkbox hides it).
+
+---
+
 ## [1.27.0] - 2026-05-29
 
 ### Added

--- a/packages/onboarding-ui/package.json
+++ b/packages/onboarding-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocapine/react-native-onboarding-ui",
-  "version": "1.27.0",
+  "version": "1.28.0",
   "description": "UI components and renderers for Rocapine Onboarding Studio - Built on top of the headless SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/CheckboxGroupElement.tsx
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/CheckboxGroupElement.tsx
@@ -11,6 +11,7 @@ export type CheckboxGroupElementProps = BaseBoxProps & {
   defaultValues?: string[];
   gap?: number;
   direction?: "vertical" | "horizontal";
+  showTick?: boolean;
   items: Array<{ label: string; value: string }>;
   itemBackgroundColor?: string;
   itemSelectedBackgroundColor?: string;
@@ -34,6 +35,7 @@ export const CheckboxGroupElementPropsSchema = BaseBoxPropsSchema.extend({
   defaultValues: z.array(z.string()).optional(),
   gap: z.number().optional(),
   direction: z.enum(["vertical", "horizontal"]).optional(),
+  showTick: z.boolean().optional(),
   items: z.array(z.object({ label: z.string().trim().min(1, "item label must not be empty"), value: z.string().trim().min(1, "item value must not be empty") })).min(1, "items must not be empty"),
   itemBackgroundColor: z.string().optional(),
   itemSelectedBackgroundColor: z.string().optional(),
@@ -160,31 +162,33 @@ export const CheckboxGroupComponent = ({ element, ctx }: Props): React.ReactElem
               paddingVertical: element.props.itemPaddingVertical,
             }}
           >
-            <View
-              style={{
-                width: 20,
-                height: 20,
-                borderRadius: 4,
-                borderWidth: 2,
-                borderColor: isSelected ? theme.colors.primary : theme.colors.neutral.medium,
-                alignItems: "center",
-                justifyContent: "center",
-                backgroundColor: isSelected ? theme.colors.primary : "transparent",
-              }}
-            >
-              {isSelected && (
-                <Text
-                  style={{
-                    color: "#fff",
-                    fontSize: 12,
-                    fontWeight: "700",
-                    lineHeight: 14,
-                  }}
-                >
-                  ✓
-                </Text>
-              )}
-            </View>
+            {element.props.showTick !== false && (
+              <View
+                style={{
+                  width: 20,
+                  height: 20,
+                  borderRadius: 4,
+                  borderWidth: 2,
+                  borderColor: isSelected ? theme.colors.primary : theme.colors.neutral.medium,
+                  alignItems: "center",
+                  justifyContent: "center",
+                  backgroundColor: isSelected ? theme.colors.primary : "transparent",
+                }}
+              >
+                {isSelected && (
+                  <Text
+                    style={{
+                      color: "#fff",
+                      fontSize: 12,
+                      fontWeight: "700",
+                      lineHeight: 14,
+                    }}
+                  >
+                    ✓
+                  </Text>
+                )}
+              </View>
+            )}
             <Text
               style={{
                 flexShrink: 1,

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/RadioGroupElement.tsx
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/RadioGroupElement.tsx
@@ -11,6 +11,7 @@ export type RadioGroupElementProps = BaseBoxProps & {
   defaultValue?: string;
   gap?: number;
   direction?: "vertical" | "horizontal";
+  showTick?: boolean;
   items: Array<{ label: string; value: string }>;
   itemBackgroundColor?: string;
   itemSelectedBackgroundColor?: string;
@@ -34,6 +35,7 @@ export const RadioGroupElementPropsSchema = BaseBoxPropsSchema.extend({
   defaultValue: z.string().optional(),
   gap: z.number().optional(),
   direction: z.enum(["vertical", "horizontal"]).optional(),
+  showTick: z.boolean().optional(),
   items: z.array(z.object({ label: z.string().trim().min(1, "item label must not be empty"), value: z.string().trim().min(1, "item value must not be empty") })).min(1, "items must not be empty"),
   itemBackgroundColor: z.string().optional(),
   itemSelectedBackgroundColor: z.string().optional(),
@@ -145,28 +147,30 @@ export const RadioGroupComponent = ({ element, ctx }: Props): React.ReactElement
               paddingVertical: element.props.itemPaddingVertical,
             }}
           >
-            <View
-              style={{
-                width: 20,
-                height: 20,
-                borderRadius: 10,
-                borderWidth: 2,
-                borderColor: isSelected ? theme.colors.primary : theme.colors.neutral.medium,
-                alignItems: "center",
-                justifyContent: "center",
-              }}
-            >
-              {isSelected && (
-                <View
-                  style={{
-                    width: 10,
-                    height: 10,
-                    borderRadius: 5,
-                    backgroundColor: theme.colors.primary,
-                  }}
-                />
-              )}
-            </View>
+            {element.props.showTick !== false && (
+              <View
+                style={{
+                  width: 20,
+                  height: 20,
+                  borderRadius: 10,
+                  borderWidth: 2,
+                  borderColor: isSelected ? theme.colors.primary : theme.colors.neutral.medium,
+                  alignItems: "center",
+                  justifyContent: "center",
+                }}
+              >
+                {isSelected && (
+                  <View
+                    style={{
+                      width: 10,
+                      height: 10,
+                      borderRadius: 5,
+                      backgroundColor: theme.colors.primary,
+                    }}
+                  />
+                )}
+              </View>
+            )}
             <Text
               style={{
                 flexShrink: 1,

--- a/packages/onboarding/CHANGELOG.md
+++ b/packages/onboarding/CHANGELOG.md
@@ -8,6 +8,13 @@ All notable changes to `@rocapine/react-native-onboarding` are documented here.
 
 ---
 
+## [1.28.0] - 2026-05-29
+
+### Added
+- **`RadioGroup` / `CheckboxGroup`: `showTick` prop** — both schemas extend with optional `showTick: boolean` (default `true`). When `false`, the per-item indicator (radio circle / checkbox box) is omitted; the item label and selected background / border styling still render. Lets authors build pill / card-style single- and multi-select groups without the tick glyph.
+
+---
+
 ## [1.27.0] - 2026-05-29
 
 ### Added

--- a/packages/onboarding/package.json
+++ b/packages/onboarding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocapine/react-native-onboarding",
-  "version": "1.27.0",
+  "version": "1.28.0",
   "description": "Headless React Native SDK for Rocapine Onboarding Studio - Data fetching, state management, and hooks",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/onboarding/src/onboarding-example.ts
+++ b/packages/onboarding/src/onboarding-example.ts
@@ -362,6 +362,7 @@ export const onboardingExample = {
                 props: {
                   variableName: "plan",
                   defaultValue: "monthly",
+                  showTick: true,
                   gap: 8,
                   marginVertical: 8,
                   items: [
@@ -405,6 +406,7 @@ export const onboardingExample = {
                 props: {
                   variableName: "goals",
                   defaultValues: ["health", "fitness"],
+                  showTick: false,
                   gap: 8,
                   marginVertical: 8,
                   items: [

--- a/packages/onboarding/src/steps/ComposableScreen/elements/CheckboxGroupElement.ts
+++ b/packages/onboarding/src/steps/ComposableScreen/elements/CheckboxGroupElement.ts
@@ -6,6 +6,7 @@ export type CheckboxGroupElementProps = BaseBoxProps & {
   defaultValues?: string[];
   gap?: number;
   direction?: "vertical" | "horizontal";
+  showTick?: boolean;
   items: Array<{ label: string; value: string }>;
   itemBackgroundColor?: string;
   itemSelectedBackgroundColor?: string;
@@ -29,6 +30,7 @@ export const CheckboxGroupElementPropsSchema = BaseBoxPropsSchema.extend({
   defaultValues: z.array(z.string()).optional(),
   gap: z.number().optional(),
   direction: z.enum(["vertical", "horizontal"]).optional(),
+  showTick: z.boolean().optional(),
   items: z.array(z.object({ label: z.string().trim().min(1, "item label must not be empty"), value: z.string().trim().min(1, "item value must not be empty") })).min(1, "items must not be empty"),
   itemBackgroundColor: z.string().optional(),
   itemSelectedBackgroundColor: z.string().optional(),

--- a/packages/onboarding/src/steps/ComposableScreen/elements/RadioGroupElement.ts
+++ b/packages/onboarding/src/steps/ComposableScreen/elements/RadioGroupElement.ts
@@ -6,6 +6,7 @@ export type RadioGroupElementProps = BaseBoxProps & {
   defaultValue?: string;
   gap?: number;
   direction?: "vertical" | "horizontal";
+  showTick?: boolean;
   items: Array<{ label: string; value: string }>;
   itemBackgroundColor?: string;
   itemSelectedBackgroundColor?: string;
@@ -29,6 +30,7 @@ export const RadioGroupElementPropsSchema = BaseBoxPropsSchema.extend({
   defaultValue: z.string().optional(),
   gap: z.number().optional(),
   direction: z.enum(["vertical", "horizontal"]).optional(),
+  showTick: z.boolean().optional(),
   items: z.array(z.object({ label: z.string().trim().min(1, "item label must not be empty"), value: z.string().trim().min(1, "item value must not be empty") })).min(1, "items must not be empty"),
   itemBackgroundColor: z.string().optional(),
   itemSelectedBackgroundColor: z.string().optional(),

--- a/website/docs/page-types.mdx
+++ b/website/docs/page-types.mdx
@@ -577,6 +577,7 @@ As of 1.15.0, `OnboardingTemplate` does not apply safe-area insets. Built-in pag
 | `itemBorderWidth` | `number` | Defaults to `1` |
 | `itemColor` | `string` | Unselected label color; defaults to `theme.colors.text.primary` |
 | `itemSelectedColor` | `string` | Selected label color; defaults to `theme.colors.primary` |
+| `showTick` | `boolean` | Show/hide the radio circle indicator. When `false`, the label and selected background/border still render. Defaults to `true` |
 | `itemFontSize` | `number` | |
 | `itemFontWeight` | `string` | |
 | `itemFontFamily` | `string` | |
@@ -606,6 +607,7 @@ As of 1.15.0, `OnboardingTemplate` does not apply safe-area insets. Built-in pag
 | `itemBorderWidth` | `number` | Defaults to `1` |
 | `itemColor` | `string` | Unselected label color; defaults to `theme.colors.text.primary` |
 | `itemSelectedColor` | `string` | Selected label color; defaults to `theme.colors.primary` |
+| `showTick` | `boolean` | Show/hide the checkbox box indicator. When `false`, the label and selected background/border still render. Defaults to `true` |
 | `itemFontSize` | `number` | |
 | `itemFontWeight` | `string` | |
 | `itemFontFamily` | `string` | |


### PR DESCRIPTION
## Summary
Add optional `showTick?: boolean` (default `true`) to the `RadioGroup` and `CheckboxGroup` ComposableScreen UIElements. When `false`, the per-item indicator (radio circle / checkbox box) is hidden while the item label and selected background/border styling still render — enables pill/card-style select groups without the tick glyph.

## Changes
- **Headless schema + type** — `showTick: z.boolean().optional()` on `RadioGroupElement.ts` + `CheckboxGroupElement.ts`
- **UI mirror + renderers** — same field; indicator gated on `showTick !== false`
- **Examples** — `onboarding-example.ts` + `example/app/example/composable-screen.tsx` exercise both states (radio shows tick, checkbox hides it)
- **Docs** — `page-types.mdx`, `customize-onboarding-components` SKILL, `composable-archetypes.md`
- **Release** — bump both SDKs + plugin to `1.28.0`, changelog entries

## Verify
- [x] `npm run build:headless` + `npm run build:ui` — 0 errors
- [x] `showTick` present in built dist for all 4 element files

## Follow-up
Mirror schema change in `onboarding-studio` (studio sync prompt provided in session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)