### PR TITLE
📝 Encode beautiful-onboarding patterns from production reference into plugin skills

### DIFF
--- a/claude-plugin/skills/compose-screen-builder/SKILL.md
+++ b/claude-plugin/skills/compose-screen-builder/SKILL.md
@@ -26,6 +26,8 @@ Inject every value into every element you emit. Never:
 
 Start from an archetype in `../create-step-json/references/composable-archetypes.md`. Customize from there. Don't compose from scratch unless the screen is genuinely novel.
 
+Then apply the polish layer from `../create-step-json/references/screen-patterns.md` — universal skeleton + canonical CTA, select-and-advance questions, carousel state machines, staggered-entrance choreography, self-completing loaders, social-proof layering, permission screens, ghost opt-outs. Archetypes are the skeleton; screen-patterns is what makes the screen feel hand-built.
+
 ### 3. Compose the tree
 
 ## Element types
@@ -148,7 +150,7 @@ Reference variables from `Text` ONLY when `Text.props.mode === "expression"`. Th
 - `{ "type": "custom", "function": "name", "variables": ["a","b"] }` — emit to host. Host wires the implementation.
 - `{ "type": "setVariable", "name": "counter", "value": "{{counter}} + 1", "valueMode": "expression" }` — write a variable. `valueMode: "expression"` triggers interpolation + numeric coercion based on the variable's runtime `kind`.
 
-Note: the headless Zod schema currently only enumerates `"continue" | CustomButtonAction`. The UI mirror re-declares the schema and supports `setVariable`. If Studio validates strictly against headless, prefer `custom` actions for non-continue behavior — see `packages/onboarding/src/onboarding-example.ts` for the patterns that ship.
+The headless Zod schema enumerates all three: `"continue" | CustomButtonAction | SetVariableButtonAction` (`ButtonElement.ts`). `setVariable` also accepts `kind: "int" | "float" | "string"` to tag the stored variable's type — set it when the value feeds numeric expressions or comparisons.
 
 ## Disabling continue conditionally
 
