### PR TITLE
🚚 Rename claude plugin to react-native-onboarding

### DIFF
--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
-  "name": "rocapine-onboarding-sdk",
+  "name": "react-native-onboarding",
   "version": "1.35.0",
   "description": "End-to-end workflow for building and updating Rocapine Onboarding Studio flows: author step JSON, integrate the headless + UI SDKs, customize theme/components, and review onboarding quality.",
   "author": {

--- a/claude-plugin/README.md
+++ b/claude-plugin/README.md
@@ -50,7 +50,7 @@ cat > .claude-plugin/marketplace.json <<'EOF'
 {
   "name": "rocapine-local",
   "owner": { "name": "Rocapine" },
-  "plugins": [{ "name": "rocapine-onboarding-sdk", "source": "./claude-plugin" }]
+  "plugins": [{ "name": "react-native-onboarding", "source": "./claude-plugin" }]
 }
 EOF
 ```
@@ -58,7 +58,7 @@ EOF
 Then in Claude Code:
 ```
 /plugin marketplace add /path/to/repo
-/plugin install rocapine-onboarding-sdk@rocapine-local
+/plugin install react-native-onboarding@rocapine-local
 ```
 
 ## Reference


### PR DESCRIPTION
## Summary
- Rename Claude plugin from `rocapine-onboarding-sdk` to `react-native-onboarding` in `claude-plugin/.claude-plugin/plugin.json`
- Update README marketplace example and install command to match

🤖 Generated with [Claude Code](https://claude.com/claude-code)