### PR TITLE
✨ Inline rich-text spans for ComposableScreen Text (v1.31.0)

### DIFF
--- a/.claude/rules/example-app.md
+++ b/.claude/rules/example-app.md
@@ -27,6 +27,8 @@ Fresh worktree has no `example/node_modules` — `tsc` **and `npm run build:ui`*
 
 Local `main` ref is **stale** in a worktree (branched from `origin/main`, which is usually ahead). For release/scope diffs (`/bump-version`, `git diff main...HEAD`) use `origin/main` as the base, else already-merged commits leak in and the version-bump scope is wrong. A worktree `npm install` also rewrites `package-lock.json`'s version field — don't bundle that into a feature commit (causes rebase conflicts; resolve with `git checkout --ours package-lock.json`).
 
+Running metro from a worktree while another session runs metro in the main repo: port 8081 is taken, and `expo start` is **non-interactive** in a background shell — it prints "Use port 8083 instead?" then bails with "Skipping dev server". Pass an explicit free port: `npm start --prefix example -- --port 8083`.
+
 ## Native module autolinking (peer-dep elements)
 
 A UIElement that renders an optional peer dep (e.g. `@react-native-picker/picker` for `Picker` / `WheelPicker`) needs that dep in **`example/package.json`** — workspace hoisting satisfies JS resolution but autolinking only sees declared example deps, so the native module is missing at runtime (`Unimplemented component: RNCPicker`). After adding, rebuild the dev client (`npx expo run:ios`) — reloading Metro is not enough.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,5 +182,6 @@ cd packages/onboarding-ui && npm run patch # bump + build + publish
 - Env values live in `example/.env` + `example/.env.local` (`.env.local` overrides → local Supabase `localhost:64321`); a fresh **worktree** has empty/missing env, so read the values from the **main repo's** `example/.env*`.
 - Validate against the schema in Node using the **headless** dist only (`require('./packages/onboarding/dist/steps/ComposableScreen/types.js')`) — the UI dist imports `react-native` and won't load under Node.
 - The parse entry point is the exported `ComposableScreenStepTypeSchema` (`.safeParse(step)`).
+- A minimal step for `.safeParse` needs top-level `id`, `name` (string), `type`, `displayProgressHeader` (boolean), and `payload.elements` — missing `name`/`displayProgressHeader` reads as element errors, not obviously a step-shape problem.
 - Zod v4 `invalid_union` paths are cumulative across nested variant errors; walk the issue tree and concatenate `prefix + it.path` recursively to surface the real failing path.
 - Triage data-vs-schema: many parse failures are CMS **data** bugs, not SDK bugs (e.g. `variant:"clear"` — only `filled/outlined/ghost`; `shadowOpacity:12` — RN bounds `0..1`). Fix in studio, not the schema.