@@ -254,3 +256,5 @@ Each override is a `Partial` of the overridable Button props: `BaseBoxProps` (in
 - Don't put `Carousel` inside vertical-scrolling container without explicit `height`.
 - Don't invent brand colors when probe data exists.
 - Don't reach for hex when a theme token applies.
+- Don't use `RadioGroup` for a single-select that should advance on tap — use select-and-advance Button rows (`[{setVariable}, "continue"]` + `pressedStyle` previewing the selected state; `screen-patterns.md` §2). RadioGroup is for review-before-advance steps.
+- Don't show a Rive/Lottie hero with all text + CTA visible at once — stagger their `FadeIn` entrances behind the media's runtime (`screen-patterns.md` §4).

--- a/claude-plugin/skills/create-step-json/SKILL.md
+++ b/claude-plugin/skills/create-step-json/SKILL.md
@@ -37,11 +37,12 @@ Pick from `references/composable-archetypes.md`:
 | Numeric picker (age, weight, height) | `picker` |
 | Reflection / personalized message | `reflection` |
 | Social proof | `social-proof` |
-| Loader / "building your plan" | `loader` |
+| Loader / "building your plan" | `loader` (self-completing — chained `ProgressIndicator`s, no host timer) |
 | Commitment / signature | `commitment` |
+| Permission / integration ask (notifications, HealthKit, …) | `permission` |
 | Carousel intro | `carousel` |
 
-Each archetype is a ready ComposableScreen tree using only `BaseStepTypeSchema` + ComposableScreen UIElements. Customize tokens/copy from the app probe.
+Each archetype is a ready ComposableScreen tree using only `BaseStepTypeSchema` + ComposableScreen UIElements. Customize tokens/copy from the app probe. After picking the archetype, consult `references/screen-patterns.md` for production-grade composition (select-and-advance questions, motion choreography, loaders, social-proof layering, permission branches).
 
 ### 3. Generate the step
 
@@ -50,7 +51,7 @@ Always set:
 - `type: "ComposableScreen"`
 - `id` — the **step** id: kebab-case, matches target app convention (camelCase / kebab — match probe). Referenced by `nextStep` links, so keep it stable/readable. (Distinct from **element** ids inside `payload.elements`, which must be UUID v4 — see `payload` below.)
 - `name` — human-readable.
-- `displayProgressHeader` — `false` for hook/loader/commitment, `true` otherwise.
+- `displayProgressHeader` — `true` ONLY for data-collection screens (`question-*`, `input`, `picker`); `false` for narrative/value screens (`hero`, `carousel`, `reflection`, `social-proof`, `permission`, `loader`, `commitment`). Rule of thumb: progress bar shows while the user is actively answering, hidden during storytelling and permission moments.
 - `customPayload: null`
 - `continueButtonLabel` — pick verb from app's voice (probe). Note: in ComposableScreen this is usually unused since the CTA is its own `Button` element inside `payload.elements`.
 - `nextStep` — **always emit as an explicit multi-path link** when generating a flow of > 1 step. Default-link each step to the next via `{ defaultTargetStepId: "<next-step-id>", branches: [] }`. Only the terminal step (or a true single-step generation) gets `nextStep: null`. If a branching condition applies, add `branches: [{ condition, targetStepId }]` — first match wins, `defaultTargetStepId` is the fallback. **Do not rely on the null + array-order linear fallback for multi-step flows.** Explicit links survive reordering and make adding branches trivial. (`null` still resolves linearly at runtime — see `resolveNextStepNumber.test.ts` — but explicit multi-path is the convention.)

--- a/claude-plugin/skills/create-step-json/references/composable-archetypes.md
+++ b/claude-plugin/skills/create-step-json/references/composable-archetypes.md
@@ -6,6 +6,8 @@
 
 > **Design fidelity rule.** Every value below in `<DP.xxx>` placeholders comes from the Design Profile produced by `inspect-target-app.md`. Replace, don't ship with placeholders. Generic skeletons are a regression.
 
+> **Polish layer.** Archetypes below are skeletons. For production-grade composition — motion choreography, select-and-advance questions, self-completing loaders, social-proof layering, permission screens — see `screen-patterns.md` (same directory).
+
 Outer shape (always):
 
 ```json
@@ -44,10 +46,15 @@ CTA pattern (use every time — never bare `actions: ["continue"]` with no styli
     "fontSize": 17,
     "borderRadius": "<DP.buttonBorderRadius>",
     "paddingVertical": 16,
+    "haptic": "light",
+    "pressedStyle": { "opacity": 0.85 },
+    "disabledStyle": { "backgroundColor": "<DP.surface.raised>", "color": "<DP.text.muted>" },
     "actions": ["continue"]
   }
 }
 ```
+
+(`haptic` + `pressedStyle` on every CTA; `disabledStyle` only matters with a `disabledWhen`. Never the deprecated `disabledBackgroundColor`/`disabledColor`.)
 
 ### Adding motion to an element
 
@@ -95,7 +102,7 @@ Two ways to mix styles across fragments:
 
 ## hero
 
-Branded welcome. Hero media + tight value prop + primary CTA. No progress bar.
+Branded welcome. Hero media + tight value prop + primary CTA. No progress bar. When the hero is a Rive/Lottie, stagger the text + CTA entrances behind it (`screen-patterns.md` §4) instead of showing everything at once; decorative pill titles: §9.
 
 ```json
 [
@@ -113,13 +120,52 @@ Branded welcome. Hero media + tight value prop + primary CTA. No progress bar.
 
 ## question-single
 
-Title + helper + tappable cards (RadioGroup styled as cards) + disabled-until-selected CTA.
+**Default: select-and-advance** — full-width Button rows that set the variable and continue on tap. No separate Continue button; `pressedStyle` previews the selected state so the tap reads as a selection. See `screen-patterns.md` §2.
 
 ```json
 [
-  { "id": "kicker", "type": "Text", "props": { "content": "Step 2 of 6", "fontFamily": "<DP.fonts.body>", "fontSize": "<DP.typeScale.caption>", "color": "<DP.text.tertiary>", "letterSpacing": 1.2 } },
   { "id": "title", "type": "Text", "props": { "content": "What's your goal?", "fontFamily": "<DP.fonts.heading>", "fontSize": "<DP.typeScale.h1>", "fontWeight": "<DP.fontWeights.bold>", "color": "<DP.text.primary>" } },
   { "id": "subtitle", "type": "Text", "props": { "content": "We'll personalize your plan around this.", "fontFamily": "<DP.fonts.body>", "fontSize": "<DP.typeScale.body>", "color": "<DP.text.secondary>" } },
+  {
+    "id": "answers",
+    "type": "YStack",
+    "props": { "gap": "<DP.spacing.sm>", "paddingTop": "<DP.spacing.md>" },
+    "children": [
+      {
+        "id": "opt-lose", "type": "Button",
+        "props": {
+          "label": "Lose weight", "haptic": "light",
+          "color": "<DP.text.primary>", "backgroundColor": "<DP.surface.card>",
+          "fontFamily": "<DP.fonts.body>", "fontSize": "<DP.typeScale.body>", "fontWeight": "<DP.fontWeights.regular>",
+          "textAlign": "left", "borderRadius": "<DP.radius.md>",
+          "paddingVertical": 18, "paddingHorizontal": 20,
+          "pressedStyle": { "color": "<DP.text.onBrand>", "backgroundColor": "<DP.brand.primary>" },
+          "actions": [ { "type": "setVariable", "name": "goal", "value": "lose" }, "continue" ]
+        }
+      },
+      {
+        "id": "opt-muscle", "type": "Button",
+        "props": {
+          "label": "Build muscle", "haptic": "light",
+          "color": "<DP.text.primary>", "backgroundColor": "<DP.surface.card>",
+          "fontFamily": "<DP.fonts.body>", "fontSize": "<DP.typeScale.body>", "fontWeight": "<DP.fontWeights.regular>",
+          "textAlign": "left", "borderRadius": "<DP.radius.md>",
+          "paddingVertical": 18, "paddingHorizontal": 20,
+          "pressedStyle": { "color": "<DP.text.onBrand>", "backgroundColor": "<DP.brand.primary>" },
+          "actions": [ { "type": "setVariable", "name": "goal", "value": "muscle" }, "continue" ]
+        }
+      }
+      /* one Button per option, same recipe */
+    ]
+  }
+]
+```
+
+**RadioGroup variant** (use only when the user should review/change the pick before advancing — confirm-style steps):
+
+```json
+[
+  { "id": "title", "type": "Text", "props": { "content": "What's your goal?", "fontFamily": "<DP.fonts.heading>", "fontSize": "<DP.typeScale.h1>", "fontWeight": "<DP.fontWeights.bold>", "color": "<DP.text.primary>" } },
   {
     "id": "answers",
     "type": "RadioGroup",
@@ -127,6 +173,7 @@ Title + helper + tappable cards (RadioGroup styled as cards) + disabled-until-se
       "variableName": "goal",
       "direction": "vertical",
       "gap": "<DP.spacing.sm>",
+      "haptic": "light",
       "itemBackgroundColor": "<DP.surface.card>",
       "itemSelectedBackgroundColor": "<DP.brand.primary>",
       "itemBorderColor": "<DP.border.subtle>",
@@ -157,9 +204,9 @@ Title + helper + tappable cards (RadioGroup styled as cards) + disabled-until-se
       "backgroundColor": "<DP.brand.primary>", "color": "<DP.text.onBrand>",
       "fontFamily": "<DP.fonts.heading>", "fontWeight": "<DP.fontWeights.semibold>", "fontSize": 17,
       "borderRadius": "<DP.buttonBorderRadius>", "paddingVertical": 16,
-      "disabledBackgroundColor": "<DP.surface.raised>",
-      "disabledColor": "<DP.text.muted>",
-      "disabledWhen": { "variable": "goal", "operator": "eq", "value": "" },
+      "haptic": "light", "pressedStyle": { "opacity": 0.85 },
+      "disabledStyle": { "backgroundColor": "<DP.surface.raised>", "color": "<DP.text.muted>" },
+      "disabledWhen": { "variable": "goal", "operator": "is_empty" },
       "actions": ["continue"]
     }
   }
@@ -207,8 +254,9 @@ Same shape as question-single but `CheckboxGroup` + multi-select. CTA disabled u
       "backgroundColor": "<DP.brand.primary>", "color": "<DP.text.onBrand>",
       "fontFamily": "<DP.fonts.heading>", "fontWeight": "<DP.fontWeights.semibold>", "fontSize": 17,
       "borderRadius": "<DP.buttonBorderRadius>", "paddingVertical": 16,
-      "disabledBackgroundColor": "<DP.surface.raised>", "disabledColor": "<DP.text.muted>",
-      "disabledWhen": { "variable": "obstacles", "operator": "eq", "value": "" },
+      "haptic": "light", "pressedStyle": { "opacity": 0.85 },
+      "disabledStyle": { "backgroundColor": "<DP.surface.raised>", "color": "<DP.text.muted>" },
+      "disabledWhen": { "variable": "obstacles", "operator": "is_empty" },
       "actions": ["continue"]
     }
   }
@@ -250,8 +298,9 @@ Centered hero input with the app's input styling.
       "backgroundColor": "<DP.brand.primary>", "color": "<DP.text.onBrand>",
       "fontFamily": "<DP.fonts.heading>", "fontWeight": "<DP.fontWeights.semibold>", "fontSize": 17,
       "borderRadius": "<DP.buttonBorderRadius>", "paddingVertical": 16,
-      "disabledBackgroundColor": "<DP.surface.raised>", "disabledColor": "<DP.text.muted>",
-      "disabledWhen": { "variable": "name", "operator": "eq", "value": "" },
+      "haptic": "light", "pressedStyle": { "opacity": 0.85 },
+      "disabledStyle": { "backgroundColor": "<DP.surface.raised>", "color": "<DP.text.muted>" },
+      "disabledWhen": { "variable": "name", "operator": "is_empty" },
       "actions": ["continue"]
     }
   }
@@ -300,8 +349,9 @@ Large display number + small unit. Wrap input + unit in an XStack so they align.
       "backgroundColor": "<DP.brand.primary>", "color": "<DP.text.onBrand>",
       "fontFamily": "<DP.fonts.heading>", "fontWeight": "<DP.fontWeights.semibold>", "fontSize": 17,
       "borderRadius": "<DP.buttonBorderRadius>", "paddingVertical": 16,
