### PR TITLE
✨ Animations/transitions/effects for ComposableScreen + TextSpan styles (v1.32.0)

### DIFF
--- a/.claude/rules/composable-screen-runtime.md
+++ b/.claude/rules/composable-screen-runtime.md
@@ -9,6 +9,16 @@ paths:
 
 Every UIElement renderer that wraps content builds `containerStyle` from `BaseBoxProps`: `alignSelf`, `flex`, `flexShrink/Grow`, `width` (via `dim()`), `height` (via `dim()`), `min/maxWidth/Height`, `margin*`, `padding*`, `borderRadius/Width/Color`, `backgroundColor` (only when no `backgroundGradient`), `opacity`, `overflow`. Apply to outermost wrapper (`GradientBox` or `View`). Missing fields = user can't control that aspect from CMS payload.
 
+## Motion: animation / transform (BaseBoxProps)
+
+`animation` (`entering`/`exiting`/`layout`/`effect`) + `transform` live on `BaseBoxProps`, so every element inherits them. A single `AnimatedBox` wrapper injected in `renderElement` (only when `animation`/`transform` present) applies them for all 15 types — **don't** convert individual element roots to `Animated.View`. It forwards `flex`/`alignSelf` so the wrapper stays layout-transparent.
+
+`buildAnimation.ts` resolves reanimated builders **by name** (`Reanimated[preset]`) — the schema `preset` string IS the exact reanimated builder name; unknown preset → no-op (forward-compat). Shared `EASING_MAP` lives here (imported by `ProgressIndicatorElement`) — don't re-declare it.
+
+## TextSpan is not a UIElement
+
+Rich-text `TextSpan` (Text element's `content[]`) renders as inline nested `<Text>` (`RichTextSpan`), bypassing `renderElement` — so **no `animation`/`transform`/`effect` on spans** (and RN ignores `transform` on inline nested Text regardless). Animated/rotating text = a standalone `Text` element. Spans take only inline text-style props (font*, color, backgroundColor, opacity, textTransform, textDecoration*, letterSpacing, lineHeight).
+
 ## Sizing libs needing numeric pixels
 
 `react-native-reanimated-carousel`, `react-native-video`, Lottie/Rive don't accept `"50%"` strings. Pattern:

--- a/claude-plugin/skills/compose-screen-builder/SKILL.md
+++ b/claude-plugin/skills/compose-screen-builder/SKILL.md
@@ -57,6 +57,42 @@ Authoritative prop shapes: `packages/onboarding/src/steps/ComposableScreen/eleme
 
 **Match probe values**: use the app's button `borderRadius` for buttons and large media, half of that for chips/tags, etc.
 
+## Animations / transitions / effects (every element)
+
+Two optional `BaseBoxProps` surfaces apply to **every** element type. Both mirror `react-native-reanimated`. Unknown presets degrade to a no-op (never crash).
+
+**`transform`** (static, applied once):
+
+```
+{ translateX?, translateY?, scale?, scaleX?, scaleY?, rotate? }  // all numbers; rotate is in degrees
+```
+
+**`animation`** — `{ entering?, exiting?, layout?, effect? }`:
+
+- `entering` / `exiting`: `{ preset, duration?, delay?, easing?, spring? }`. `preset` is the **exact reanimated builder name**.
+  - Entering presets: `FadeIn`, `FadeInUp`, `FadeInDown`, `FadeInLeft`, `FadeInRight`, `SlideInUp`, `SlideInDown`, `SlideInLeft`, `SlideInRight`, `ZoomIn`, `ZoomInRotate`, `ZoomInUp`, `ZoomInDown`, `ZoomInLeft`, `ZoomInRight`, `ZoomInEasyUp`, `ZoomInEasyDown`, `BounceIn`, `BounceInUp`, `BounceInDown`, `BounceInLeft`, `BounceInRight`, `FlipInXUp`, `FlipInYLeft`, `FlipInXDown`, `FlipInYRight`, `FlipInEasyX`, `FlipInEasyY`, `StretchInX`, `StretchInY`, `RotateInDownLeft`, `RotateInDownRight`, `RotateInUpLeft`, `RotateInUpRight`, `RollInLeft`, `RollInRight`, `PinwheelIn`, `LightSpeedInLeft`, `LightSpeedInRight`.
+  - Exiting presets: the matching `...Out...` names — e.g. `FadeOut`, `SlideOutLeft`, `ZoomOut`, `BounceOut`, `FlipOutXUp`, `StretchOutX`, `RotateOutDownLeft`, `RollOutLeft`, `PinwheelOut`, `LightSpeedOutLeft`, etc.
+- `layout`: `{ preset, duration?, spring? }`. Presets: `LinearTransition`, `FadingTransition`, `SequencedTransition`, `JumpingTransition`, `CurvedTransition`, `EntryExitTransition`.
+- `effect` (continuous loop — **NOT** a reanimated builder name): `{ preset, duration?, delay?, easing?, loop?, minScale?, maxScale?, minOpacity?, degrees? }`. `preset` ∈ `"pulse" | "fade" | "rotate" | "shimmer" | "bounce"`. `minScale`/`maxScale` apply to `pulse`; `minOpacity` to `fade`; `degrees` to `rotate`.
+- `easing`: `"linear" | "ease-in" | "ease-out" | "ease-in-out"`. `spring`: `{ damping?, stiffness?, mass? }` — mirrors reanimated `.springify(config)`; **`spring` wins over `easing`** when both are present.
+
+Worked example (Image with static tilt, entrance/exit, and a continuous pulse):
+
+```json
+{
+  "id": "hero-badge", "type": "Image",
+  "props": {
+    "url": "https://cdn.example.com/badge.png", "width": 96,
+    "transform": { "rotate": -4 },
+    "animation": {
+      "entering": { "preset": "ZoomInDown", "duration": 600, "delay": 200, "spring": { "damping": 12, "stiffness": 180 } },
+      "exiting": { "preset": "FadeOut", "duration": 250 },
+      "effect": { "preset": "pulse", "duration": 1200, "minScale": 0.97, "maxScale": 1.06 }
+    }
+  }
+}
+```
+
 ## Variables
 
 **There is no `payload.variables` map.** Variables live at runtime in the headless provider's variables store. They are populated by:

--- a/claude-plugin/skills/create-step-json/references/composable-archetypes.md
+++ b/claude-plugin/skills/create-step-json/references/composable-archetypes.md
@@ -49,6 +49,27 @@ CTA pattern (use every time — never bare `actions: ["continue"]` with no styli
 }
 ```
 
+### Adding motion to an element
+
+Every element accepts optional `transform` (static) and `animation` (`{ entering, exiting, layout, effect }`, mirroring `react-native-reanimated`) via `BaseBoxProps`. Drop them into any archetype element's `props` for entrance/exit/loop motion. `entering`/`exiting` presets are exact reanimated builder names (e.g. `FadeInUp`, `ZoomInDown`, `FadeOut`); `effect.preset` is a continuous loop — one of `"pulse"|"fade"|"rotate"|"shimmer"|"bounce"`. Full preset lists live in the `compose-screen-builder` skill. Unknown presets degrade to a no-op.
+
+```json
+{
+  "id": "hero-badge", "type": "Image",
+  "props": {
+    "url": "https://cdn.example.com/badge.png", "width": 96,
+    "transform": { "rotate": -4 },
+    "animation": {
+      "entering": { "preset": "ZoomInDown", "duration": 600, "delay": 200, "spring": { "damping": 12, "stiffness": 180 } },
+      "exiting": { "preset": "FadeOut", "duration": 250 },
+      "effect": { "preset": "pulse", "duration": 1200, "minScale": 0.97, "maxScale": 1.06 }
+    }
+  }
+}
+```
+
+Common touches: stagger a list of cards by bumping `entering.delay` per item (`100`, `200`, `300…`); give a hero a subtle living feel with `effect: { "preset": "pulse" }` or `{ "preset": "fade" }`; use `spring` (`{ damping?, stiffness?, mass? }`) instead of `easing` for bouncy entrances (`spring` wins when both are set).
+
 ---
 
 ## hero

--- a/claude-plugin/skills/customize-onboarding-components/SKILL.md
+++ b/claude-plugin/skills/customize-onboarding-components/SKILL.md
@@ -52,6 +52,10 @@ Containers (`YStack` / `XStack` / `ZStack` / `SafeAreaView`):
 - `backgroundColor`, `borderRadius`, `borderWidth`, `borderColor`
 - gradients via `background: GradientBackground`
 
+Motion (every element, via `BaseBoxProps`):
+- `transform` — static `{ translateX?, translateY?, scale?, scaleX?, scaleY?, rotate? }` (`rotate` in degrees)
+- `animation` — `{ entering?, exiting?, layout?, effect? }` mirroring `react-native-reanimated` (`entering`/`exiting` use builder-name presets; `effect` is a continuous loop `"pulse"|"fade"|"rotate"|"shimmer"|"bounce"`). See `compose-screen-builder` for the full preset lists and a worked example.
+
 This is the canonical path. 90% of customization needs are met by injecting Design Profile values into these props.
 
 ## Tier 2 — Custom button actions (host-wired behavior)

--- a/claude-plugin/skills/validate-step-json/SKILL.md
+++ b/claude-plugin/skills/validate-step-json/SKILL.md
@@ -48,6 +48,12 @@ Run: `npx tsx scripts/_validate-composable.ts "$(cat step.json)"`
    - `Button.props.disabledWhen` (NOT `disabled`) is a valid `LeafCondition` or `ConditionGroup`
    - `Button.props.pressedStyle` / `disabledStyle` (if present) are objects — `Partial` of overridable Button props; must NOT nest `pressedStyle`/`disabledStyle`. `transitionDurationMs` is a non-negative number.
    - Shadow fields (any element): `shadowColor` string; `shadowOffset` is `{width, height}` (NOT a number); `shadowOpacity` 0–1; `shadowRadius`/`elevation` non-negative numbers
+   - `transform` (any element, optional): object with any of `translateX`/`translateY`/`scale`/`scaleX`/`scaleY`/`rotate` — all numbers (`rotate` in degrees). No other keys.
+   - `animation` (any element, optional): object `{ entering?, exiting?, layout?, effect? }`.
+     - `entering`/`exiting`: `{ preset, duration?, delay?, easing?, spring? }`. `preset` is a string (exact reanimated builder name — entering: `FadeIn`/`FadeInUp`/`FadeInDown`/`FadeInLeft`/`FadeInRight`/`SlideInUp`/`SlideInDown`/`SlideInLeft`/`SlideInRight`/`ZoomIn`/`ZoomInRotate`/`ZoomInUp`/`ZoomInDown`/`ZoomInLeft`/`ZoomInRight`/`ZoomInEasyUp`/`ZoomInEasyDown`/`BounceIn`/`BounceInUp`/`BounceInDown`/`BounceInLeft`/`BounceInRight`/`FlipInXUp`/`FlipInYLeft`/`FlipInXDown`/`FlipInYRight`/`FlipInEasyX`/`FlipInEasyY`/`StretchInX`/`StretchInY`/`RotateInDownLeft`/`RotateInDownRight`/`RotateInUpLeft`/`RotateInUpRight`/`RollInLeft`/`RollInRight`/`PinwheelIn`/`LightSpeedInLeft`/`LightSpeedInRight`; exiting: matching `...Out...` names e.g. `FadeOut`/`SlideOutLeft`/`ZoomOut`/`BounceOut`/`FlipOutXUp`/`StretchOutX`/`RotateOutDownLeft`/`RollOutLeft`/`PinwheelOut`/`LightSpeedOutLeft`). Unknown presets degrade to no-op (not an error).
+     - `layout`: `{ preset, duration?, spring? }`. `preset` ∈ `LinearTransition`/`FadingTransition`/`SequencedTransition`/`JumpingTransition`/`CurvedTransition`/`EntryExitTransition`.
+     - `effect` (continuous loop, NOT a builder name): `{ preset, duration?, delay?, easing?, loop?, minScale?, maxScale?, minOpacity?, degrees? }`. `preset` ∈ `"pulse"|"fade"|"rotate"|"shimmer"|"bounce"`.
+     - `easing` (where present) ∈ `"linear"|"ease-in"|"ease-out"|"ease-in-out"`; `spring` is `{ damping?, stiffness?, mass? }` (numbers); `duration`/`delay` non-negative numbers. `spring` wins over `easing` when both present.
    - `SafeAreaView.props.edges` is an array of `"top"|"right"|"bottom"|"left"` OR an object with edge mode `"off"|"additive"|"maximum"` — NEVER `"always"`
    - **Flow-level chain integrity (when input is an array of steps)**:
      - Every non-terminal step has `nextStep: { defaultTargetStepId, branches }`. Terminal step has `nextStep: null`. Flag steps that rely on `null` linear fallback in the middle of a flow as a warning ("implicit linear link — prefer explicit defaultTargetStepId").
@@ -75,6 +81,9 @@ Run: `npx tsx scripts/_validate-composable.ts "$(cat step.json)"`
 - `Button.props.action` (singular) used instead of `actions: [...]` (array).
 - `Button.props.disabled` instead of `disabledWhen`.
 - `shadowOffset` given as a number instead of `{ width, height }`.
+- `transform.rotate` given as a string (e.g. `"-4deg"`) instead of a number (degrees).
+- `animation.effect.preset` set to a reanimated builder name (e.g. `FadeIn`) — `effect` presets are only `"pulse"|"fade"|"rotate"|"shimmer"|"bounce"`; builder names belong under `entering`/`exiting`/`layout`. (Unknown presets are not a hard error — they degrade to no-op — but flag as a likely mistake.)
+- `animation.easing` outside `"linear"|"ease-in"|"ease-out"|"ease-in-out"`.
 - `pressedStyle` / `disabledStyle` nesting another `pressedStyle`/`disabledStyle` (stripped — not overridable).
 - `SafeAreaView.props.edges: { top: "always" }` — invalid edge mode. Use `["top","bottom"]` or `"off" | "additive" | "maximum"`.
 - `Lottie.source: { localPathId }` instead of string URL.

--- a/example/app/example/composable-screen-animations.tsx
+++ b/example/app/example/composable-screen-animations.tsx
@@ -1,0 +1,335 @@
+import * as OnboardingUi from '@rocapine/react-native-onboarding-ui';
+import { View, Pressable, Text, StyleSheet } from 'react-native';
+import { useRouter } from 'expo-router';
+import { useState } from 'react';
+
+export const unstable_settings = {
+  anchor: '(tabs)',
+};
+
+// A small card wrapping a label, used to show off each entering preset.
+const enteringCard = (
+  id: string,
+  preset: string,
+  delay: number,
+  extra: Record<string, unknown> = {}
+) => ({
+  id,
+  type: 'YStack' as const,
+  props: {
+    padding: 14,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: '#E0E0E0',
+    backgroundColor: '#fff',
+    animation: {
+      entering: { preset: preset as any, duration: 500, delay, easing: 'ease-out' as const },
+    },
+  },
+  children: [
+    {
+      id: `${id}-label`,
+      type: 'Text' as const,
+      props: { content: preset, fontSize: 14, fontWeight: '600' as const, ...extra },
+    },
+  ],
+});
+
+export default function ComposableScreenAnimationsExample() {
+  const router = useRouter();
+  // Bumping this key remounts the renderer, re-firing every `entering` animation.
+  const [replayKey, setReplayKey] = useState(0);
+
+  const step = {
+    id: 'composable-screen-animations',
+    type: 'ComposableScreen',
+    name: 'Animations',
+    displayProgressHeader: true,
+    payload: {
+      elements: [
+        {
+          id: 'safe-root',
+          type: 'SafeAreaView' as const,
+          props: { flex: 1, edges: ['top', 'bottom'] as ('top' | 'right' | 'bottom' | 'left')[] },
+          children: [
+            {
+              id: 'scroll-root',
+              type: 'ScrollView' as const,
+              props: { flex: 1, showsVerticalScrollIndicator: false },
+              children: [
+                {
+                  id: 'root',
+                  type: 'YStack',
+                  props: { gap: 16, padding: 24 },
+                  children: [
+                    // ---- Title ----
+                    {
+                      id: 'title',
+                      type: 'Text' as const,
+                      props: {
+                        content: 'Animations',
+                        fontSize: 30,
+                        fontWeight: '700' as const,
+                        animation: { entering: { preset: 'FadeInDown' as const, duration: 450 } },
+                      },
+                    },
+                    {
+                      id: 'subtitle',
+                      type: 'Text' as const,
+                      props: {
+                        content: 'transform + animation (entering / exiting / layout / effect) — schema mirrors reanimated.',
+                        fontSize: 14,
+                        lineHeight: 20,
+                        opacity: 0.6,
+                        animation: { entering: { preset: 'FadeIn' as const, duration: 450, delay: 120 } },
+                      },
+                    },
+
+                    // ---- Section: entering presets (staggered via `delay`) ----
+                    {
+                      id: 'sec-entering',
+                      type: 'Text' as const,
+                      props: { content: 'Entering — staggered by delay', fontSize: 13, fontWeight: '700' as const, opacity: 0.5, marginVertical: 4 },
+                    },
+                    enteringCard('e1', 'FadeInDown', 100),
+                    enteringCard('e2', 'SlideInLeft', 180),
+                    enteringCard('e3', 'ZoomIn', 260),
+                    enteringCard('e4', 'BounceInUp', 340),
+                    enteringCard('e5', 'FlipInEasyX', 420),
+                    enteringCard('e6', 'RotateInDownLeft', 500),
+                    enteringCard('e7', 'RollInLeft', 580),
+                    enteringCard('e8', 'LightSpeedInRight', 660),
+                    enteringCard('e9', 'PinwheelIn', 740),
+                    enteringCard('e10', 'StretchInX', 820),
+
+                    // ---- Section: spring vs easing ----
+                    {
+                      id: 'sec-spring',
+                      type: 'Text' as const,
+                      props: { content: 'Spring (springify) vs easing', fontSize: 13, fontWeight: '700' as const, opacity: 0.5, marginVertical: 4 },
+                    },
+                    {
+                      id: 'spring-card',
+                      type: 'YStack' as const,
+                      props: {
+                        padding: 14,
+                        borderRadius: 12,
+                        backgroundColor: '#EEF2FF',
+                        animation: { entering: { preset: 'ZoomInDown' as const, duration: 600, delay: 100, spring: { damping: 9, stiffness: 170 } } },
+                      },
+                      children: [
+                        { id: 'spring-card-label', type: 'Text' as const, props: { content: 'ZoomInDown • spring(damping 9, stiffness 170)', fontSize: 13 } },
+                      ],
+                    },
+
+                    // ---- Section: continuous effects ----
+                    {
+                      id: 'sec-effects',
+                      type: 'Text' as const,
+                      props: { content: 'Effects — continuous loops', fontSize: 13, fontWeight: '700' as const, opacity: 0.5, marginVertical: 4 },
+                    },
+                    {
+                      id: 'effects-row',
+                      type: 'XStack' as const,
+                      props: { gap: 16, justifyContent: 'space-between' as const, alignItems: 'center' as const, paddingVertical: 8 },
+                      children: [
+                        {
+                          id: 'fx-pulse',
+                          type: 'Icon' as const,
+                          props: { name: 'Heart', size: 36, color: '#FF6584', fill: '#FF6584', fillOpacity: 0.25, animation: { effect: { preset: 'pulse' as const, duration: 900, minScale: 0.85, maxScale: 1.15 } } },
+                        },
+                        {
+                          id: 'fx-rotate',
+                          type: 'Icon' as const,
+                          props: { name: 'Loader', size: 36, color: '#6C63FF', animation: { effect: { preset: 'rotate' as const, duration: 1000, degrees: 360 } } },
+                        },
+                        {
+                          id: 'fx-fade',
+                          type: 'Icon' as const,
+                          props: { name: 'Star', size: 36, color: '#F59E0B', fill: '#F59E0B', fillOpacity: 0.3, animation: { effect: { preset: 'fade' as const, duration: 800, minOpacity: 0.2 } } },
+                        },
+                        {
+                          id: 'fx-bounce',
+                          type: 'Icon' as const,
+                          props: { name: 'ArrowDown', size: 36, color: '#10B981', animation: { effect: { preset: 'bounce' as const, duration: 600 } } },
+                        },
+                        {
+                          id: 'fx-shimmer',
+                          type: 'Icon' as const,
+                          props: { name: 'Sparkles', size: 36, color: '#0EA5E9', animation: { effect: { preset: 'shimmer' as const, duration: 700 } } },
+                        },
+                      ],
+                    },
+
+                    // ---- Section: static transforms ----
+                    {
+                      id: 'sec-transform',
+                      type: 'Text' as const,
+                      props: { content: 'Transform — static', fontSize: 13, fontWeight: '700' as const, opacity: 0.5, marginVertical: 4 },
+                    },
+                    {
+                      id: 'transform-row',
+                      type: 'XStack' as const,
+                      props: { gap: 12, justifyContent: 'space-around' as const, alignItems: 'center' as const, paddingVertical: 12 },
+                      children: [
+                        {
+                          id: 'tf-tilt',
+                          type: 'YStack' as const,
+                          props: { padding: 12, borderRadius: 8, backgroundColor: '#6C63FF', transform: { rotate: -8 } },
+                          children: [{ id: 'tf-tilt-l', type: 'Text' as const, props: { content: 'rotate -8°', fontSize: 12, color: '#fff', fontWeight: '600' as const } }],
+                        },
+                        {
+                          id: 'tf-scale',
+                          type: 'YStack' as const,
+                          props: { padding: 12, borderRadius: 8, backgroundColor: '#FF6584', transform: { scale: 1.15 } },
+                          children: [{ id: 'tf-scale-l', type: 'Text' as const, props: { content: 'scale 1.15', fontSize: 12, color: '#fff', fontWeight: '600' as const } }],
+                        },
+                        {
+                          id: 'tf-shift',
+                          type: 'YStack' as const,
+                          props: { padding: 12, borderRadius: 8, backgroundColor: '#10B981', transform: { translateY: -8 } },
+                          children: [{ id: 'tf-shift-l', type: 'Text' as const, props: { content: 'translateY -8', fontSize: 12, color: '#fff', fontWeight: '600' as const } }],
+                        },
+                      ],
+                    },
+
+                    // ---- Section: exiting + layout (toggle via renderWhen) ----
+                    {
+                      id: 'sec-exit',
+                      type: 'Text' as const,
+                      props: { content: 'Exiting + layout — toggle the card', fontSize: 13, fontWeight: '700' as const, opacity: 0.5, marginVertical: 4 },
+                    },
+                    {
+                      id: 'toggle-row',
+                      type: 'XStack' as const,
+                      props: { gap: 12 },
+                      children: [
+                        {
+                          id: 'btn-show',
+                          type: 'Button' as const,
+                          props: {
+                            label: 'Show',
+                            variant: 'outlined' as const,
+                            flex: 1,
+                            actions: [{ type: 'setVariable' as const, name: 'cardVisible', value: 'yes', label: 'shown' }],
+                          },
+                        },
+                        {
+                          id: 'btn-hide',
+                          type: 'Button' as const,
+                          props: {
+                            label: 'Hide',
+                            variant: 'outlined' as const,
+                            flex: 1,
+                            actions: [{ type: 'setVariable' as const, name: 'cardVisible', value: 'no', label: 'hidden' }],
+                          },
+                        },
+                      ],
+                    },
+                    // The toggled card: enters + exits; siblings below reflow with a layout transition.
+                    {
+                      id: 'toggle-card',
+                      renderWhen: { variable: 'cardVisible', operator: 'eq' as const, value: 'yes' },
+                      type: 'YStack' as const,
+                      props: {
+                        padding: 20,
+                        borderRadius: 16,
+                        backgroundColor: '#EEF2FF',
+                        animation: {
+                          entering: { preset: 'SlideInDown' as const, duration: 350 },
+                          exiting: { preset: 'SlideOutUp' as const, duration: 300 },
+                        },
+                      },
+                      children: [
+                        { id: 'toggle-card-t', type: 'Text' as const, props: { content: 'Now you see me', fontSize: 16, fontWeight: '700' as const } },
+                        { id: 'toggle-card-b', type: 'Text' as const, props: { content: 'SlideInDown on show, SlideOutUp on hide.', fontSize: 13, opacity: 0.6 } },
+                      ],
+                    },
+                    {
+                      id: 'reflow-note',
+                      type: 'YStack' as const,
+                      props: {
+                        padding: 16,
+                        borderRadius: 12,
+                        borderWidth: 1,
+                        borderColor: '#C7DEFF',
+                        animation: { layout: { preset: 'LinearTransition' as const, duration: 300 } },
+                      },
+                      children: [
+                        { id: 'reflow-note-t', type: 'Text' as const, props: { content: 'This block slides up/down smoothly (LinearTransition) as the card above toggles.', fontSize: 13, opacity: 0.7 } },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    customPayload: null,
+    continueButtonLabel: 'Continue',
+    figmaUrl: null,
+  } satisfies OnboardingUi.ComposableScreenStepType;
+
+  return (
+    <View style={{ flex: 1 }}>
+      {/* `key` remount re-fires every entering animation. */}
+      <OnboardingUi.ComposableScreenRenderer key={replayKey} step={step} onContinue={() => router.back()} />
+      <Pressable style={styles.replayButton} onPress={() => setReplayKey((k) => k + 1)}>
+        <Text style={styles.replayButtonText}>↻ Replay</Text>
+      </Pressable>
+      <Pressable style={styles.backButton} onPress={() => router.back()}>
+        <Text style={styles.backButtonText}>‹</Text>
+      </Pressable>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  backButton: {
+    position: 'absolute',
+    top: 50,
+    left: 20,
+    width: 32,
+    height: 32,
+    backgroundColor: 'rgba(255, 255, 255, 0.9)',
+    borderRadius: 16,
+    alignItems: 'center',
+    justifyContent: 'center',
+    zIndex: 1000,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.1,
+    shadowRadius: 4,
+    elevation: 3,
+  },
+  backButtonText: {
+    color: '#007AFF',
+    fontSize: 32,
+    fontWeight: '400',
+    lineHeight: 32,
+  },
+  replayButton: {
+    position: 'absolute',
+    top: 50,
+    right: 20,
+    paddingHorizontal: 14,
+    height: 32,
+    backgroundColor: 'rgba(255, 255, 255, 0.95)',
+    borderRadius: 16,
+    alignItems: 'center',
+    justifyContent: 'center',
+    zIndex: 1000,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.1,
+    shadowRadius: 4,
+    elevation: 3,
+  },
+  replayButtonText: {
+    color: '#007AFF',
+    fontSize: 14,
+    fontWeight: '600',
+  },
+});

--- a/example/app/example/composable-screen.tsx
+++ b/example/app/example/composable-screen.tsx
@@ -54,7 +54,7 @@ export default function ComposableScreenExample() {
                 fit: 'FitWidth',
               },
             },
-            // Hero image
+            // Hero image — fade/slide in on mount (reanimated entering builder)
             {
               id: 'hero-image',
               type: 'Image',
@@ -63,9 +63,12 @@ export default function ComposableScreenExample() {
                 height: 180,
                 resizeMode: 'cover',
                 borderRadius: 16,
+                animation: {
+                  entering: { preset: 'FadeInDown' as const, duration: 500, delay: 100, easing: 'ease-out' as const },
+                },
               },
             },
-            // Icon element (filled — fill + fillOpacity)
+            // Icon element (filled) — static tilt + continuous breathing pulse
             {
               id: 'hero-icon',
               type: 'Icon',
@@ -76,6 +79,11 @@ export default function ComposableScreenExample() {
                 fill: '#007AFF',
                 fillOpacity: 0.25,
                 marginVertical: 8,
+                transform: { rotate: -8 },
+                animation: {
+                  entering: { preset: 'ZoomIn' as const, duration: 400, spring: { damping: 10, stiffness: 160 } },
+                  effect: { preset: 'pulse' as const, duration: 1200, minScale: 0.92, maxScale: 1.08 },
+                },
               },
             },
             // Progress indicators — linear (autoplay loop) + circular (autoplay once)

--- a/example/app/example/index.tsx
+++ b/example/app/example/index.tsx
@@ -27,6 +27,7 @@ const examples: Example[] = [
       { name: "ScrollView", route: "/example/composable-screen-scrollview" },
       { name: "Keyboard", route: "/example/composable-screen-keyboard" },
       { name: "Runtime Fonts", route: "/example/composable-screen-fonts" },
+      { name: "Animations", route: "/example/composable-screen-animations" },
       { name: "All", route: "/example/composable-screen" },
     ],
   },

--- a/packages/onboarding-ui/CHANGELOG.md
+++ b/packages/onboarding-ui/CHANGELOG.md
@@ -15,6 +15,7 @@ here.
 - **`AnimatedBox` wrapper + `buildAnimation` helper** — renders the new `transform` / `animation` surface (see headless `1.32.0`) for every ComposableScreen element. `renderElement` wraps the dispatched node in a single `Animated.View` (`AnimatedBox`) only when `animation` or `transform` is present (zero extra view otherwise), forwarding `flex`/`alignSelf` so the wrapper stays layout-transparent. `entering`/`exiting`/`layout` resolve to reanimated builders by name (`Reanimated[preset]`) with `.duration().delay().springify().easing()` modifiers; unknown presets degrade to no-op. Continuous `effect` (`pulse`/`fade`/`rotate`/`shimmer`/`bounce`) runs imperatively via `withRepeat`. No new peer deps — uses the existing `react-native-reanimated` stack.
 - Shared `EASING_MAP` extracted to `buildAnimation.ts`; `ProgressIndicatorElement` now imports it (removes the duplicated easing table).
 - New `composable-screen-animations` example screen (entering presets staggered by `delay`, spring vs easing, looping effects, static transforms, exiting + layout toggle, Replay button). `composable-screen.tsx` + `onboarding-example.ts` demos: hero image fades in (`FadeInDown`), star icon zooms in with a static tilt and a continuous `pulse`.
+- **`RichTextSpan` extended** — applies the new `TextSpan` fields (`backgroundColor`, `opacity`, `textTransform`, `textDecorationColor`, `textDecorationStyle`, `lineHeight`) to the nested inline `<Text>`.
 
 ---
 

--- a/packages/onboarding-ui/CHANGELOG.md
+++ b/packages/onboarding-ui/CHANGELOG.md
@@ -9,6 +9,15 @@ here.
 
 ---
 
+## [1.32.0] - 2026-06-01
+
+### Added
+- **`AnimatedBox` wrapper + `buildAnimation` helper** — renders the new `transform` / `animation` surface (see headless `1.32.0`) for every ComposableScreen element. `renderElement` wraps the dispatched node in a single `Animated.View` (`AnimatedBox`) only when `animation` or `transform` is present (zero extra view otherwise), forwarding `flex`/`alignSelf` so the wrapper stays layout-transparent. `entering`/`exiting`/`layout` resolve to reanimated builders by name (`Reanimated[preset]`) with `.duration().delay().springify().easing()` modifiers; unknown presets degrade to no-op. Continuous `effect` (`pulse`/`fade`/`rotate`/`shimmer`/`bounce`) runs imperatively via `withRepeat`. No new peer deps — uses the existing `react-native-reanimated` stack.
+- Shared `EASING_MAP` extracted to `buildAnimation.ts`; `ProgressIndicatorElement` now imports it (removes the duplicated easing table).
+- New `composable-screen-animations` example screen (entering presets staggered by `delay`, spring vs easing, looping effects, static transforms, exiting + layout toggle, Replay button). `composable-screen.tsx` + `onboarding-example.ts` demos: hero image fades in (`FadeInDown`), star icon zooms in with a static tilt and a continuous `pulse`.
+
+---
+
 ## [1.31.0] - 2026-06-01
 
 ### Added

--- a/packages/onboarding-ui/package.json
+++ b/packages/onboarding-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocapine/react-native-onboarding-ui",
-  "version": "1.31.0",
+  "version": "1.32.0",
   "description": "UI components and renderers for Rocapine Onboarding Studio - Built on top of the headless SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/AnimatedBox.tsx
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/AnimatedBox.tsx
@@ -1,0 +1,133 @@
+import React, { useEffect, useMemo } from "react";
+import Animated, {
+  useSharedValue,
+  useAnimatedStyle,
+  withTiming,
+  withRepeat,
+  withDelay,
+  cancelAnimation,
+  interpolate,
+} from "react-native-reanimated";
+import type { ElementAnimation, ElementTransform } from "@rocapine/react-native-onboarding";
+import { buildEntering, buildExiting, buildLayout, EASING_MAP } from "./buildAnimation";
+
+type Props = {
+  animation?: ElementAnimation;
+  transform?: ElementTransform;
+  // Layout props forwarded from the child so the extra wrapper stays
+  // layout-transparent (a trapped `flex`/`alignSelf` would otherwise break
+  // the child's relationship to its parent).
+  flex?: number;
+  alignSelf?: "auto" | "flex-start" | "flex-end" | "center" | "stretch" | "baseline";
+  children: React.ReactNode;
+};
+
+// Build the static transform array (RN expects `[{translateX}, {scale}, ...]`).
+// Typed `any[]`: RN's transform element is a strict per-key union that a
+// programmatically-built array can't satisfy structurally, and the array is
+// composed with animated entries inside the worklet below.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const buildStaticTransform = (t?: ElementTransform): any[] => {
+  if (!t) return [];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const arr: any[] = [];
+  if (t.translateX != null) arr.push({ translateX: t.translateX });
+  if (t.translateY != null) arr.push({ translateY: t.translateY });
+  if (t.scale != null) arr.push({ scale: t.scale });
+  if (t.scaleX != null) arr.push({ scaleX: t.scaleX });
+  if (t.scaleY != null) arr.push({ scaleY: t.scaleY });
+  if (t.rotate != null) arr.push({ rotate: `${t.rotate}deg` });
+  return arr;
+};
+
+/**
+ * Wraps a rendered UIElement in an `Animated.View` that owns its
+ * entering/exiting/layout transitions (reanimated builders) and a continuous
+ * `effect` (imperative `withRepeat`), plus any static `transform`.
+ *
+ * Injected by `renderElement` only when `animation` or `transform` is present.
+ * All reanimated hooks are called unconditionally (rules of hooks) — the
+ * effect-vs-no-effect branch lives inside the effect/worklet body.
+ */
+export const AnimatedBox = ({
+  animation,
+  transform,
+  flex,
+  alignSelf,
+  children,
+}: Props): React.ReactElement => {
+  const entering = buildEntering(animation?.entering);
+  const exiting = buildExiting(animation?.exiting);
+  const layout = buildLayout(animation?.layout);
+
+  const effect = animation?.effect;
+  const staticTransform = useMemo(() => buildStaticTransform(transform), [transform]);
+
+  // Continuous-effect driver (0 -> 1). Created unconditionally.
+  const driver = useSharedValue(0);
+
+  useEffect(() => {
+    if (!effect) {
+      cancelAnimation(driver);
+      driver.value = 0;
+      return;
+    }
+    driver.value = 0;
+    // rotate spins one direction; the rest breathe back and forth.
+    const reverse = effect.preset !== "rotate";
+    const half = withTiming(1, {
+      duration: effect.duration ?? 1000,
+      easing: EASING_MAP[effect.easing ?? "ease-in-out"],
+    });
+    const repeated = withRepeat(half, effect.loop === false ? 1 : -1, reverse);
+    driver.value = effect.delay ? withDelay(effect.delay, repeated) : repeated;
+    return () => cancelAnimation(driver);
+  }, [effect, driver]);
+
+  const animatedStyle = useAnimatedStyle(() => {
+    if (!effect) return { transform: staticTransform };
+    switch (effect.preset) {
+      case "pulse":
+        return {
+          transform: [
+            ...staticTransform,
+            { scale: interpolate(driver.value, [0, 1], [effect.minScale ?? 0.95, effect.maxScale ?? 1.05]) },
+          ],
+        };
+      case "fade":
+        return {
+          transform: staticTransform,
+          opacity: interpolate(driver.value, [0, 1], [effect.minOpacity ?? 0.4, 1]),
+        };
+      case "rotate":
+        return {
+          transform: [
+            ...staticTransform,
+            { rotate: `${interpolate(driver.value, [0, 1], [0, effect.degrees ?? 360])}deg` },
+          ],
+        };
+      case "bounce":
+        return {
+          transform: [...staticTransform, { translateY: interpolate(driver.value, [0, 1], [0, -10]) }],
+        };
+      case "shimmer":
+        return {
+          transform: staticTransform,
+          opacity: interpolate(driver.value, [0, 1], [0.5, 1]),
+        };
+      default:
+        return { transform: staticTransform };
+    }
+  }, [effect, staticTransform]);
+
+  return (
+    <Animated.View
+      entering={entering}
+      exiting={exiting}
+      layout={layout}
+      style={[{ flex, alignSelf }, animatedStyle]}
+    >
+      {children}
+    </Animated.View>
+  );
+};

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/BaseBoxProps.ts
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/BaseBoxProps.ts
@@ -50,6 +50,213 @@ export const ShadowOffsetSchema = z.object({
   height: z.number(),
 });
 
+// ---------------------------------------------------------------------------
+// Animation / Transform surface
+//
+// Schema stays intentionally close to react-native-reanimated: `preset` values
+// are the *exact* reanimated builder names (e.g. `FadeInDown`, `SlideOutLeft`,
+// `LinearTransition`), so the UI renderer resolves them by direct namespace
+// lookup (`Reanimated[preset]`) rather than a translation table. Modifier fields
+// (`duration`/`delay`/`spring`/`easing`) map to reanimated builder methods
+// (`.duration().delay().springify().easing()`).
+// ---------------------------------------------------------------------------
+
+// Reuses the easing-name convention from ProgressIndicatorElement.
+export type AnimationEasing = "linear" | "ease-in" | "ease-out" | "ease-in-out";
+
+const AnimationEasingSchema = z.enum(["linear", "ease-in", "ease-out", "ease-in-out"]);
+
+// Mirrors reanimated's `.springify(config)` — only the fields it accepts.
+// When `spring` is present it wins over `easing` (matches reanimated semantics).
+export type SpringConfig = {
+  damping?: number;
+  stiffness?: number;
+  mass?: number;
+};
+
+const SpringConfigSchema = z.object({
+  damping: z.number().positive().optional(),
+  stiffness: z.number().positive().optional(),
+  mass: z.number().positive().optional(),
+});
+
+// Exact reanimated entering builder names.
+export type EnteringPreset =
+  | "FadeIn" | "FadeInUp" | "FadeInDown" | "FadeInLeft" | "FadeInRight"
+  | "SlideInUp" | "SlideInDown" | "SlideInLeft" | "SlideInRight"
+  | "ZoomIn" | "ZoomInRotate" | "ZoomInUp" | "ZoomInDown" | "ZoomInLeft" | "ZoomInRight"
+  | "ZoomInEasyUp" | "ZoomInEasyDown"
+  | "BounceIn" | "BounceInUp" | "BounceInDown" | "BounceInLeft" | "BounceInRight"
+  | "FlipInXUp" | "FlipInYLeft" | "FlipInXDown" | "FlipInYRight" | "FlipInEasyX" | "FlipInEasyY"
+  | "StretchInX" | "StretchInY"
+  | "RotateInDownLeft" | "RotateInDownRight" | "RotateInUpLeft" | "RotateInUpRight"
+  | "RollInLeft" | "RollInRight"
+  | "PinwheelIn"
+  | "LightSpeedInLeft" | "LightSpeedInRight";
+
+const EnteringPresetSchema = z.enum([
+  "FadeIn", "FadeInUp", "FadeInDown", "FadeInLeft", "FadeInRight",
+  "SlideInUp", "SlideInDown", "SlideInLeft", "SlideInRight",
+  "ZoomIn", "ZoomInRotate", "ZoomInUp", "ZoomInDown", "ZoomInLeft", "ZoomInRight",
+  "ZoomInEasyUp", "ZoomInEasyDown",
+  "BounceIn", "BounceInUp", "BounceInDown", "BounceInLeft", "BounceInRight",
+  "FlipInXUp", "FlipInYLeft", "FlipInXDown", "FlipInYRight", "FlipInEasyX", "FlipInEasyY",
+  "StretchInX", "StretchInY",
+  "RotateInDownLeft", "RotateInDownRight", "RotateInUpLeft", "RotateInUpRight",
+  "RollInLeft", "RollInRight",
+  "PinwheelIn",
+  "LightSpeedInLeft", "LightSpeedInRight",
+]);
+
+// Exact reanimated exiting builder names.
+export type ExitingPreset =
+  | "FadeOut" | "FadeOutUp" | "FadeOutDown" | "FadeOutLeft" | "FadeOutRight"
+  | "SlideOutUp" | "SlideOutDown" | "SlideOutLeft" | "SlideOutRight"
+  | "ZoomOut" | "ZoomOutRotate" | "ZoomOutUp" | "ZoomOutDown" | "ZoomOutLeft" | "ZoomOutRight"
+  | "ZoomOutEasyUp" | "ZoomOutEasyDown"
+  | "BounceOut" | "BounceOutUp" | "BounceOutDown" | "BounceOutLeft" | "BounceOutRight"
+  | "FlipOutXUp" | "FlipOutYLeft" | "FlipOutXDown" | "FlipOutYRight" | "FlipOutEasyX" | "FlipOutEasyY"
+  | "StretchOutX" | "StretchOutY"
+  | "RotateOutDownLeft" | "RotateOutDownRight" | "RotateOutUpLeft" | "RotateOutUpRight"
+  | "RollOutLeft" | "RollOutRight"
+  | "PinwheelOut"
+  | "LightSpeedOutLeft" | "LightSpeedOutRight";
+
+const ExitingPresetSchema = z.enum([
+  "FadeOut", "FadeOutUp", "FadeOutDown", "FadeOutLeft", "FadeOutRight",
+  "SlideOutUp", "SlideOutDown", "SlideOutLeft", "SlideOutRight",
+  "ZoomOut", "ZoomOutRotate", "ZoomOutUp", "ZoomOutDown", "ZoomOutLeft", "ZoomOutRight",
+  "ZoomOutEasyUp", "ZoomOutEasyDown",
+  "BounceOut", "BounceOutUp", "BounceOutDown", "BounceOutLeft", "BounceOutRight",
+  "FlipOutXUp", "FlipOutYLeft", "FlipOutXDown", "FlipOutYRight", "FlipOutEasyX", "FlipOutEasyY",
+  "StretchOutX", "StretchOutY",
+  "RotateOutDownLeft", "RotateOutDownRight", "RotateOutUpLeft", "RotateOutUpRight",
+  "RollOutLeft", "RollOutRight",
+  "PinwheelOut",
+  "LightSpeedOutLeft", "LightSpeedOutRight",
+]);
+
+// Exact reanimated layout-transition builder names.
+export type LayoutPreset =
+  | "LinearTransition" | "FadingTransition" | "SequencedTransition"
+  | "JumpingTransition" | "CurvedTransition" | "EntryExitTransition";
+
+const LayoutPresetSchema = z.enum([
+  "LinearTransition", "FadingTransition", "SequencedTransition",
+  "JumpingTransition", "CurvedTransition", "EntryExitTransition",
+]);
+
+export type EnteringAnimation = {
+  preset: EnteringPreset;
+  duration?: number;
+  delay?: number;
+  easing?: AnimationEasing;
+  spring?: SpringConfig;
+};
+
+const EnteringAnimationSchema = z.object({
+  preset: EnteringPresetSchema,
+  duration: z.number().min(0).optional(),
+  delay: z.number().min(0).optional(),
+  easing: AnimationEasingSchema.optional(),
+  spring: SpringConfigSchema.optional(),
+});
+
+export type ExitingAnimation = {
+  preset: ExitingPreset;
+  duration?: number;
+  delay?: number;
+  easing?: AnimationEasing;
+  spring?: SpringConfig;
+};
+
+const ExitingAnimationSchema = z.object({
+  preset: ExitingPresetSchema,
+  duration: z.number().min(0).optional(),
+  delay: z.number().min(0).optional(),
+  easing: AnimationEasingSchema.optional(),
+  spring: SpringConfigSchema.optional(),
+});
+
+export type LayoutAnimation = {
+  preset: LayoutPreset;
+  duration?: number;
+  spring?: SpringConfig;
+};
+
+const LayoutAnimationSchema = z.object({
+  preset: LayoutPresetSchema,
+  duration: z.number().min(0).optional(),
+  spring: SpringConfigSchema.optional(),
+});
+
+// Continuous looping effects — the one piece not named after a reanimated
+// builder. Rendered imperatively with `withRepeat` over `withTiming`.
+export type EffectPreset = "pulse" | "fade" | "rotate" | "shimmer" | "bounce";
+
+const EffectPresetSchema = z.enum(["pulse", "fade", "rotate", "shimmer", "bounce"]);
+
+export type ElementEffect = {
+  preset: EffectPreset;
+  duration?: number;
+  delay?: number;
+  easing?: AnimationEasing;
+  loop?: boolean;
+  /** pulse: scale bounds (default 0.95 / 1.05). */
+  minScale?: number;
+  maxScale?: number;
+  /** fade: lower opacity bound (default 0.4). */
+  minOpacity?: number;
+  /** rotate: sweep in degrees (default 360). */
+  degrees?: number;
+};
+
+const EffectSchema = z.object({
+  preset: EffectPresetSchema,
+  duration: z.number().min(0).optional(),
+  delay: z.number().min(0).optional(),
+  easing: AnimationEasingSchema.optional(),
+  loop: z.boolean().optional(),
+  minScale: z.number().positive().optional(),
+  maxScale: z.number().positive().optional(),
+  minOpacity: z.number().min(0).max(1).optional(),
+  degrees: z.number().optional(),
+});
+
+export type ElementAnimation = {
+  entering?: EnteringAnimation;
+  exiting?: ExitingAnimation;
+  layout?: LayoutAnimation;
+  effect?: ElementEffect;
+};
+
+const ElementAnimationSchema = z.object({
+  entering: EnteringAnimationSchema.optional(),
+  exiting: ExitingAnimationSchema.optional(),
+  layout: LayoutAnimationSchema.optional(),
+  effect: EffectSchema.optional(),
+});
+
+// Static transform surface — also what `effect` animates at runtime.
+export type ElementTransform = {
+  translateX?: number;
+  translateY?: number;
+  scale?: number;
+  scaleX?: number;
+  scaleY?: number;
+  /** degrees */
+  rotate?: number;
+};
+
+const TransformSchema = z.object({
+  translateX: z.number().optional(),
+  translateY: z.number().optional(),
+  scale: z.number().optional(),
+  scaleX: z.number().optional(),
+  scaleY: z.number().optional(),
+  rotate: z.number().optional(),
+});
+
 export type BaseBoxProps = {
   width?: number | string;
   height?: number | string;
@@ -80,6 +287,8 @@ export type BaseBoxProps = {
   shadowOpacity?: number;
   shadowRadius?: number;
   elevation?: number;
+  transform?: ElementTransform;
+  animation?: ElementAnimation;
 };
 
 export const BaseBoxPropsSchema = z.object({
@@ -112,4 +321,6 @@ export const BaseBoxPropsSchema = z.object({
   shadowOpacity: z.number().min(0).max(1).optional(),
   shadowRadius: z.number().min(0).optional(),
   elevation: z.number().min(0).optional(),
+  transform: TransformSchema.optional(),
+  animation: ElementAnimationSchema.optional(),
 });

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/ProgressIndicatorElement.tsx
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/ProgressIndicatorElement.tsx
@@ -10,13 +10,13 @@ import Animated, {
   withRepeat,
   withDelay,
   runOnJS,
-  Easing,
   cancelAnimation,
 } from "react-native-reanimated";
 import Svg, { Circle } from "react-native-svg";
 import { BaseBoxProps, BaseBoxPropsSchema } from "./BaseBoxProps";
 import { UIElement } from "../types";
 import { RenderContext, dim } from "./shared";
+import { EASING_MAP } from "./buildAnimation";
 
 export type ProgressEasing = "linear" | "ease-in" | "ease-out" | "ease-in-out";
 
@@ -59,14 +59,6 @@ export const ProgressIndicatorElementPropsSchema = BaseBoxPropsSchema.extend({
 });
 
 const AnimatedCircle = Animated.createAnimatedComponent(Circle);
-
-// CSS-style cubic-bezier curves matching the selectable easing names.
-const EASING_MAP: Record<ProgressEasing, ReturnType<typeof Easing.bezier> | typeof Easing.linear> = {
-  linear: Easing.linear,
-  "ease-in": Easing.bezier(0.42, 0, 1, 1),
-  "ease-out": Easing.bezier(0, 0, 0.58, 1),
-  "ease-in-out": Easing.bezier(0.42, 0, 0.58, 1),
-};
 
 const clamp = (n: number): number => Math.max(0, Math.min(100, n));
 

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/TextElement.tsx
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/TextElement.tsx
@@ -14,12 +14,18 @@ export type TextSpan = {
   fontFamily?: string | "inherit";
   fontSize?: number;
   letterSpacing?: number;
+  lineHeight?: number;
   color?: string;
+  backgroundColor?: string;
+  opacity?: number;
+  textTransform?: "none" | "uppercase" | "lowercase" | "capitalize";
   textDecorationLine?:
     | "none"
     | "underline"
     | "line-through"
     | "underline line-through";
+  textDecorationColor?: string;
+  textDecorationStyle?: "solid" | "double" | "dotted" | "dashed";
 };
 
 export const TextSpanSchema = z.object({
@@ -29,10 +35,16 @@ export const TextSpanSchema = z.object({
   fontFamily: z.string().optional(),
   fontSize: z.number().optional(),
   letterSpacing: z.number().optional(),
+  lineHeight: z.number().optional(),
   color: z.string().optional(),
+  backgroundColor: z.string().optional(),
+  opacity: z.number().min(0).max(1).optional(),
+  textTransform: z.enum(["none", "uppercase", "lowercase", "capitalize"]).optional(),
   textDecorationLine: z
     .enum(["none", "underline", "line-through", "underline line-through"])
     .optional(),
+  textDecorationColor: z.string().optional(),
+  textDecorationStyle: z.enum(["solid", "double", "dotted", "dashed"]).optional(),
 });
 
 export type TextElementProps = BaseBoxProps & {
@@ -86,8 +98,14 @@ const RichTextSpan = ({
         fontStyle: span.fontStyle,
         fontSize: span.fontSize,
         letterSpacing: span.letterSpacing,
+        lineHeight: span.lineHeight,
         color: span.color,
+        backgroundColor: span.backgroundColor,
+        opacity: span.opacity,
+        textTransform: span.textTransform,
         textDecorationLine: span.textDecorationLine,
+        textDecorationColor: span.textDecorationColor,
+        textDecorationStyle: span.textDecorationStyle,
       }}
     >
       {span.text}

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/buildAnimation.ts
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/buildAnimation.ts
@@ -1,0 +1,83 @@
+import * as Reanimated from "react-native-reanimated";
+import { Easing } from "react-native-reanimated";
+import type {
+  AnimationEasing,
+  EnteringAnimation,
+  ExitingAnimation,
+  LayoutAnimation,
+} from "@rocapine/react-native-onboarding";
+
+// CSS-style cubic-bezier curves matching the selectable easing names. Shared by
+// the animation builders here and by ProgressIndicatorElement (single source).
+export const EASING_MAP: Record<
+  AnimationEasing,
+  ReturnType<typeof Easing.bezier> | typeof Easing.linear
+> = {
+  linear: Easing.linear,
+  "ease-in": Easing.bezier(0.42, 0, 1, 1),
+  "ease-out": Easing.bezier(0, 0, 0.58, 1),
+  "ease-in-out": Easing.bezier(0.42, 0, 0.58, 1),
+};
+
+// Reanimated builders are exported by name off the namespace. Looking them up by
+// the schema's `preset` string is what keeps the JSON 1:1 with reanimated — the
+// preset value *is* the builder name. Unknown/typo presets degrade to `undefined`
+// (no animation) instead of crashing, so a payload referencing a preset the host's
+// installed reanimated version lacks still mounts.
+type AnyBuilder = any;
+
+const resolveBuilder = (preset: string): AnyBuilder | undefined => {
+  const b = (Reanimated as unknown as Record<string, AnyBuilder>)[preset];
+  return b ?? undefined;
+};
+
+const applySpringOrEasing = (
+  builder: AnyBuilder,
+  spring?: { damping?: number; stiffness?: number; mass?: number },
+  easing?: AnimationEasing
+): AnyBuilder => {
+  // reanimated: `spring` (`.springify()`) and `.easing()` are mutually exclusive.
+  // Spring wins, matching the schema contract.
+  if (spring) {
+    let b = builder.springify();
+    if (spring.damping != null) b = b.damping(spring.damping);
+    if (spring.stiffness != null) b = b.stiffness(spring.stiffness);
+    if (spring.mass != null) b = b.mass(spring.mass);
+    return b;
+  }
+  if (easing) return builder.easing(EASING_MAP[easing]);
+  return builder;
+};
+
+const buildTransition = (
+  cfg: EnteringAnimation | ExitingAnimation | undefined
+): AnyBuilder | undefined => {
+  if (!cfg) return undefined;
+  let b = resolveBuilder(cfg.preset);
+  if (!b) return undefined;
+  if (cfg.duration != null) b = b.duration(cfg.duration);
+  if (cfg.delay != null) b = b.delay(cfg.delay);
+  return applySpringOrEasing(b, cfg.spring, cfg.easing);
+};
+
+export const buildEntering = (cfg: EnteringAnimation | undefined): AnyBuilder | undefined =>
+  buildTransition(cfg);
+
+export const buildExiting = (cfg: ExitingAnimation | undefined): AnyBuilder | undefined =>
+  buildTransition(cfg);
+
+export const buildLayout = (cfg: LayoutAnimation | undefined): AnyBuilder | undefined => {
+  if (!cfg) return undefined;
+  let b = resolveBuilder(cfg.preset);
+  if (!b) return undefined;
+  // Layout transitions are referenced as static builder objects; calling a
+  // modifier returns a configured instance.
+  if (cfg.duration != null) b = b.duration(cfg.duration);
+  if (cfg.spring) {
+    b = b.springify();
+    if (cfg.spring.damping != null) b = b.damping(cfg.spring.damping);
+    if (cfg.spring.stiffness != null) b = b.stiffness(cfg.spring.stiffness);
+    if (cfg.spring.mass != null) b = b.mass(cfg.spring.mass);
+  }
+  return b;
+};

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/renderElement.tsx
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/renderElement.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { evaluateCondition } from "@rocapine/react-native-onboarding";
 import { UIElement } from "../types";
+import { BaseBoxProps } from "./BaseBoxProps";
 import { RenderContext } from "./shared";
 import { StackElementComponent } from "./StackElement";
 import { TextElementComponent } from "./TextElement";
@@ -21,6 +22,7 @@ import { SafeAreaViewElementComponent } from "./SafeAreaViewElement";
 import { ScrollViewElementComponent } from "./ScrollViewElement";
 import { KeyboardAvoidingViewElementComponent } from "./KeyboardAvoidingViewElement";
 import { ProgressIndicatorElementComponent } from "./ProgressIndicatorElement";
+import { AnimatedBox } from "./AnimatedBox";
 
 export const renderElement = (
   element: UIElement,
@@ -34,6 +36,9 @@ export const renderElement = (
     if (!evaluateCondition(element.renderWhen, flatVars)) return null;
   }
 
+  // Dispatch to the concrete element renderer. Captured into `node` so a single
+  // AnimatedBox wrapper can apply animation/transform to any of the 15 types.
+  const node = ((): React.ReactNode => {
   if (element.type === "YStack" || element.type === "XStack") {
     return <StackElementComponent key={element.id} element={element} ctx={ctx} parentType={parentType} />;
   }
@@ -110,5 +115,27 @@ export const renderElement = (
     return <ProgressIndicatorElementComponent key={element.id} element={element} ctx={ctx} />;
   }
 
-  return null;
+    return null;
+  })();
+
+  // Wrap only when motion is requested — zero overhead (no extra view) otherwise.
+  // Cast to BaseBoxProps: not every element's props type extends it (e.g.
+  // WheelPicker), but the animation/transform/flex/alignSelf fields are all
+  // optional BaseBoxProps members and simply read as undefined when absent.
+  const p = element.props as BaseBoxProps;
+  if (node !== null && (p.animation || p.transform)) {
+    return (
+      <AnimatedBox
+        key={element.id}
+        animation={p.animation}
+        transform={p.transform}
+        flex={p.flex}
+        alignSelf={p.alignSelf}
+      >
+        {node}
+      </AnimatedBox>
+    );
+  }
+
+  return node;
 };

--- a/packages/onboarding/CHANGELOG.md
+++ b/packages/onboarding/CHANGELOG.md
@@ -8,6 +8,19 @@ All notable changes to `@rocapine/react-native-onboarding` are documented here.
 
 ---
 
+## [1.32.0] - 2026-06-01
+
+### Added
+- **Animations / transitions / effects on every UIElement** — `BaseBoxProps` gains two optional fields, so any ComposableScreen element can declare motion. Schema mirrors `react-native-reanimated`: `preset` values are the **exact reanimated builder names** and modifier fields map to builder methods.
+  - **`transform`** (static): `{ translateX?, translateY?, scale?, scaleX?, scaleY?, rotate? (deg) }`.
+  - **`animation`**: `{ entering?, exiting?, layout?, effect? }`.
+    - `entering` / `exiting`: `{ preset, duration?, delay?, easing?, spring? }`. Entering presets: `FadeIn(Up/Down/Left/Right)`, `SlideIn(Up/Down/Left/Right)`, `ZoomIn(Rotate/Up/Down/Left/Right/EasyUp/EasyDown)`, `BounceIn(Up/Down/Left/Right)`, `FlipIn(XUp/YLeft/XDown/YRight/EasyX/EasyY)`, `StretchIn(X/Y)`, `RotateIn(DownLeft/DownRight/UpLeft/UpRight)`, `RollIn(Left/Right)`, `PinwheelIn`, `LightSpeedIn(Left/Right)`; exiting presets are the matching `…Out…` names.
+    - `layout`: `{ preset, duration?, spring? }` — `LinearTransition`, `FadingTransition`, `SequencedTransition`, `JumpingTransition`, `CurvedTransition`, `EntryExitTransition`.
+    - `effect` (continuous loop, not a reanimated builder name): `{ preset: "pulse" | "fade" | "rotate" | "shimmer" | "bounce", duration?, delay?, easing?, loop?, minScale?/maxScale? (pulse), minOpacity? (fade), degrees? (rotate) }`.
+  - `easing` (`"linear"` | `"ease-in"` | `"ease-out"` | `"ease-in-out"`) and `spring` (`{ damping?, stiffness?, mass? }`, mirrors `.springify(config)` and wins over `easing`). New exported types: `AnimationEasing`, `SpringConfig`, `EnteringPreset`, `ExitingPreset`, `LayoutPreset`, `EffectPreset`, `EnteringAnimation`, `ExitingAnimation`, `LayoutAnimation`, `ElementEffect`, `ElementAnimation`, `ElementTransform`.
+
+---
+
 ## [1.31.0] - 2026-06-01
 
 ### Added

--- a/packages/onboarding/CHANGELOG.md
+++ b/packages/onboarding/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to `@rocapine/react-native-onboarding` are documented here.
     - `layout`: `{ preset, duration?, spring? }` — `LinearTransition`, `FadingTransition`, `SequencedTransition`, `JumpingTransition`, `CurvedTransition`, `EntryExitTransition`.
     - `effect` (continuous loop, not a reanimated builder name): `{ preset: "pulse" | "fade" | "rotate" | "shimmer" | "bounce", duration?, delay?, easing?, loop?, minScale?/maxScale? (pulse), minOpacity? (fade), degrees? (rotate) }`.
   - `easing` (`"linear"` | `"ease-in"` | `"ease-out"` | `"ease-in-out"`) and `spring` (`{ damping?, stiffness?, mass? }`, mirrors `.springify(config)` and wins over `easing`). New exported types: `AnimationEasing`, `SpringConfig`, `EnteringPreset`, `ExitingPreset`, `LayoutPreset`, `EffectPreset`, `EnteringAnimation`, `ExitingAnimation`, `LayoutAnimation`, `ElementEffect`, `ElementAnimation`, `ElementTransform`.
+- **`TextSpan` extended** — inline rich-text spans gain `backgroundColor`, `opacity` (0–1), `textTransform` (`"none"` | `"uppercase"` | `"lowercase"` | `"capitalize"`), `textDecorationColor`, `textDecorationStyle` (`"solid"` | `"double"` | `"dotted"` | `"dashed"`), and `lineHeight`. All optional, inline-safe (animation/transform remain element-level only — spans are not UIElements).
 
 ---
 

--- a/packages/onboarding/package.json
+++ b/packages/onboarding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocapine/react-native-onboarding",
-  "version": "1.31.0",
+  "version": "1.32.0",
   "description": "Headless React Native SDK for Rocapine Onboarding Studio - Data fetching, state management, and hooks",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/onboarding/src/index.ts
+++ b/packages/onboarding/src/index.ts
@@ -14,6 +14,18 @@ export type {
   WheelPickerRange,
   ProgressIndicatorElementProps,
   ProgressEasing,
+  AnimationEasing,
+  SpringConfig,
+  EnteringPreset,
+  ExitingPreset,
+  LayoutPreset,
+  EffectPreset,
+  EnteringAnimation,
+  ExitingAnimation,
+  LayoutAnimation,
+  ElementEffect,
+  ElementAnimation,
+  ElementTransform,
 } from "./steps/ComposableScreen/types";
 export {
   ButtonActionSchema,

--- a/packages/onboarding/src/onboarding-example.ts
+++ b/packages/onboarding/src/onboarding-example.ts
@@ -149,6 +149,10 @@ export const onboardingExample = {
                   height: 180,
                   resizeMode: "cover",
                   borderRadius: 16,
+                  // Slide + fade in on mount (reanimated builder name + modifiers).
+                  animation: {
+                    entering: { preset: "FadeInDown", duration: 500, delay: 100, easing: "ease-out" },
+                  },
                 },
               },
               {
@@ -161,6 +165,12 @@ export const onboardingExample = {
                   fill: "#007AFF",
                   fillOpacity: 0.2,
                   marginVertical: 8,
+                  // Static tilt + continuous breathing pulse.
+                  transform: { rotate: -8 },
+                  animation: {
+                    entering: { preset: "ZoomIn", duration: 400, spring: { damping: 10, stiffness: 160 } },
+                    effect: { preset: "pulse", duration: 1200, minScale: 0.92, maxScale: 1.08 },
+                  },
                 },
               },
               {

--- a/packages/onboarding/src/steps/ComposableScreen/elements/BaseBoxProps.ts
+++ b/packages/onboarding/src/steps/ComposableScreen/elements/BaseBoxProps.ts
@@ -50,6 +50,213 @@ export const ShadowOffsetSchema = z.object({
   height: z.number(),
 });
 
+// ---------------------------------------------------------------------------
+// Animation / Transform surface
+//
+// Schema stays intentionally close to react-native-reanimated: `preset` values
+// are the *exact* reanimated builder names (e.g. `FadeInDown`, `SlideOutLeft`,
+// `LinearTransition`), so the UI renderer resolves them by direct namespace
+// lookup (`Reanimated[preset]`) rather than a translation table. Modifier fields
+// (`duration`/`delay`/`spring`/`easing`) map to reanimated builder methods
+// (`.duration().delay().springify().easing()`).
+// ---------------------------------------------------------------------------
+
+// Reuses the easing-name convention from ProgressIndicatorElement.
+export type AnimationEasing = "linear" | "ease-in" | "ease-out" | "ease-in-out";
+
+const AnimationEasingSchema = z.enum(["linear", "ease-in", "ease-out", "ease-in-out"]);
+
+// Mirrors reanimated's `.springify(config)` — only the fields it accepts.
+// When `spring` is present it wins over `easing` (matches reanimated semantics).
+export type SpringConfig = {
+  damping?: number;
+  stiffness?: number;
+  mass?: number;
+};
+
+const SpringConfigSchema = z.object({
+  damping: z.number().positive().optional(),
+  stiffness: z.number().positive().optional(),
+  mass: z.number().positive().optional(),
+});
+
+// Exact reanimated entering builder names.
+export type EnteringPreset =
+  | "FadeIn" | "FadeInUp" | "FadeInDown" | "FadeInLeft" | "FadeInRight"
+  | "SlideInUp" | "SlideInDown" | "SlideInLeft" | "SlideInRight"
+  | "ZoomIn" | "ZoomInRotate" | "ZoomInUp" | "ZoomInDown" | "ZoomInLeft" | "ZoomInRight"
+  | "ZoomInEasyUp" | "ZoomInEasyDown"
+  | "BounceIn" | "BounceInUp" | "BounceInDown" | "BounceInLeft" | "BounceInRight"
+  | "FlipInXUp" | "FlipInYLeft" | "FlipInXDown" | "FlipInYRight" | "FlipInEasyX" | "FlipInEasyY"
+  | "StretchInX" | "StretchInY"
+  | "RotateInDownLeft" | "RotateInDownRight" | "RotateInUpLeft" | "RotateInUpRight"
+  | "RollInLeft" | "RollInRight"
+  | "PinwheelIn"
+  | "LightSpeedInLeft" | "LightSpeedInRight";
+
+const EnteringPresetSchema = z.enum([
+  "FadeIn", "FadeInUp", "FadeInDown", "FadeInLeft", "FadeInRight",
+  "SlideInUp", "SlideInDown", "SlideInLeft", "SlideInRight",
+  "ZoomIn", "ZoomInRotate", "ZoomInUp", "ZoomInDown", "ZoomInLeft", "ZoomInRight",
+  "ZoomInEasyUp", "ZoomInEasyDown",
+  "BounceIn", "BounceInUp", "BounceInDown", "BounceInLeft", "BounceInRight",
+  "FlipInXUp", "FlipInYLeft", "FlipInXDown", "FlipInYRight", "FlipInEasyX", "FlipInEasyY",
+  "StretchInX", "StretchInY",
+  "RotateInDownLeft", "RotateInDownRight", "RotateInUpLeft", "RotateInUpRight",
+  "RollInLeft", "RollInRight",
+  "PinwheelIn",
+  "LightSpeedInLeft", "LightSpeedInRight",
+]);
+
+// Exact reanimated exiting builder names.
+export type ExitingPreset =
+  | "FadeOut" | "FadeOutUp" | "FadeOutDown" | "FadeOutLeft" | "FadeOutRight"
+  | "SlideOutUp" | "SlideOutDown" | "SlideOutLeft" | "SlideOutRight"
+  | "ZoomOut" | "ZoomOutRotate" | "ZoomOutUp" | "ZoomOutDown" | "ZoomOutLeft" | "ZoomOutRight"
+  | "ZoomOutEasyUp" | "ZoomOutEasyDown"
+  | "BounceOut" | "BounceOutUp" | "BounceOutDown" | "BounceOutLeft" | "BounceOutRight"
+  | "FlipOutXUp" | "FlipOutYLeft" | "FlipOutXDown" | "FlipOutYRight" | "FlipOutEasyX" | "FlipOutEasyY"
+  | "StretchOutX" | "StretchOutY"
+  | "RotateOutDownLeft" | "RotateOutDownRight" | "RotateOutUpLeft" | "RotateOutUpRight"
+  | "RollOutLeft" | "RollOutRight"
+  | "PinwheelOut"
+  | "LightSpeedOutLeft" | "LightSpeedOutRight";
+
+const ExitingPresetSchema = z.enum([
+  "FadeOut", "FadeOutUp", "FadeOutDown", "FadeOutLeft", "FadeOutRight",
+  "SlideOutUp", "SlideOutDown", "SlideOutLeft", "SlideOutRight",
+  "ZoomOut", "ZoomOutRotate", "ZoomOutUp", "ZoomOutDown", "ZoomOutLeft", "ZoomOutRight",
+  "ZoomOutEasyUp", "ZoomOutEasyDown",
+  "BounceOut", "BounceOutUp", "BounceOutDown", "BounceOutLeft", "BounceOutRight",
+  "FlipOutXUp", "FlipOutYLeft", "FlipOutXDown", "FlipOutYRight", "FlipOutEasyX", "FlipOutEasyY",
+  "StretchOutX", "StretchOutY",
+  "RotateOutDownLeft", "RotateOutDownRight", "RotateOutUpLeft", "RotateOutUpRight",
+  "RollOutLeft", "RollOutRight",
+  "PinwheelOut",
+  "LightSpeedOutLeft", "LightSpeedOutRight",
+]);
+
+// Exact reanimated layout-transition builder names.
+export type LayoutPreset =
+  | "LinearTransition" | "FadingTransition" | "SequencedTransition"
+  | "JumpingTransition" | "CurvedTransition" | "EntryExitTransition";
+
+const LayoutPresetSchema = z.enum([
+  "LinearTransition", "FadingTransition", "SequencedTransition",
+  "JumpingTransition", "CurvedTransition", "EntryExitTransition",
+]);
+
+export type EnteringAnimation = {
+  preset: EnteringPreset;
+  duration?: number;
+  delay?: number;
+  easing?: AnimationEasing;
+  spring?: SpringConfig;
+};
+
+const EnteringAnimationSchema = z.object({
+  preset: EnteringPresetSchema,
+  duration: z.number().min(0).optional(),
+  delay: z.number().min(0).optional(),
+  easing: AnimationEasingSchema.optional(),
+  spring: SpringConfigSchema.optional(),
+});
+
+export type ExitingAnimation = {
+  preset: ExitingPreset;
+  duration?: number;
+  delay?: number;
+  easing?: AnimationEasing;
+  spring?: SpringConfig;
+};
+
+const ExitingAnimationSchema = z.object({
+  preset: ExitingPresetSchema,
+  duration: z.number().min(0).optional(),
+  delay: z.number().min(0).optional(),
+  easing: AnimationEasingSchema.optional(),
+  spring: SpringConfigSchema.optional(),
+});
+
+export type LayoutAnimation = {
+  preset: LayoutPreset;
+  duration?: number;
+  spring?: SpringConfig;
+};
+
+const LayoutAnimationSchema = z.object({
+  preset: LayoutPresetSchema,
+  duration: z.number().min(0).optional(),
+  spring: SpringConfigSchema.optional(),
+});
+
+// Continuous looping effects — the one piece not named after a reanimated
+// builder. Rendered imperatively with `withRepeat` over `withTiming`.
+export type EffectPreset = "pulse" | "fade" | "rotate" | "shimmer" | "bounce";
+
+const EffectPresetSchema = z.enum(["pulse", "fade", "rotate", "shimmer", "bounce"]);
+
+export type ElementEffect = {
+  preset: EffectPreset;
+  duration?: number;
+  delay?: number;
+  easing?: AnimationEasing;
+  loop?: boolean;
+  /** pulse: scale bounds (default 0.95 / 1.05). */
+  minScale?: number;
+  maxScale?: number;
+  /** fade: lower opacity bound (default 0.4). */
+  minOpacity?: number;
+  /** rotate: sweep in degrees (default 360). */
+  degrees?: number;
+};
+
+const EffectSchema = z.object({
+  preset: EffectPresetSchema,
+  duration: z.number().min(0).optional(),
+  delay: z.number().min(0).optional(),
+  easing: AnimationEasingSchema.optional(),
+  loop: z.boolean().optional(),
+  minScale: z.number().positive().optional(),
+  maxScale: z.number().positive().optional(),
+  minOpacity: z.number().min(0).max(1).optional(),
+  degrees: z.number().optional(),
+});
+
+export type ElementAnimation = {
+  entering?: EnteringAnimation;
+  exiting?: ExitingAnimation;
+  layout?: LayoutAnimation;
+  effect?: ElementEffect;
+};
+
+const ElementAnimationSchema = z.object({
+  entering: EnteringAnimationSchema.optional(),
+  exiting: ExitingAnimationSchema.optional(),
+  layout: LayoutAnimationSchema.optional(),
+  effect: EffectSchema.optional(),
+});
+
+// Static transform surface — also what `effect` animates at runtime.
+export type ElementTransform = {
+  translateX?: number;
+  translateY?: number;
+  scale?: number;
+  scaleX?: number;
+  scaleY?: number;
+  /** degrees */
+  rotate?: number;
+};
+
+const TransformSchema = z.object({
+  translateX: z.number().optional(),
+  translateY: z.number().optional(),
+  scale: z.number().optional(),
+  scaleX: z.number().optional(),
+  scaleY: z.number().optional(),
+  rotate: z.number().optional(),
+});
+
 export type BaseBoxProps = {
   width?: number | string;
   height?: number | string;
@@ -80,6 +287,8 @@ export type BaseBoxProps = {
   shadowOpacity?: number;
   shadowRadius?: number;
   elevation?: number;
+  transform?: ElementTransform;
+  animation?: ElementAnimation;
 };
 
 export const BaseBoxPropsSchema = z.object({
@@ -112,4 +321,6 @@ export const BaseBoxPropsSchema = z.object({
   shadowOpacity: z.number().min(0).max(1).optional(),
   shadowRadius: z.number().min(0).optional(),
   elevation: z.number().min(0).optional(),
+  transform: TransformSchema.optional(),
+  animation: ElementAnimationSchema.optional(),
 });

--- a/packages/onboarding/src/steps/ComposableScreen/elements/TextElement.ts
+++ b/packages/onboarding/src/steps/ComposableScreen/elements/TextElement.ts
@@ -18,12 +18,20 @@ export type TextSpan = {
   fontFamily?: string | "inherit";
   fontSize?: number;
   letterSpacing?: number;
+  lineHeight?: number;
   color?: string;
+  /** Inline highlight behind the span text. */
+  backgroundColor?: string;
+  /** Per-span opacity (0–1). */
+  opacity?: number;
+  textTransform?: "none" | "uppercase" | "lowercase" | "capitalize";
   textDecorationLine?:
     | "none"
     | "underline"
     | "line-through"
     | "underline line-through";
+  textDecorationColor?: string;
+  textDecorationStyle?: "solid" | "double" | "dotted" | "dashed";
 };
 
 export const TextSpanSchema = z.object({
@@ -33,10 +41,16 @@ export const TextSpanSchema = z.object({
   fontFamily: z.string().optional(),
   fontSize: z.number().optional(),
   letterSpacing: z.number().optional(),
+  lineHeight: z.number().optional(),
   color: z.string().optional(),
+  backgroundColor: z.string().optional(),
+  opacity: z.number().min(0).max(1).optional(),
+  textTransform: z.enum(["none", "uppercase", "lowercase", "capitalize"]).optional(),
   textDecorationLine: z
     .enum(["none", "underline", "line-through", "underline line-through"])
     .optional(),
+  textDecorationColor: z.string().optional(),
+  textDecorationStyle: z.enum(["solid", "double", "dotted", "dashed"]).optional(),
 });
 
 export type TextElementProps = BaseBoxProps & {

--- a/packages/onboarding/src/steps/ComposableScreen/types.ts
+++ b/packages/onboarding/src/steps/ComposableScreen/types.ts
@@ -30,6 +30,20 @@ import {
 import { type ProgressIndicatorElementProps, ProgressIndicatorElementPropsSchema } from "./elements/ProgressIndicatorElement";
 
 export type { BaseBoxProps, GradientBackground, GradientEdge, GradientStop, LinearGradientConfig } from "./elements/BaseBoxProps";
+export type {
+  AnimationEasing,
+  SpringConfig,
+  EnteringPreset,
+  ExitingPreset,
+  LayoutPreset,
+  EffectPreset,
+  EnteringAnimation,
+  ExitingAnimation,
+  LayoutAnimation,
+  ElementEffect,
+  ElementAnimation,
+  ElementTransform,
+} from "./elements/BaseBoxProps";
 export { BaseBoxPropsSchema, GradientBackgroundSchema } from "./elements/BaseBoxProps";
 export type { StackElementProps } from "./elements/StackElement";
 export type { TextElementProps, TextSpan } from "./elements/TextElement";

--- a/website/docs/page-types.mdx
+++ b/website/docs/page-types.mdx
@@ -436,6 +436,51 @@ Build arbitrary onboarding screens entirely from CMS data — no custom renderer
 | `Rive` | `<Rive>` | — | `rive-react-native` |
 | `Video` | `<VideoView>` | — | `expo-video` |
 
+#### Animations, transitions & effects (every element)
+
+Every UIElement inherits an optional `transform` and `animation` from `BaseBoxProps`, so motion can be attached to any element type. The schema mirrors [react-native-reanimated](https://docs.swmansion.com/react-native-reanimated/) — `preset` values are the **exact reanimated builder names** and the modifier fields map to builder methods (`.duration().delay().springify().easing()`). `react-native-reanimated` `>=3` is a peer dependency (already required for `Carousel` / `ProgressIndicator`); no extra install.
+
+**`transform`** — static, also the surface `effect` animates:
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `translateX` / `translateY` | `number` | px offset |
+| `scale` / `scaleX` / `scaleY` | `number` | |
+| `rotate` | `number` | degrees |
+
+**`animation`** — `{ entering?, exiting?, layout?, effect? }`:
+
+| Sub-field | Shape | Notes |
+|-----------|-------|-------|
+| `entering` | `{ preset, duration?, delay?, easing?, spring? }` | Plays once on mount |
+| `exiting` | `{ preset, duration?, delay?, easing?, spring? }` | Plays on unmount (e.g. when `renderWhen` flips false) |
+| `layout` | `{ preset, duration?, spring? }` | Animates re-layout when siblings appear/disappear |
+| `effect` | `{ preset, duration?, delay?, easing?, loop?, … }` | Continuous loop (`withRepeat`) |
+
+- `easing`: `"linear" \| "ease-in" \| "ease-out" \| "ease-in-out"`. `spring` (`{ damping?, stiffness?, mass? }`) mirrors `.springify(config)` and **wins over** `easing` when both are set.
+- **Entering presets** (reanimated builder names): `FadeIn(Up/Down/Left/Right)`, `SlideIn(Up/Down/Left/Right)`, `ZoomIn(Rotate/Up/Down/Left/Right/EasyUp/EasyDown)`, `BounceIn(Up/Down/Left/Right)`, `FlipIn(XUp/YLeft/XDown/YRight/EasyX/EasyY)`, `StretchIn(X/Y)`, `RotateIn(DownLeft/DownRight/UpLeft/UpRight)`, `RollIn(Left/Right)`, `PinwheelIn`, `LightSpeedIn(Left/Right)`.
+- **Exiting presets**: the `…Out…` counterparts of the above.
+- **Layout presets**: `LinearTransition`, `FadingTransition`, `SequencedTransition`, `JumpingTransition`, `CurvedTransition`, `EntryExitTransition`.
+- **Effect presets** (looping, not reanimated-named): `pulse` (`minScale`/`maxScale`), `fade` (`minOpacity`), `rotate` (`degrees`), `shimmer`, `bounce`. `loop: false` runs the effect once.
+- Unknown presets degrade to no-op (forward-compatible across reanimated versions). On web some entering presets degrade gracefully (content still mounts).
+
+```json
+{
+  "id": "hero-badge",
+  "type": "Image",
+  "props": {
+    "url": "https://cdn.example.com/badge.png",
+    "width": 96,
+    "transform": { "rotate": -4 },
+    "animation": {
+      "entering": { "preset": "ZoomInDown", "duration": 600, "delay": 200, "spring": { "damping": 12, "stiffness": 180 } },
+      "exiting": { "preset": "FadeOut", "duration": 250 },
+      "effect": { "preset": "pulse", "duration": 1200, "minScale": 0.97, "maxScale": 1.06 }
+    }
+  }
+}
+```
+
 **Stack props (`YStack` / `XStack`):**
 
 | Prop | Type | Notes |


### PR DESCRIPTION
## Summary

Adds a **react-native-reanimated-aligned** motion surface to every ComposableScreen UIElement, and extends rich-text `TextSpan` with more inline styles. Bumps both SDK packages to **v1.32.0**.

### Animations / transitions / effects (every element)
New optional fields on `BaseBoxProps` (so all 15 element types inherit them):
- **`transform`** (static): `translateX/Y`, `scale/X/Y`, `rotate` (deg).
- **`animation`**: `{ entering, exiting, layout, effect }`.
  - `entering`/`exiting`: `{ preset, duration?, delay?, easing?, spring? }` — `preset` is the **exact reanimated builder name** (`FadeInDown`, `SlideOutLeft`, …).
  - `layout`: `LinearTransition`, `CurvedTransition`, … (`{ preset, duration?, spring? }`).
  - `effect`: looping `pulse`/`fade`/`rotate`/`shimmer`/`bounce` (`withRepeat`).
  - `easing` enum + `spring` (`.springify()`, wins over easing).

**Render:** a single `AnimatedBox` wrapper injected at the `renderElement` dispatch boundary applies motion to any element (zero extra view when unused), forwarding `flex`/`alignSelf` to stay layout-transparent. `buildAnimation.ts` resolves builders by name (`Reanimated[preset]`); unknown preset → no-op (forward-compat). No new peer deps — reuses the existing reanimated stack. Shared `EASING_MAP` extracted from `ProgressIndicator`.

### TextSpan extended
Inline-safe additions: `backgroundColor`, `opacity`, `textTransform`, `textDecorationColor`, `textDecorationStyle`, `lineHeight`. (Animation/transform stay element-level — spans aren't UIElements.)

### Also
- New `composable-screen-animations` example screen (entering presets staggered by `delay`, spring vs easing, effects, transforms, exiting+layout toggle, Replay button).
- Docs: website `page-types.mdx` + 4 skill mirrors + `composable-screen-runtime.md` rules.
- Both CHANGELOGs updated.

## Verification
- `npm run build` clean (both packages)
- `npm test --workspace=packages/onboarding` — 95/95 pass
- Schema validates the worked-example payload + default onboarding; rejects unknown presets
- Example `tsc --noEmit` clean

## Follow-up
Mirror the schema in **onboarding-studio** (animation/transform on BaseBoxProps + extended TextSpan) — mirror prompt provided in the implementing session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)