--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rocapine-onboarding-sdk",
-  "version": "1.30.0",
+  "version": "1.31.0",
   "description": "End-to-end workflow for building and updating Rocapine Onboarding Studio flows: author step JSON, integrate the headless + UI SDKs, customize theme/components, and review onboarding quality.",
   "author": {
     "name": "Rocapine",

--- a/claude-plugin/skills/compose-screen-builder/SKILL.md
+++ b/claude-plugin/skills/compose-screen-builder/SKILL.md
@@ -35,7 +35,7 @@ Start from an archetype in `../create-step-json/references/composable-archetypes
 | `YStack` / `XStack` | Vertical / horizontal flex container; has `children` |
 | `ZStack` | Layered stack (overlay) |
 | `SafeAreaView` | Safe-area wrapper with per-edge mode |
-| `Text` | Text node (supports `{{variableName}}` interpolation) |
+| `Text` | Text node (supports `{{variableName}}` interpolation; `content` may be a string or an array of styled spans for inline rich text) |
 | `Image` | Image with `source: { uri }` or `{ localPathId }` |
 | `Lottie` / `Rive` / `Video` | Animated media |
 | `Icon` | Vector icon |
@@ -188,7 +188,7 @@ Each override is a `Partial` of the overridable Button props: `BaseBoxProps` (in
 | Element | Right | Wrong |
 |---------|-------|-------|
 | Payload | `payload.elements: UIElement[]` | `payload.root`, `payload.variables` |
-| `Text` | `content`, `mode: "expression"` for interp, `fontSize`/`fontWeight` | `text`, `variant` |
+| `Text` | `content` (string **or** span array), `mode: "expression"` for interp, `fontSize`/`fontWeight` | `text`, `variant` |
 | `Image` | `url: string` | `source: { uri }`, `source: { localPathId }` |
 | `Lottie` | `source: string` | `source: { localPathId }` |
 | `Rive` | `url: string` | `source` |
@@ -208,6 +208,7 @@ Each override is a `Partial` of the overridable Button props: `BaseBoxProps` (in
 - Don't nest a `KeyboardAvoidingView` inside another `KeyboardAvoidingView` — the headless schema rejects it.
 - Don't use `{{var}}` in `Text.content` without `mode: "expression"` — interpolation silently disabled otherwise.
 - Don't use `Text.variant` — it doesn't exist. Set `fontSize` / `fontWeight` / `fontFamily` directly.
+- **Inline rich text:** set `Text.content` to an array of spans — `[{ "text": "Lose " }, { "text": "5kg", "fontWeight": "700", "color": "#E11D48" }]`. Each span needs a `text` and may override `fontWeight`, `fontStyle`, `fontFamily`, `fontSize`, `letterSpacing`, `color`, `textDecorationLine` (`"underline" | "line-through" | "underline line-through" | "none"`); omitted props inherit from the parent `Text`. In `mode: "expression"`, `{{var}}` interpolates inside each span's `text`. Use this instead of an `XStack` of `Text` elements when fragments must wrap on one baseline.
 - Don't use `SafeAreaView` edge mode `"always"` — only `"off" | "additive" | "maximum"`.
 - Don't nest `SafeAreaView` inside another `SafeAreaView`.
 - Don't set fixed `height` on a container that should grow; use `flex: 1`.

--- a/claude-plugin/skills/validate-step-json/SKILL.md
+++ b/claude-plugin/skills/validate-step-json/SKILL.md
@@ -38,7 +38,7 @@ Run: `npx tsx scripts/_validate-composable.ts "$(cat step.json)"`
    - Every UIElement has `id` (string), `type` (string literal), `props` (object).
    - Every container UIElement (`YStack`, `XStack`, `ZStack`, `SafeAreaView`, `Carousel`) has `children: UIElement[]` at element top-level — required, must exist even if empty (`"children": []`). Non-container types must NOT have `children`.
    - All `id`s unique within `payload.elements` tree
-   - `Text.props.content` exists; if `{{var}}` interpolation, `Text.props.mode === "expression"`
+   - `Text.props.content` exists — a string, or an array of spans `[{text, fontWeight?, fontStyle?, fontFamily?, fontSize?, letterSpacing?, color?, textDecorationLine?}]` (each span requires `text`; `textDecorationLine` ∈ `none|underline|line-through|underline line-through`). If `{{var}}` interpolation, `Text.props.mode === "expression"`
    - `Image.props.url` is a string (NOT `source.uri` / `source.localPathId`)
    - `Lottie.props.source` is a string; `Rive.props.url` is a string
    - `RadioGroup.props.items` / `CheckboxGroup.props.items` is `[{label, value}]` (NOT `options`)

--- a/example/app/example/composable-screen.tsx
+++ b/example/app/example/composable-screen.tsx
@@ -161,6 +161,27 @@ export default function ComposableScreenExample() {
                 marginVertical: 4,
               },
             },
+            // Inline rich text — `content` as styled spans. Each span inherits
+            // the parent Text style and overrides only what it sets.
+            {
+              id: 'richtext-demo',
+              type: 'Text' as const,
+              props: {
+                content: [
+                  { text: 'Lose ' },
+                  { text: '5kg', fontWeight: '700', color: '#E11D48' },
+                  { text: ' in 30 days — ' },
+                  {
+                    text: 'guaranteed',
+                    fontStyle: 'italic' as const,
+                    textDecorationLine: 'underline' as const,
+                  },
+                ],
+                fontSize: 16,
+                textAlign: 'center' as const,
+                marginVertical: 4,
+              },
+            },
             // Horizontal ScrollView demo — swipeable row of cards.
             {
               id: 'scroll-demo',

--- a/packages/onboarding-ui/CHANGELOG.md
+++ b/packages/onboarding-ui/CHANGELOG.md
@@ -9,6 +9,16 @@ here.
 
 ---
 
+## [1.31.0] - 2026-06-01
+
+### Added
+- **Inline rich-text rendering in `TextElement`** — when `content` is a span array, the renderer maps each span to a nested `<Text>` (new internal `RichTextSpan` component) so fragments with different weight/style/color/decoration wrap together on one baseline. Each span resolves its own font via `useResolvedFontStyle` against the parent `Text`'s inherited family, so a span setting only `fontWeight` still picks the correct weighted font variant. Supports per-span `fontWeight`, `fontStyle`, `fontFamily`, `fontSize`, `letterSpacing`, `color`, `textDecorationLine`.
+
+### Changed
+- **`TextElementPropsSchema.content`** mirror widened to `string | TextSpan[]`; `TextSpan` / `TextSpanSchema` added to the UI element. Plain string `content` renders identically to before. Expression mode interpolates `{{variable}}` inside each span's `text`.
+
+---
+
 ## [1.30.0] - 2026-05-29
 
 ### Added

--- a/packages/onboarding-ui/package.json
+++ b/packages/onboarding-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocapine/react-native-onboarding-ui",
-  "version": "1.30.0",
+  "version": "1.31.0",
   "description": "UI components and renderers for Rocapine Onboarding Studio - Built on top of the headless SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/TextElement.tsx
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/TextElement.tsx
@@ -7,8 +7,36 @@ import { UIElement } from "../types";
 import { RenderContext, interpolate, dim, resolveInheritedFontFamily } from "./shared";
 import { GradientBox } from "./GradientBox";
 
+export type TextSpan = {
+  text: string;
+  fontWeight?: string;
+  fontStyle?: "normal" | "italic";
+  fontFamily?: string | "inherit";
+  fontSize?: number;
+  letterSpacing?: number;
+  color?: string;
+  textDecorationLine?:
+    | "none"
+    | "underline"
+    | "line-through"
+    | "underline line-through";
+};
+
+export const TextSpanSchema = z.object({
+  text: z.string(),
+  fontWeight: z.string().optional(),
+  fontStyle: z.enum(["normal", "italic"]).optional(),
+  fontFamily: z.string().optional(),
+  fontSize: z.number().optional(),
+  letterSpacing: z.number().optional(),
+  color: z.string().optional(),
+  textDecorationLine: z
+    .enum(["none", "underline", "line-through", "underline line-through"])
+    .optional(),
+});
+
 export type TextElementProps = BaseBoxProps & {
-  content: string;
+  content: string | TextSpan[];
   mode?: "plain" | "expression";
   fontSize?: number;
   fontWeight?: string;
@@ -21,7 +49,7 @@ export type TextElementProps = BaseBoxProps & {
 };
 
 export const TextElementPropsSchema = BaseBoxPropsSchema.extend({
-  content: z.string(),
+  content: z.union([z.string(), z.array(TextSpanSchema)]),
   mode: z.enum(["plain", "expression"]).optional(),
   fontSize: z.number().optional(),
   fontWeight: z.string().optional(),
@@ -32,6 +60,40 @@ export const TextElementPropsSchema = BaseBoxPropsSchema.extend({
   letterSpacing: z.number().optional(),
   lineHeight: z.number().optional(),
 });
+
+/**
+ * Renders one inline span. Isolated as its own component so the
+ * `useResolvedFontStyle` hook is called once per stable component instance —
+ * calling the hook in a `.map` loop inside the parent would break rules of
+ * hooks when the span count changes.
+ */
+const RichTextSpan = ({
+  span,
+  baseFontFamily,
+}: {
+  span: TextSpan;
+  baseFontFamily: string | undefined;
+}): React.ReactElement => {
+  const fontFamily = resolveInheritedFontFamily(span.fontFamily, baseFontFamily);
+  const resolved = useResolvedFontStyle(fontFamily, span.fontWeight);
+  return (
+    <Text
+      style={{
+        fontFamily: resolved.fontFamily,
+        fontWeight: resolved.resolvedToVariant
+          ? undefined
+          : (span.fontWeight as any),
+        fontStyle: span.fontStyle,
+        fontSize: span.fontSize,
+        letterSpacing: span.letterSpacing,
+        color: span.color,
+        textDecorationLine: span.textDecorationLine,
+      }}
+    >
+      {span.text}
+    </Text>
+  );
+};
 
 type TextUIElement = Extract<UIElement, { type: "Text" }>;
 
@@ -44,8 +106,12 @@ type Props = {
 export const TextElementComponent = ({ element, ctx, parentType }: Props): React.ReactElement => {
   const { theme, variables } = ctx;
   const p = element.props;
-  const content =
-    p.mode === "expression"
+  const isExpression = p.mode === "expression";
+  const content: string | TextSpan[] = Array.isArray(p.content)
+    ? isExpression
+      ? p.content.map((s) => ({ ...s, text: interpolate(s.text, variables) }))
+      : p.content
+    : isExpression
       ? interpolate(p.content, variables)
       : p.content;
   const inheritedFontFamily = resolveInheritedFontFamily(
@@ -88,7 +154,11 @@ export const TextElementComponent = ({ element, ctx, parentType }: Props): React
         opacity: p.backgroundGradient ? undefined : p.opacity,
       }}
     >
-      {content}
+      {typeof content === "string"
+        ? content
+        : content.map((s, i) => (
+            <RichTextSpan key={i} span={s} baseFontFamily={inheritedFontFamily} />
+          ))}
     </Text>
   );
 

--- a/packages/onboarding/CHANGELOG.md
+++ b/packages/onboarding/CHANGELOG.md
@@ -8,6 +8,16 @@ All notable changes to `@rocapine/react-native-onboarding` are documented here.
 
 ---
 
+## [1.31.0] - 2026-06-01
+
+### Added
+- **Inline rich text for `Text`** — `TextElementProps.content` is now `string | TextSpan[]`. A span array renders styled fragments inline (nested `<Text>`) that wrap together on one baseline. New `TextSpan` type and `TextSpanSchema` exported from the headless package. Span fields (all optional except `text`): `text`, `fontWeight`, `fontStyle`, `fontFamily`, `fontSize`, `letterSpacing`, `color`, `textDecorationLine` (`"none"` | `"underline"` | `"line-through"` | `"underline line-through"`). Omitted span props inherit from the parent `Text`. In `mode: "expression"`, `{{variable}}` interpolation applies to each span's `text`.
+
+### Changed
+- **`TextElementPropsSchema.content`** widened from `z.string()` to `z.union([z.string(), z.array(TextSpanSchema)])`. Backward compatible — existing string payloads validate and render unchanged.
+
+---
+
 ## [1.30.0] - 2026-05-29
 
 ### Added

--- a/packages/onboarding/package.json
+++ b/packages/onboarding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocapine/react-native-onboarding",
-  "version": "1.30.0",
+  "version": "1.31.0",
   "description": "Headless React Native SDK for Rocapine Onboarding Studio - Data fetching, state management, and hooks",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/onboarding/src/onboarding-example.ts
+++ b/packages/onboarding/src/onboarding-example.ts
@@ -242,6 +242,28 @@ export const onboardingExample = {
                 },
               },
               {
+                // Inline rich text — `content` as an array of styled spans.
+                // Each span inherits the parent Text style and overrides only
+                // what it sets (here: weight, color, underline).
+                id: "richtext-demo",
+                type: "Text",
+                props: {
+                  content: [
+                    { text: "Lose " },
+                    { text: "5kg", fontWeight: "700", color: "#E11D48" },
+                    { text: " in 30 days — " },
+                    {
+                      text: "guaranteed",
+                      fontStyle: "italic",
+                      textDecorationLine: "underline",
+                    },
+                  ],
+                  fontSize: 16,
+                  textAlign: "center",
+                  marginVertical: 4,
+                },
+              },
+              {
                 id: "scroll-demo",
                 type: "ScrollView",
                 props: {

--- a/packages/onboarding/src/steps/ComposableScreen/elements/TextElement.ts
+++ b/packages/onboarding/src/steps/ComposableScreen/elements/TextElement.ts
@@ -1,8 +1,51 @@
 import { z } from "zod";
 import { BaseBoxProps, BaseBoxPropsSchema } from "./BaseBoxProps";
 
+/**
+ * A styled inline run of text. Used to compose rich text inside a single
+ * `Text` element — spans render as nested `<Text>` and inherit any prop they
+ * omit from the parent `Text` (React Native nested-`<Text>` inheritance), so a
+ * span only declares the styling it overrides.
+ */
+export type TextSpan = {
+  text: string;
+  fontWeight?: string;
+  fontStyle?: "normal" | "italic";
+  /**
+   * Font family name. Omit or set to `"inherit"` to inherit the parent
+   * `Text` element's resolved font family.
+   */
+  fontFamily?: string | "inherit";
+  fontSize?: number;
+  letterSpacing?: number;
+  color?: string;
+  textDecorationLine?:
+    | "none"
+    | "underline"
+    | "line-through"
+    | "underline line-through";
+};
+
+export const TextSpanSchema = z.object({
+  text: z.string(),
+  fontWeight: z.string().optional(),
+  fontStyle: z.enum(["normal", "italic"]).optional(),
+  fontFamily: z.string().optional(),
+  fontSize: z.number().optional(),
+  letterSpacing: z.number().optional(),
+  color: z.string().optional(),
+  textDecorationLine: z
+    .enum(["none", "underline", "line-through", "underline line-through"])
+    .optional(),
+});
+
 export type TextElementProps = BaseBoxProps & {
-  content: string;
+  /**
+   * Plain string, or an array of styled spans for inline rich text. In
+   * `expression` mode `{{variable}}` interpolation applies to the string or to
+   * each span's `text`.
+   */
+  content: string | TextSpan[];
   mode?: "plain" | "expression";
   fontSize?: number;
   fontWeight?: string;
@@ -19,7 +62,7 @@ export type TextElementProps = BaseBoxProps & {
 };
 
 export const TextElementPropsSchema = BaseBoxPropsSchema.extend({
-  content: z.string(),
+  content: z.union([z.string(), z.array(TextSpanSchema)]),
   mode: z.enum(["plain", "expression"]).optional(),
   fontSize: z.number().optional(),
   fontWeight: z.string().optional(),

--- a/packages/onboarding/src/steps/ComposableScreen/types.ts
+++ b/packages/onboarding/src/steps/ComposableScreen/types.ts
@@ -32,7 +32,8 @@ import { type ProgressIndicatorElementProps, ProgressIndicatorElementPropsSchema
 export type { BaseBoxProps, GradientBackground, GradientEdge, GradientStop, LinearGradientConfig } from "./elements/BaseBoxProps";
 export { BaseBoxPropsSchema, GradientBackgroundSchema } from "./elements/BaseBoxProps";
 export type { StackElementProps } from "./elements/StackElement";
-export type { TextElementProps } from "./elements/TextElement";
+export type { TextElementProps, TextSpan } from "./elements/TextElement";
+export { TextSpanSchema } from "./elements/TextElement";
 export type { ImageElementProps } from "./elements/ImageElement";
 export type { LottieElementProps } from "./elements/LottieElement";
 export type { RiveElementProps } from "./elements/RiveElement";

--- a/website/docs/page-types.mdx
+++ b/website/docs/page-types.mdx
@@ -521,8 +521,8 @@ As of 1.15.0, `OnboardingTemplate` does not apply safe-area insets. Built-in pag
 
 | Prop | Type | Notes |
 |------|------|-------|
-| `content` | `string` | **Required** |
-| `mode` | `"plain" \| "expression"` | `"plain"` (default) renders content as-is; `"expression"` interpolates `{{variableName}}` patterns from the variable context |
+| `content` | `string \| TextSpan[]` | **Required.** A string, or an array of styled spans for inline rich text (see below) |
+| `mode` | `"plain" \| "expression"` | `"plain"` (default) renders content as-is; `"expression"` interpolates `{{variableName}}` patterns from the variable context (in each span's `text` when `content` is a span array) |
 | `fontSize` / `fontWeight` / `letterSpacing` / `lineHeight` | `number \| string` | |
 | `fontFamily` | `string` | Font family name; must be loaded by the host app (e.g. via `expo-font`) |
 | `color` | `string` | Defaults to `theme.colors.text.primary` |
@@ -531,6 +531,36 @@ As of 1.15.0, `OnboardingTemplate` does not apply safe-area insets. Built-in pag
 | `padding` / `paddingHorizontal` / `paddingVertical` | `number` | |
 | `margin` / `marginHorizontal` / `marginVertical` | `number` | |
 | `borderWidth` / `borderRadius` / `opacity` | `number` | |
+
+**Inline rich text (`TextSpan`):**
+
+Set `content` to an array of spans to style fragments differently within a single line — they render as nested `<Text>` and wrap together on one baseline. Each span inherits any prop it omits from the parent `Text`, so a span only declares what it overrides.
+
+```json
+{
+  "type": "Text",
+  "props": {
+    "content": [
+      { "text": "Lose " },
+      { "text": "5kg", "fontWeight": "700", "color": "#E11D48" },
+      { "text": " in 30 days — " },
+      { "text": "guaranteed", "fontStyle": "italic", "textDecorationLine": "underline" }
+    ],
+    "fontSize": 16,
+    "textAlign": "center"
+  }
+}
+```
+
+| Span prop | Type | Notes |
+|------|------|-------|
+| `text` | `string` | **Required.** The span's text (interpolated in `mode: "expression"`) |
+| `fontWeight` | `string` | |
+| `fontStyle` | `"normal" \| "italic"` | |
+| `fontFamily` | `string \| "inherit"` | Defaults to the parent `Text`'s resolved family |
+| `fontSize` / `letterSpacing` | `number` | |
+| `color` | `string` | |
+| `textDecorationLine` | `"none" \| "underline" \| "line-through" \| "underline line-through"` | |
 
 **Input props:**
 


### PR DESCRIPTION
## What

`Text` element `content` now accepts `string | TextSpan[]`. A span array renders styled fragments inline (nested `<Text>`) that wrap together on one baseline — bold/colored/underlined fragments mid-sentence without splitting into an `XStack`.

```json
{
  "type": "Text",
  "props": {
    "content": [
      { "text": "Lose " },
      { "text": "5kg", "fontWeight": "700", "color": "#E11D48" },
      { "text": " in 30 days — " },
      { "text": "guaranteed", "fontStyle": "italic", "textDecorationLine": "underline" }
    ]
  }
}
```

Each span overrides only what it sets; omitted props inherit from the parent `Text`. Expression mode interpolates `{{var}}` inside each span's `text`. Backward compatible — string `content` renders unchanged.

## Span fields

`text` (required), `fontWeight`, `fontStyle`, `fontFamily`, `fontSize`, `letterSpacing`, `color`, `textDecorationLine` (`none | underline | line-through | underline line-through`).

## Changes

- **headless** `TextElement.ts` — `TextSpan` type + `TextSpanSchema`; `content` widened to a union; re-exported from `types.ts`.
- **ui** `TextElement.tsx` — mirror schema + `RichTextSpan` component. Each span calls `useResolvedFontStyle` in its own component instance (rules-of-hooks safe with variable span count) and resolves weighted font variants against the parent's inherited family.
- examples (`onboarding-example.ts`, example app `composable-screen.tsx`), docs (`page-types.mdx`, `compose-screen-builder` + `validate-step-json` skills).
- version bump both packages + plugin → **1.31.0**, changelogs.
- repo docs: worktree metro-port gotcha + step `.safeParse` required fields.

## Studio mirror

CMS schema mirror needed in onboarding-studio (content union + `TextSpan` + editor UI). Prompt generated in the implementing session.

## Verification

- `npm run build:headless` + `build:ui` compile clean.
- `npm test --workspace=packages/onboarding` — 95 pass.
- Node `.safeParse` against headless dist: string content, span arrays, minimal spans validate; span missing `text` and bad `textDecorationLine` rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)