-      "disabledBackgroundColor": "<DP.surface.raised>", "disabledColor": "<DP.text.muted>",
-      "disabledWhen": { "variable": "weight", "operator": "eq", "value": "" },
+      "haptic": "light", "pressedStyle": { "opacity": 0.85 },
+      "disabledStyle": { "backgroundColor": "<DP.surface.raised>", "color": "<DP.text.muted>" },
+      "disabledWhen": { "variable": "weight", "operator": "is_empty" },
       "actions": ["continue"]
     }
   }
@@ -353,90 +403,88 @@ Personalized mirror of prior answers. Card-styled body wrapping a `YStack`.
 
 ## social-proof
 
-Three quote cards in a vertical scroll.
+Layered composition beats a list of quote cards: laurel header (laurels + gold stars + claim), ONE floating testimonial card with a big soft shadow, a payoff RichText line, then the CTA. Stat-anchored variant (accent-colored number span inside gray copy) for value-prop screens. Full recipes: `screen-patterns.md` §6.
 
 ```json
 [
-  { "id": "title", "type": "Text", "props": { "content": "Why 50,000 people start with us", "fontFamily": "<DP.fonts.heading>", "fontSize": "<DP.typeScale.h2>", "fontWeight": "<DP.fontWeights.bold>", "color": "<DP.text.primary>", "textAlign": "center" } },
-  {
-    "id": "quotes",
-    "type": "YStack",
-    "props": { "gap": "<DP.spacing.md>" },
+  { "id": "laurel-row", "type": "XStack", "props": { "justifyContent": "center", "alignItems": "center", "gap": "<DP.spacing.sm>" },
     "children": [
-      {
-        "id": "quote-1",
-        "type": "YStack",
-        "props": { "backgroundColor": "<DP.surface.card>", "borderRadius": "<DP.radius.md>", "padding": "<DP.spacing.md>", "gap": 6, "borderWidth": 1, "borderColor": "<DP.border.subtle>" },
+      { "id": "laurel-l", "type": "Image", "props": { "url": "<APP_LAUREL_SVG>", "width": 48, "resizeMode": "contain" } },
+      { "id": "rating-block", "type": "YStack", "props": { "alignItems": "center", "gap": 2 },
         "children": [
-          { "id": "q1-stars", "type": "Text", "props": { "content": "★★★★★", "color": "<DP.brand.primary>" } },
-          { "id": "q1-text", "type": "Text", "props": { "content": "Changed my routine completely.", "fontFamily": "<DP.fonts.body>", "fontSize": "<DP.typeScale.body>", "color": "<DP.text.primary>" } },
-          { "id": "q1-author", "type": "Text", "props": { "content": "Alex, 32", "fontFamily": "<DP.fonts.body>", "fontSize": "<DP.typeScale.caption>", "color": "<DP.text.tertiary>" } }
-        ]
-      },
-      {
-        "id": "quote-2",
-        "type": "YStack",
-        "props": { "backgroundColor": "<DP.surface.card>", "borderRadius": "<DP.radius.md>", "padding": "<DP.spacing.md>", "gap": 6, "borderWidth": 1, "borderColor": "<DP.border.subtle>" },
-        "children": [
-          { "id": "q2-stars", "type": "Text", "props": { "content": "★★★★★", "color": "<DP.brand.primary>" } },
-          { "id": "q2-text", "type": "Text", "props": { "content": "I look forward to opening this every day.", "fontFamily": "<DP.fonts.body>", "fontSize": "<DP.typeScale.body>", "color": "<DP.text.primary>" } },
-          { "id": "q2-author", "type": "Text", "props": { "content": "Maya, 28", "fontFamily": "<DP.fonts.body>", "fontSize": "<DP.typeScale.caption>", "color": "<DP.text.tertiary>" } }
-        ]
-      }
-    ]
-  },
+          { "id": "stars", "type": "Text", "props": { "content": "★★★★★", "fontSize": "<DP.typeScale.h3>", "color": "<DP.accent.gold>" } },
+          { "id": "claim", "type": "Text", "props": { "content": "Loved by +100K users", "fontFamily": "<DP.fonts.body>", "fontSize": "<DP.typeScale.caption>", "color": "<DP.text.secondary>" } }
+        ] },
+      { "id": "laurel-r", "type": "Image", "props": { "url": "<APP_LAUREL_SVG_MIRRORED>", "width": 48, "resizeMode": "contain" } }
+    ] },
+  { "id": "testimonial", "type": "YStack",
+    "props": { "backgroundColor": "<DP.surface.card>", "borderRadius": "<DP.radius.xl>", "padding": 20, "gap": 6, "margin": 12,
+      "elevation": 12, "shadowColor": "#000000", "shadowOffset": { "width": 0, "height": 10 }, "shadowRadius": 20, "shadowOpacity": 0.25 },
+    "children": [
+      { "id": "q-author", "type": "Text", "props": { "content": "@maya.runs", "fontFamily": "<DP.fonts.body>", "fontSize": "<DP.typeScale.bodySm>", "fontWeight": "<DP.fontWeights.semibold>", "color": "<DP.text.primary>" } },
+      { "id": "q-stars", "type": "Text", "props": { "content": "★★★★★", "color": "<DP.accent.gold>" } },
+      { "id": "q-text", "type": "Text", "props": { "content": "I look forward to opening this every day.", "fontFamily": "<DP.fonts.body>", "fontSize": "<DP.typeScale.body>", "color": "<DP.text.primary>" } },
+      { "id": "q-date", "type": "Text", "props": { "content": "May 12", "fontSize": 13, "color": "<DP.text.tertiary>" } }
+    ] },
   { "id": "spacer", "type": "YStack", "props": { "flex": 1 }, "children": [] },
   {
     "id": "cta",
     "type": "Button",
     "props": {
-      "label": "Continue", "variant": "filled",
+      "label": "Rate the app", "variant": "filled",
       "backgroundColor": "<DP.brand.primary>", "color": "<DP.text.onBrand>",
       "fontFamily": "<DP.fonts.heading>", "fontWeight": "<DP.fontWeights.semibold>", "fontSize": 17,
       "borderRadius": "<DP.buttonBorderRadius>", "paddingVertical": 16,
+      "haptic": "light", "pressedStyle": { "opacity": 0.85 },
       "actions": ["continue"]
     }
   }
 ]
 ```
 
+Simpler fallback (no laurel assets): keep the title + ONE quote card — never three plain stacked quotes.
+
 ---
 
 ## loader
 
-Lottie + status line + secondary tip card. No auto-advance built into schema — emit a `custom` action `delayedContinue` that the host wires to a timer (fall back to plain `["continue"]` if host doesn't implement it).
+**Self-completing sequential loader** — no host timer needed. Chained `ProgressIndicator`s fill one after another via `delay`; each row's label flips from in-progress text to a done-row (check icon) via `renderWhen` on the bound variable; the CTA only renders when the last bar hits 100. Full recipe + "Did you know?" card rail: `screen-patterns.md` §5.
 
 ```json
 [
-  { "id": "spacer-top", "type": "YStack", "props": { "flex": 1 }, "children": [] },
-  { "id": "anim", "type": "Lottie", "props": { "source": "<APP_LOADER_LOTTIE_URL>", "autoPlay": true, "loop": true, "height": 220 } },
-  { "id": "title", "type": "Text", "props": { "content": "Building your plan…", "fontFamily": "<DP.fonts.heading>", "fontSize": "<DP.typeScale.h2>", "fontWeight": "<DP.fontWeights.bold>", "color": "<DP.text.primary>", "textAlign": "center" } },
-  { "id": "subtitle", "type": "Text", "props": { "content": "Tuning macros and weekly targets to your inputs.", "fontFamily": "<DP.fonts.body>", "fontSize": "<DP.typeScale.body>", "color": "<DP.text.secondary>", "textAlign": "center" } },
+  { "id": "title", "type": "Text", "props": { "content": "Building your plan…", "fontFamily": "<DP.fonts.heading>", "fontSize": "<DP.typeScale.h1>", "fontWeight": "<DP.fontWeights.medium>", "color": "<DP.text.primary>" } },
   {
-    "id": "tip",
-    "type": "YStack",
-    "props": { "backgroundColor": "<DP.surface.card>", "borderRadius": "<DP.radius.md>", "padding": "<DP.spacing.md>", "gap": 4, "borderWidth": 1, "borderColor": "<DP.border.subtle>" },
+    "id": "rows", "type": "YStack", "props": { "gap": "<DP.spacing.md>", "paddingTop": "<DP.spacing.lg>" },
     "children": [
-      { "id": "tip-kicker", "type": "Text", "props": { "content": "Did you know", "fontFamily": "<DP.fonts.body>", "fontSize": "<DP.typeScale.caption>", "fontWeight": "<DP.fontWeights.semibold>", "color": "<DP.brand.primary>", "letterSpacing": 1.2 } },
-      { "id": "tip-body", "type": "Text", "props": { "content": "Most people see results in the first 2 weeks of consistent logging.", "fontFamily": "<DP.fonts.body>", "fontSize": "<DP.typeScale.body>", "color": "<DP.text.primary>" } }
+      { "id": "bar-1", "type": "ProgressIndicator", "props": { "variant": "linear", "autoplay": true, "duration": 5000, "delay": 0, "initialValue": 0, "thickness": 12, "color": "<DP.brand.primary>", "trackColor": "<DP.surface.raised>", "variableName": "loader1" } },
+      { "id": "label-1-busy", "type": "Text", "renderWhen": { "variable": "loader1", "operator": "lt", "value": "100" }, "props": { "content": "Analyzing your answers…", "fontFamily": "<DP.fonts.body>", "fontSize": "<DP.typeScale.body>", "color": "<DP.text.secondary>" } },
+      { "id": "label-1-done", "type": "XStack", "renderWhen": { "variable": "loader1", "operator": "eq", "value": "100" }, "props": { "gap": 10, "alignItems": "center" },
+        "children": [
+          { "id": "check-1", "type": "Icon", "props": { "name": "CircleCheck", "size": 20, "color": "<DP.brand.primary>" } },
+          { "id": "done-1", "type": "Text", "props": { "content": "Answers analyzed", "fontFamily": "<DP.fonts.body>", "fontSize": "<DP.typeScale.body>", "color": "<DP.text.primary>" } }
+        ] },
+      { "id": "bar-2", "type": "ProgressIndicator", "props": { "variant": "linear", "autoplay": true, "duration": 5000, "delay": 5000, "initialValue": 0, "thickness": 12, "color": "<DP.brand.primary>", "trackColor": "<DP.surface.raised>", "variableName": "loader2" } }
+      /* bar N: delay = (N-1) × duration; matching busy/done rows per bar */
     ]
   },
-  { "id": "spacer-bot", "type": "YStack", "props": { "flex": 1 }, "children": [] },
+  { "id": "spacer", "type": "YStack", "props": { "flex": 1 }, "children": [] },
   {
     "id": "cta",
     "type": "Button",
+    "renderWhen": { "variable": "loader2", "operator": "eq", "value": "100" },
     "props": {
       "label": "Continue", "variant": "filled",
       "backgroundColor": "<DP.brand.primary>", "color": "<DP.text.onBrand>",
       "fontFamily": "<DP.fonts.heading>", "fontWeight": "<DP.fontWeights.semibold>", "fontSize": 17,
       "borderRadius": "<DP.buttonBorderRadius>", "paddingVertical": 16,
-      "actions": [
-        { "type": "custom", "function": "delayedContinue", "variables": [] }
-      ]
+      "haptic": "light", "pressedStyle": { "opacity": 0.85 },
+      "actions": ["continue"]
     }
   }
 ]
 ```
+
+Fallback: if the wait must track *real* backend work (not a fixed duration), emit `actions: [{ "type": "custom", "function": "delayedContinue", "variables": [] }]` and let the host wire the timer.
 
 ---
 
@@ -476,8 +524,9 @@ Signature-style: title + 3 commitment checkboxes (forced-tap) + big CTA.
       "backgroundColor": "<DP.brand.primary>", "color": "<DP.text.onBrand>",
       "fontFamily": "<DP.fonts.heading>", "fontWeight": "<DP.fontWeights.semibold>", "fontSize": 17,
       "borderRadius": "<DP.buttonBorderRadius>", "paddingVertical": 16,
-      "disabledBackgroundColor": "<DP.surface.raised>", "disabledColor": "<DP.text.muted>",
-      "disabledWhen": { "variable": "commitments", "operator": "eq", "value": "" },
+      "haptic": "light", "pressedStyle": { "opacity": 0.85 },
+      "disabledStyle": { "backgroundColor": "<DP.surface.raised>", "color": "<DP.text.muted>" },
+      "disabledWhen": { "variable": "commitments", "operator": "is_empty" },
       "actions": ["continue"]
     }
   }
@@ -486,9 +535,15 @@ Signature-style: title + 3 commitment checkboxes (forced-tap) + big CTA.
 
 ---
 
+## permission
+
+OS-permission / integration ask (notifications, HealthKit, …) as a designed screen — logo with soft shadow, benefit rows (icon-in-circle + title/body), privacy reassurance line, primary CTA firing a host `custom` action, ghost "Later" opt-out. If granting populates data later screens would collect manually, branch past them (`is_not_null` conditions on the populated variables). Full recipe + branch shape: `screen-patterns.md` §7–8. `displayProgressHeader: false`.
+
+---
+
 ## carousel
 
-3-slide intro. Each slide = title + image + body inside a YStack. Use carousel's built-in dots.
+3-slide intro. Each slide = title + image + body inside a YStack. Use carousel's built-in dots. For a per-page CTA that pages the carousel itself ("Discover" → "Next →" → "Continue"), bind `variableName` and swap CTAs via `renderWhen` — the state-machine variant in `screen-patterns.md` §3.
 
 ```json
 [

--- a/claude-plugin/skills/create-step-json/references/screen-patterns.md
+++ b/claude-plugin/skills/create-step-json/references/screen-patterns.md
@@ -1,0 +1,242 @@
+# Screen Patterns — production-grade composition cookbook
+
+Patterns extracted from a gold-standard production onboarding (21 ComposableScreen steps, health-app vertical). Archetypes in `composable-archetypes.md` give the skeleton; this file is the polish layer — motion choreography, interaction idioms, and composition recipes that make a flow feel hand-built.
+
+> **Schema reminder.** `payload = { elements: UIElement[] }`. No `payload.root`, no `payload.variables`. Every container needs `children` (even `[]`).
+
+> **Element ids.** Readable ids below are illustrative. Real output: fresh UUID v4 per element, never reused.
+
+> **⚠ Colors/fonts below are EXAMPLE VALUES from the reference app** (`#66A3FF` brand blue, `#FAFAFA` background, SF Pro Display, etc.). They are concrete so you can see real recipes — but **always replace every color, font, radius, and spacing value with the target app's Design Profile** (`inspect-target-app.md`). Shipping the reference palette into another app is a regression.
+
+---
+
+## 1. Universal screen skeleton
+
+Nearly every screen shares one bone structure: SafeAreaView → space-between YStack → top content block + bottom-pinned CTA. `justifyContent: "space-between"` replaces spacer elements when there are exactly two groups.
+
+```json
+{
+  "id": "safe", "type": "SafeAreaView",
+  "props": { "flex": 1, "edges": ["top", "bottom"], "backgroundColor": "#FAFAFA" },
+  "children": [
+    {
+      "id": "root", "type": "YStack",
+      "props": { "flex": 1, "justifyContent": "space-between", "paddingHorizontal": 24, "paddingTop": 12, "paddingBottom": 24, "gap": 16 },
+      "children": [
+        { "id": "content", "type": "YStack", "props": { "gap": 16 }, "children": [ /* heading, subtitle, body */ ] },
+        { "id": "cta", "type": "Button", "props": {
+          "label": "Continue", "variant": "filled",
+          "backgroundColor": "#66A3FF", "color": "#FFFFFF",
+          "fontSize": 17, "fontWeight": "600", "borderRadius": 16, "paddingVertical": 16,
+          "haptic": "light",
+          "pressedStyle": { "opacity": 0.85 },
+          "disabledStyle": { "color": "#8E8E93", "backgroundColor": "#E5E5E5" },
+          "actions": ["continue"]
+        } }
+      ]
+    }
+  ]
+}
+```
+
+The canonical CTA recipe — reuse on every screen, identical across the flow: brand fill + on-brand text, radius 16 (≈ `<DP.buttonBorderRadius>`), `paddingVertical 16`, `fontSize 17`, semibold, `haptic: "light"`, `pressedStyle: { opacity: 0.85 }`, `disabledStyle` (never the deprecated `disabledBackgroundColor`/`disabledColor`). Give big top breathing room above headings on sparse screens (`paddingTop`/`paddingVertical` up to 60).
+
+## 2. Select-and-advance single-select (preferred over RadioGroup)
+
+For single-select questions that should advance on tap, render answers as full-width **Button rows** — not a RadioGroup + Continue. The reference flow's 7 question screens used **zero RadioGroups**. Each button sets the variable then continues; `pressedStyle` previews the selected state so the tap *feels* like a selection.
+
+```json
+{
+  "id": "answers", "type": "YStack", "props": { "gap": 12 },
+  "children": [
+    { "id": "opt-instagram", "type": "Button", "props": {
+      "label": "Instagram", "haptic": "light",
+      "color": "#1A1A1A", "backgroundColor": "#FFFFFF",
+      "fontSize": 17, "fontWeight": "400", "textAlign": "left",
+      "borderRadius": 16, "paddingVertical": 18, "paddingHorizontal": 20,
+      "pressedStyle": { "color": "#FFFFFF", "backgroundColor": "#66A3FF" },
+      "actions": [ { "type": "setVariable", "name": "attribution", "value": "instagram" }, "continue" ]
+    } }
+  ]
+}
+```
+
+- One Button per option; white card, left-aligned regular-weight label, radius 16, no Continue button at all. One less tap per screen.
+- **When to keep RadioGroup instead:** the user should review/change their pick before advancing, or selection alone shouldn't commit (e.g. legal/confirm steps).
+- Multi-select stays `CheckboxGroup`: `showTick: false`, selected = full brand fill + on-brand text (`itemSelectedBackgroundColor` + `itemSelectedColor`), unselected = white card, `itemBorderWidth: 0`, radius 16, `haptic: "light"`; CTA gated `disabledWhen: { "variable": "<groupVar>", "operator": "is_empty" }`.
+
+## 3. Carousel as state machine
+
+One variable drives both the carousel position and which CTA renders — one screen behaves like N. `setVariable` with `valueMode: "expression"` increments the page; `renderWhen` swaps the CTA per page range.
+
+```json
+{ "id": "pager", "type": "Carousel", "props": {
+    "carouselType": "normal", "loop": false, "variableName": "welcomePage",
+    "showDots": true, "dotColor": "#E5E5E5", "activeDotColor": "#000000", "dotWidth": 8, "dotHeight": 8
+  }, "children": [ /* 5 slides */ ] },
+
+{ "id": "cta-start", "type": "Button",
+  "props": { "label": "Discover", "actions": [ { "type": "setVariable", "name": "welcomePage", "value": "1", "kind": "int" } ] },
+  "renderWhen": { "variable": "welcomePage", "operator": "eq", "value": "0" } },
+
+{ "id": "cta-next", "type": "Button",
+  "props": { "label": "Next →", "actions": [ { "type": "setVariable", "name": "welcomePage", "value": "{{welcomePage}} +1", "valueMode": "expression" } ] },
+  "renderWhen": { "logic": "and", "conditions": [
+    { "variable": "welcomePage", "operator": "gt", "value": "0" },
+    { "variable": "welcomePage", "operator": "lt", "value": "4" } ] } },
+
+{ "id": "cta-done", "type": "Button", "props": { "label": "Continue", "actions": ["continue"] },
+  "renderWhen": { "variable": "welcomePage", "operator": "eq", "value": "4" } }
+```
+
+(CTA styling props elided — use the §1 recipe on all three.) For an N-slide carousel the bounds are `eq 0` / `gt 0 AND lt N-1` / `eq N-1`.
+
+## 4. Staggered FadeIn choreography ("reveal beat")
+
+A hero animation (Rive/Lottie) plays, then text lines and the CTA enter one-by-one with `FadeIn` + incremental delays **tuned to the media's runtime**. Turns a static reflection screen into a narrative moment.
+
+```json
+{ "id": "anim", "type": "Rive", "props": { "url": "https://cdn.example.com/reveal.riv", "autoPlay": true, "fit": "FitWidth", "alignment": "TopCenter" } },
+{ "id": "line-1", "type": "Text", "props": { "content": "Good news...", "fontSize": 28, "fontWeight": "500",
+    "animation": { "entering": { "preset": "FadeIn", "duration": 500, "delay": 3500 } } } },
+{ "id": "line-2", "type": "Text", "props": { "content": "All of your symptoms can be reversed! 🌈", "fontSize": 28, "fontWeight": "500",
+    "animation": { "entering": { "preset": "FadeIn", "duration": 500, "delay": 4500 } } } },
+{ "id": "cta", "type": "Button", "props": { "label": "See how", "actions": ["continue"],
+    "animation": { "entering": { "preset": "FadeIn", "duration": 500, "delay": 5500 } },
+    "backgroundColor": "#ffffff", "color": "#1A1A1A", "borderRadius": 16,
+    "paddingVertical": 20, "paddingHorizontal": 64,
+    "elevation": 2, "shadowColor": "#1A1A1A12", "shadowOffset": { "width": 0, "height": 2 }, "shadowRadius": 10, "shadowOpacity": 1 } }
+```
+
+Heuristics: 500ms fades, ~1000ms between beats, first delay = animation runtime so text lands as the motion settles. Works for any "diagnosis → good news → CTA" sequence. (Note 8-digit hex `#1A1A1A12` — alpha baked into `shadowColor`.)
+
+## 5. Sequential self-completing loader
+
+No host timer, no `delayedContinue`. Chain `ProgressIndicator`s via `delay` so bars fill one after another; pair each with a label that flips from in-progress text to a done-row when its variable hits 100; gate the final CTA on the last bar.
+
+```json
+{ "id": "load-1", "type": "ProgressIndicator", "props": {
+    "variant": "linear", "autoplay": true, "duration": 5000, "delay": 0,
+    "initialValue": 0, "value": 60, "thickness": 12,
+    "color": "#3b82f6", "trackColor": "#e5e7eb", "variableName": "curatingLoader1" } },
+{ "id": "label-1-busy", "type": "Text", "props": { "content": "Analyzing your answers…" },
+  "renderWhen": { "variable": "curatingLoader1", "operator": "lt", "value": "100" } },
+{ "id": "label-1-done", "type": "XStack", "props": { "gap": 10, "alignItems": "center" },
+  "renderWhen": { "variable": "curatingLoader1", "operator": "eq", "value": "100" },
+  "children": [
+    { "id": "check-1", "type": "Icon", "props": { "name": "CircleCheck", "size": 20, "color": "#3385FF" } },
+    { "id": "done-1", "type": "Text", "props": { "content": "Answers analyzed" } } ] },
+
+{ "id": "cta", "type": "Button", "props": { "label": "Access my profile", "actions": ["continue"] },
+  "renderWhen": { "variable": "curatingLoader3", "operator": "eq", "value": "100" } }
+```
+
+- N bars: each `duration: 5000`, `delay: (i-1) × 5000` — bar *i* starts when *i−1* finishes.
+- During the wait, add a horizontal `ScrollView` (`horizontal: true`, indicators off) of "Did you know?" cards — 300px-wide white cards, radius 20, icon + body + image — to make the wait feel like value.
+- Use the host-wired `custom: delayedContinue` action only when the wait must track *real* backend work, not a fixed duration.
+
+## 6. Social-proof composition
+
+Layered, not a list of plain quote cards:
+
+1. **Laurel header** — `XStack`: laurel SVG `Image` + center block (gold `★★★★★` `#FFC107`, claim line, "+100K users") + mirrored laurel SVG.
+2. **Floating testimonial card** — one quote, big soft shadow so it floats: `YStack` `backgroundColor #FFFFFF`, `borderRadius 24`, `padding 20`, `elevation 12`, `shadowColor #000000`, `shadowOffset {0,10}`, `shadowRadius 20`, `shadowOpacity 0.25`. Inside: handle, star row, quote, date (13px light gray).
+3. **Payoff RichText** — short line with one bold/accent span ("You + us = 5-star energy").
+4. **Rate CTA** (§1 recipe, e.g. "Rate the app").
+
+Stat-anchored variant (value-prop screens): hero Lottie (`flex: 2`) above a centered RichText where the number is its own accent span:
+
+```json
+{ "id": "stat", "type": "RichText",
+  "props": { "fontSize": 16, "textAlign": "center", "color": "#8E8E93", "padding": 48 },
+  "children": [
+    { "id": "n", "type": "Text", "props": { "content": "82%", "fontSize": 24, "fontWeight": "700", "color": "#F57C00" } },
+    { "id": "rest", "type": "Text", "props": { "content": " of users report better sleep within 90 days" } }
+  ] }
+```
+
+Same accent-span trick upgrades any headline: one keyword colored brand/accent inside an otherwise-plain RichText title.
+
+## 7. Permission / integration screens
+
+Permission asks deserve their own designed screen — never a bare OS dialog:
+
+- **App/integration logo** `Image` with a soft shadow (`elevation 5`, `shadowOffset {0,4}`, `shadowRadius 8`, `shadowOpacity 0.2`).
+- **Benefit rows** — per benefit, `XStack(gap 10)`: icon in a brand-tinted circle (`width/height 48`, `borderRadius 24`, brand bg) + `YStack` title (semibold, 18) / body (secondary).
+- **Privacy reassurance** — `XStack`: green `ShieldCheck` icon (`#3DA755`) + "Your data is encrypted and private" (14px secondary).
+- **Primary CTA** fires the host action: `actions: [{ "type": "custom", "function": "connectAppleHealth", "variables": [] }]` (likewise `requestNotifications`).
+- **Soft opt-out** below (§8): "Later" / "Add data manually" — never trap the user.
+
+**Integration-aware branch.** If granting the permission populates data that later screens would collect manually, branch past them:
+
+```json
+"nextStep": {
+  "defaultTargetStepId": "cycle-length-manual",
+  "branches": [ {
+    "targetStepId": "notifications",
+    "condition": { "logic": "and", "conditions": [
+      { "variable": "cycleLengthWheelPicker", "operator": "is_not_null" },
+      { "variable": "periodLengthWheelPicker", "operator": "is_not_null" },
+      { "variable": "cycleStart", "operator": "is_not_null" } ] }
+  } ]
+}
+```
+
+Default path = manual entry; the branch skips it when the integration already supplied the data. A granted permission should *shorten* the funnel.
+
+## 8. Soft opt-outs (ghost buttons)
+
+Secondary escape hatches under the primary CTA — transparent, quiet, present:
+
+```json
+{ "id": "later", "type": "Button", "props": {
+    "label": "Later", "variant": "ghost",
+    "color": "#8E8E93", "backgroundColor": "#00000000",
+    "fontSize": 16, "fontWeight": "400", "paddingVertical": 12,
+    "actions": ["continue"] } }
+```
+
+Use for permission deferrals ("Later"), manual alternatives ("Add data manually"), and auth side-doors ("Log in"). Never style an opt-out to compete with the primary CTA.
+
+## 9. Decorative rotated pills
+
+Inline emphasis chips inside a centered RichText sentence — a `Text` child with box styling + a slight rotation reads as a hand-placed sticker:
+
+```json
+{ "id": "title", "type": "RichText",
+  "props": { "fontSize": 32, "fontWeight": "500", "textAlign": "center", "fontFamily": "inherit" },
+  "children": [
+    { "id": "pill", "type": "Text", "props": {
+        "content": "Sync", "color": "#ffffff", "backgroundColor": "#B28BE0",
+        "paddingVertical": 12, "paddingHorizontal": 18, "borderRadius": 200,
+        "lineHeight": 32, "transform": { "rotate": 1.5 } } },
+    { "id": "rest", "type": "Text", "props": { "content": " with your cycle: work with your body", "lineHeight": 32 } }
+  ] }
+```
+
+Rotate ±1.5° (alternate sign across slides), full-pill radius 200, pastel chip backgrounds (purple/yellow/green/blue family), white chip text. Set `lineHeight` on both chip and plain children so rows align.
+
+## 10. Copy voice
+
+- Headings: short, second person, often a question — "What should we call you?", "How old are you?". One idea per screen.
+- Subtitles justify the ask: "This helps us tailor our recommendations."
+- Accent one keyword per headline (brand or warm accent color span).
+- CTA verbs: `Continue` (default), `Next →` (mid-carousel/education), `Discover`, `See how`, `Yes, notify me`, `Turn on <Integration>`, `Rate the app`, `Access my profile`. Opt-outs: `Later`, `Add data manually`.
+- Emoji sparing — at most one, on emotional beats (🌈), and only if `voice.usesEmoji`.
+
+## 11. Design literals ladder (reference app's — emit the target app's)
+
+| Token | Reference value | Used for |
+|-------|----------------|----------|
+| radius | **16** | CTAs, answer cards, inputs, checkbox items — the one radius everywhere |
+| radius | 20 | content cards ("Did you know?") |
+| radius | 24 | icon circles (48×48), featured/testimonial cards |
+| radius | 200 | decorative pills |
+| gap | 8 / 12 / 16 / 24 / 32 | default / answer lists / section / header groups / reveal spacing |
+| gutter | `paddingHorizontal: 24` | screen edge |
+| font sizes | 13 / 14 / 16 / 17 / 18 / 20 / 24 / 28 / 32 | date / caption / body+answers / CTA / row title / card body / section head / hero head / display |
+| weights | 400 body+answers · 500 headings · 600 CTAs+eyebrows | |
+| answer rows | `paddingVertical 18, paddingHorizontal 20` | |
+| CTA | `paddingVertical 16` | |
+
+Input screens: wrap the CTA in `KeyboardAvoidingView` (`enabled: true`) so it rides above the keyboard. These literals describe ONE app — map each row to the target's Design Profile (`buttonBorderRadius`, `spacing.*`, `typeScale.*`) before emitting.

--- a/claude-plugin/skills/onboarding-best-practices/SKILL.md
+++ b/claude-plugin/skills/onboarding-best-practices/SKILL.md
@@ -34,14 +34,22 @@ Strong consumer-app onboarding arc:
 6. **Commitment** (1 screen, archetype `commitment`) — verbal lock-in.
 7. **Paywall handoff** — exit onboarding to host paywall.
 
+Permission/integration asks (`permission` archetype) slot in after the question funnel, once value is established — and a granted integration should *shorten* the funnel (branch past manual-entry screens it makes redundant).
+
 Total: 8–12 screens. > 15 = measurable drop-off.
+
+Composition recipes (motion choreography, select-and-advance, loaders, social-proof layering): `../create-step-json/references/screen-patterns.md`.
+
+## displayProgressHeader rule
+
+Progress bar ON only while the user is actively answering — `question-*`, `input`, `picker` screens. OFF for narrative/value moments: `hero`, `carousel`, `reflection`, `social-proof`, `permission`, `loader`, `commitment`. The bar signals "almost done with questions"; on storytelling screens it only adds friction.
 
 ## Per-archetype heuristics
 
 ### question-single
-- 3–5 options. 6+ = paralysis.
+- 3–5 options. 6+ = paralysis (7 acceptable for attribution screens).
 - Labels ≤ 30 chars. Action-oriented ("Lose weight" not "Weight loss").
-- Always declare `variableName` on the `RadioGroup`.
+- **Default to select-and-advance**: Button rows with `[{setVariable}, "continue"]` + `pressedStyle` previewing the selected state — one less tap per screen. Use `RadioGroup` (+ explicit Continue) only when the user should review the pick before advancing; then always declare `variableName`.
 
 ### question-multi
 - Use only when answers are non-exclusive (e.g. obstacles, dietary restrictions).
@@ -68,10 +76,18 @@ Total: 8–12 screens. > 15 = measurable drop-off.
 ### social-proof
 - Place AFTER user has seen value, not as cold ask.
 - One quote, one name. Multiple = noise.
+- Compose in layers, not a flat list: laurels + gold stars + user-count claim, ONE floating testimonial card (big soft shadow), a payoff line, then the rate CTA. Stat-anchored variant: one big accent-colored number ("82%") inside gray supporting copy.
 
 ### loader
-- 2000–4000ms total. Faster = fake; slower = broken.
-- If SDK lacks auto-advance action, flag the gap.
+- **Self-completing**: chain `ProgressIndicator`s via `delay` (bar *i* starts when *i−1* ends), flip each row's label to a check-row via `renderWhen` at 100, gate the CTA on the last bar. No host timer needed.
+- ~5s per bar, 2–3 bars. A horizontal "Did you know?" card rail makes the wait feel like value.
+- Use the host-wired `delayedContinue` custom action only when gating on real backend work.
+
+### permission (notifications, HealthKit, …)
+- Ask late — after the question funnel, with value established. Never a bare OS dialog: designed screen with logo, benefit rows (icon-in-circle + title/body), and a privacy reassurance line ("Your data is encrypted and private" + shield icon).
+- Always offer a ghost-button opt-out ("Later", "Add data manually") — never trap.
+- CTA fires a host `custom` action (`requestNotifications`, `connectAppleHealth`).
+- **Branch on the grant**: if the integration populates variables later screens collect manually, add `is_not_null` branches that skip those screens. Granted permission = shorter funnel.
 
 ### commitment
 - 2–3 commitment items, present tense, "I will" phrasing.
@@ -126,7 +142,7 @@ Every step in a multi-step flow uses the explicit multi-path link form:
 
 ## Performance
 
-- `Image.source.localPathId` ≫ `url` for above-fold. Bundle hero image.
+- `Image.url` is the only valid prop (no `source.localPathId`). For above-fold media use fast CDN URLs; prefer WebP/SVG (decoded via `expo-image` / `react-native-svg`).
 - `Lottie` with remote source: preload or show blank.
 - `Carousel` of 4+ images: lazy-load via SDK's built-in mechanism.
 
@@ -142,9 +158,9 @@ Every step in a multi-step flow uses the explicit multi-path link form:
 
 - Email capture mid-onboarding before value delivered. Always after.
 - Push notification prompt before user has any reason to want them.
-- "Skip" button on any non-info screen — kills funnel.
+- "Skip" button on any non-info screen — kills funnel. (Quiet ghost-button opt-outs on permission screens — "Later" — are fine and expected.)
 - Onboarding > 15 screens.
-- Asking for permissions inside onboarding instead of after.
+- Asking for permissions *prematurely* — before value is delivered, or via a bare OS dialog instead of a designed `permission` screen.
 - Generic brand colors when app probe data is available.
 - Inventing font names not loaded by `expo-font`.
 - Long-form copy that won't translate (if multi-locale).

--- a/claude-plugin/skills/onboarding-best-practices/references/inspect-target-app.md
+++ b/claude-plugin/skills/onboarding-best-practices/references/inspect-target-app.md
@@ -31,8 +31,13 @@ type DesignProfile = {
   lineHeightMultiplier: number; // usually 1.2–1.5
 
   // Spacing + shape — pulled from existing Button + Card components
-  radius: { sm: number; md: number; lg: number; pill: number };
+  radius: { sm: number; md: number; lg: number; xl?: number; pill: number };  // xl ≈ featured/testimonial cards (e.g. 24)
   spacing: { xs: number; sm: number; md: number; lg: number; xl: number };
+  gutter?: number;                  // screen-edge horizontal padding (usually spacing.lg, e.g. 24)
+
+  // Optional accents + effects — fall back to nearest existing token when absent
+  accent?: { gold?: string; pastels?: string[] };  // gold = star ratings; pastels = decorative chip backgrounds
+  shadow?: { card?: { color: string; offset: { width: number; height: number }; opacity: number; radius: number; elevation: number } };
   buttonHeight: number;          // standard primary button height
   buttonPaddingH: number;        // standard primary button horizontal padding
   buttonBorderRadius: number;    // standard primary button corner radius

--- a/claude-plugin/skills/validate-step-json/SKILL.md
+++ b/claude-plugin/skills/validate-step-json/SKILL.md
@@ -44,8 +44,9 @@ Run: `npx tsx scripts/_validate-composable.ts "$(cat step.json)"`
    - `RadioGroup.props.items` / `CheckboxGroup.props.items` is `[{label, value}]` (NOT `options`)
    - `WheelPicker.props` provides exactly one of `items: [{label, value}]` (unique values) or `range: {min, max, step?, unit?}` — both or neither is a schema error; `defaultValue` (if present) must match an available item value
    - `ProgressIndicator.props.variant` (if present) is `"linear"|"circular"`; `easing` (if present) is `"linear"|"ease-in"|"ease-out"|"ease-in-out"`; `value`/`initialValue` are 0–100; `duration`/`delay`/`thickness`/`size` are non-negative numbers; `autoplay`/`loop`/`showLabel` are booleans. Not a container — must NOT have `children`
-   - `Button.props.actions` is an array; entries are `"continue"` or `{type:"custom",function,variables?}` or `{type:"setVariable",name,value,valueMode?}` (note: setVariable may not be in headless schema yet — check)
+   - `Button.props.actions` is an array; entries are `"continue"` or `{type:"custom",function,variables?}` or `{type:"setVariable",name,value,valueMode?,kind?}` (`valueMode` ∈ `"literal"|"expression"`; `kind` ∈ `"int"|"float"|"string"` — all three action shapes are in the headless schema, `ButtonElement.ts`)
    - `Button.props.disabledWhen` (NOT `disabled`) is a valid `LeafCondition` or `ConditionGroup`
+   - **Gating sanity (warning, not schema error)**: a `disabledWhen` / `renderWhen` condition should reference a variable captured on the SAME screen (this screen's `variableName` elements or `setVariable` actions) or a deliberate upstream capture. A CTA gated on a variable this screen never touches is almost always a copy-paste bug (seen in production: picker CTAs gated on a stale `goals` variable from an earlier screen) — flag it.
    - `Button.props.pressedStyle` / `disabledStyle` (if present) are objects — `Partial` of overridable Button props; must NOT nest `pressedStyle`/`disabledStyle`. `transitionDurationMs` is a non-negative number.
    - `haptic` on `Button` / `RadioGroup` / `CheckboxGroup` (if present) is one of `"none"|"light"|"medium"|"heavy"|"soft"|"rigid"` — any other value is a schema error. Optional + opt-in; needs the optional `expo-haptics` peer dep at runtime (no-op without it)
    - Shadow fields (any element): `shadowColor` string; `shadowOffset` is `{width, height}` (NOT a number); `shadowOpacity` 0–1; `shadowRadius`/`elevation` non-negative numbers
@@ -95,6 +96,7 @@ Run: `npx tsx scripts/_validate-composable.ts "$(cat step.json)"`
 - `nextStep: null` on a non-terminal step in a multi-step flow (relies on implicit array-order linking; prefer explicit `defaultTargetStepId`).
 - `branches[].targetStepId` referencing nonexistent step ID.
 - `branches[].condition` referencing a variable never captured upstream.
+- `disabledWhen` / `renderWhen` gating a CTA on a variable the screen never captures — likely a copy-paste leftover from a duplicated screen; the button silently stays enabled/disabled based on stale state. Warn with the variable name + the screen's actual captured variables.
 - Branch with non-null condition that lists an unknown `operator` (binary, require `value`: `eq|neq|gt|lt|gte|lte|contains|in|not_in`; unary, omit `value`: `is_empty|is_not_empty|is_null|is_not_null`). A binary operator missing `value` is a schema error; a unary operator ignores any `value`.
 - `customPayload: {}` instead of `null` (both validate; prefer `null`).
 - `Carousel` with empty `children`.


### PR DESCRIPTION
## Summary

Analyzed production reference onboarding `dc0fd3d0-a2ee-4df3-9cc8-7e9c97308f7b` ("TestHealthKit v3" / Harmony — 21-step ComposableScreen flow, considered the gold standard for beautiful onboardings) and encoded its reusable patterns into the plugin skill set.

## Changes

### New: `screen-patterns.md` cookbook (`create-step-json/references/`)
11 production-grade composition recipes, shared by all three authoring skills:
1. Universal screen skeleton + canonical CTA (haptic, pressedStyle, disabledStyle)
2. Select-and-advance single-select (Button rows with `[setVariable, "continue"]` — reference flow used **0 RadioGroups**)
3. Carousel as state machine (one variable drives pages + renderWhen-swapped CTAs, expression increment)
4. Staggered FadeIn choreography over Rive/Lottie ("reveal beat")
5. Sequential self-completing loader (chained ProgressIndicators via `delay` + renderWhen done-rows + gated CTA)
6. Social-proof layering (laurels + floating testimonial card + stat-anchored RichText)
7. Permission/integration screens + `is_not_null` skip-branches (granted permission = shorter funnel)
8. Ghost-button soft opt-outs
9. Decorative rotated RichText pills
10. Copy voice
11. Design literals ladder

Example hexes are real (from the reference app) but explicitly labeled "replace from Design Profile probe".

### Updated archetypes (`composable-archetypes.md`)
- `question-single`: select-and-advance Button rows now the default; RadioGroup demoted to confirm-style variant
- `loader`: self-completing ProgressIndicator pattern replaces `custom:delayedContinue` (kept as backend-gated fallback)
- `social-proof`: layered composition replaces three plain quote cards
- New `permission` archetype
- All CTAs migrated: deprecated `disabledBackgroundColor`/`disabledColor` + `eq ""` → `disabledStyle` + `is_empty`, plus `haptic` + `pressedStyle`

### Skill updates
- **create-step-json / onboarding-best-practices**: `displayProgressHeader` rule (ON only for data-collection screens), permission heuristics, softened blanket "no permissions in onboarding" anti-pattern to "not prematurely", fixed stale `Image.source.localPathId` perf note
- **compose-screen-builder**: polish-layer pointer, 2 new anti-patterns, fixed stale note claiming `setVariable` missing from headless schema (it's in `ButtonElement.ts` since v1.35)
- **validate-step-json**: new warning — `disabledWhen`/`renderWhen` gating on a variable the screen never captures (copy-paste bug found in the reference flow itself)
- **inspect-target-app**: optional DP tokens (`radius.xl`, `gutter`, `accent.gold`/`pastels`, `shadow.card`)

No version bump (rides next SDK release), no website/docs mirror (guidance, not schema).

## Verification
- All cross-reference paths resolve from each skill directory
- Snippet props verified against headless schemas (`renderWhen` element-top-level, `setVariable` + `valueMode`/`kind`, Carousel `loop`/dots, Rive `fit`/`alignment`, Icon props)
- Sweeps: zero deprecated `disabledBackgroundColor` outside deprecation notes; `delayedContinue` demoted everywhere; `displayProgressHeader` consistent across skills

🤖 Generated with [Claude Code](https://claude.com/claude-code)