### PR TITLE
🐛 Fix excessive re-renders in Loader animations + ComposableScreen tree (v1.38.1)

### DIFF
--- a/.claude/rules/composable-screen-runtime.md
+++ b/.claude/rules/composable-screen-runtime.md
@@ -79,6 +79,8 @@ Use legacy `useResolvedFontFamily` only for elements that never set `fontWeight`
 
 `ctx.variables` is `Record<string, ComposableVariableEntry>` (each entry `{value, label?}`). Headless utils that expect primitive variables (`evaluateCondition`, `evaluateLeaf`, `resolveNextStepNumber`) want `Record<string, unknown>`. Flatten before calling:
 
+**Use the precomputed `ctx.flatVariables`** — `Renderer` memoizes the flatten once per render and passes it on `RenderContext`. `renderElement`, `RichTextElement`, `ButtonElement` read `ctx.flatVariables` directly. Don't rebuild a local `Object.fromEntries` per element/component — that re-allocated on every tree re-render (an autoplay `ProgressIndicator` writes a variable each step → whole tree re-renders), which v1.38.1 removed. New consumers needing primitives outside the ctx flow flatten with:
+
 ```ts
 const flatVars = useMemo(
   () => Object.fromEntries(Object.entries(variables).map(([k, v]) => [k, v?.value])),

--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-onboarding",
-  "version": "1.38.0",
+  "version": "1.38.1",
   "description": "End-to-end workflow for building and updating Rocapine Onboarding Studio flows: author step JSON, integrate the headless + UI SDKs, customize theme/components, and review onboarding quality.",
   "author": {
     "name": "Rocapine",

--- a/packages/onboarding-ui/CHANGELOG.md
+++ b/packages/onboarding-ui/CHANGELOG.md
@@ -9,6 +9,17 @@ here.
 
 ---
 
+## [1.38.1] - 2026-06-08
+
+### Fixed
+- **Loader `CircularProgress` per-frame re-render** — the percentage `useAnimatedReaction` rounded inside its JS callback, firing `setPercentage` every frame (~60×/s) and re-rendering the component continuously; it also had no deps array, so Reanimated rebuilt the mapper on every render (resetting `prev`). Now rounds inside the reader with a `prev` guard and a `[]` deps array, so the JS callback fires only when the displayed integer changes.
+- **Loader `StepProgress` listener thrash** — the `progress.addListener` effect was keyed on `barStarted`/`barComplete`, the very states its callback flips, so each `setState` tore the listener down and re-attached it mid-animation. The one-time start/complete transitions now live in refs and the effect deps are `[progress]` (attaches once).
+
+### Changed
+- **ComposableScreen flattens variables once per render** — `renderElement` rebuilt `flatVars` via `Object.fromEntries` for every element on every tree re-render; an autoplay `ProgressIndicator` writing a variable each step re-renders the whole tree, making this pure churn. The flatten is now memoized once in `Renderer` as `ctx.flatVariables` (added to `RenderContext`) and reused by `renderElement`, `RichTextElement`, and `ButtonElement`.
+
+---
+
 ## [1.38.0] - 2026-06-08
 
 ### Added

--- a/packages/onboarding-ui/package.json
+++ b/packages/onboarding-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocapine/react-native-onboarding-ui",
-  "version": "1.38.0",
+  "version": "1.38.1",
   "description": "UI components and renderers for Rocapine Onboarding Studio - Built on top of the headless SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/onboarding-ui/src/UI/Components/CircularProgress.tsx
+++ b/packages/onboarding-ui/src/UI/Components/CircularProgress.tsx
@@ -35,12 +35,20 @@ export const CircularProgress = ({
   const progress = useSharedValue(0);
   const [percentage, setPercentage] = useState(0);
 
-  // Update percentage text using useAnimatedReaction
+  // Update percentage text using useAnimatedReaction. Round *inside* the reader
+  // so the JS callback fires only when the displayed integer changes (~100 hops),
+  // not every frame — a per-frame setPercentage re-renders this component ~60×/s
+  // and the resulting mapper churn destabilizes other animations on the screen.
+  // The deps array ([]) is REQUIRED: without it reanimated tears down and rebuilds
+  // the mapper on every render, which also resets `prev` and defeats the guard.
   useAnimatedReaction(
-    () => progress.value,
-    (currentValue) => {
-      runOnJS(setPercentage)(Math.round(currentValue));
-    }
+    () => Math.round(progress.value),
+    (rounded, prev) => {
+      if (rounded !== prev) {
+        runOnJS(setPercentage)(rounded);
+      }
+    },
+    []
   );
 
   useEffect(() => {

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/Renderer.tsx
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/Renderer.tsx
@@ -40,12 +40,20 @@ const ComposableScreenRendererBase = ({ step, onContinue }: ContentProps) => {
     [elementDefaults, composableVariables]
   );
 
+  // Flatten variables to primitives once per render — renderElement reuses this
+  // for every element's renderWhen check instead of rebuilding it per element.
+  const flatVariables = useMemo(
+    () => Object.fromEntries(Object.entries(effectiveVariables).map(([k, v]) => [k, v?.value])),
+    [effectiveVariables]
+  );
+
   const renderChildren = (children: UIElement[], parentType: "XStack" | "YStack" | "ZStack" | "RichText" | "XScroll") =>
     children.map((child) => renderElement(child, ctx, parentType));
 
   const ctx: RenderContext = {
     theme,
     variables: effectiveVariables,
+    flatVariables,
     setVariable: setVariableAndSync,
     onContinue,
     customActions,

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/ButtonElement.tsx
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/ButtonElement.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { z } from "zod";
 import { Animated, Pressable, Text } from "react-native";
 import {
@@ -108,16 +108,9 @@ type Props = {
 };
 
 export const ButtonElementComponent = ({ element, ctx }: Props): React.ReactElement => {
-  const { theme, variables } = ctx;
-  const flatVariables = useMemo(
-    () =>
-      Object.fromEntries(
-        Object.entries(variables).map(([k, v]) => [k, v?.value])
-      ),
-    [variables]
-  );
+  const { theme } = ctx;
   const isDisabled = element.props.disabledWhen
-    ? evaluateCondition(element.props.disabledWhen, flatVariables)
+    ? evaluateCondition(element.props.disabledWhen, ctx.flatVariables)
     : false;
   const [isPressed, setIsPressed] = useState(false);
 

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/RichTextElement.tsx
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/RichTextElement.tsx
@@ -118,12 +118,9 @@ export const RichTextElementComponent = ({ element, ctx, parentType }: Props): R
   // words, keep chips whole. renderWhen is evaluated once per source child here
   // (flowing-text words then render unconditionally); chips keep their renderWhen
   // and are gated by renderElement.
-  const flatVars = Object.fromEntries(
-    Object.entries(ctx.variables).map(([k, v]) => [k, v?.value])
-  );
   const expanded: UIElement[] = [];
   for (const child of element.children) {
-    if (child.renderWhen && !evaluateCondition(child.renderWhen, flatVars)) continue;
+    if (child.renderWhen && !evaluateCondition(child.renderWhen, ctx.flatVariables)) continue;
 
     if (isFlowingText(child)) {
       const raw = child.props.content as string;

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/renderElement.tsx
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/renderElement.tsx
@@ -47,10 +47,7 @@ export const renderElement = (
   parentType?: "XStack" | "YStack" | "ZStack" | "RichText" | "XScroll"
 ): React.ReactNode => {
   if (element.renderWhen) {
-    const flatVars = Object.fromEntries(
-      Object.entries(ctx.variables).map(([k, v]) => [k, v?.value])
-    );
-    if (!evaluateCondition(element.renderWhen, flatVars)) return null;
+    if (!evaluateCondition(element.renderWhen, ctx.flatVariables)) return null;
   }
 
   // Dispatch to the concrete element renderer. Captured into `node` so a single

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/shared.ts
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/shared.ts
@@ -8,6 +8,11 @@ import type { BaseBoxProps } from "./BaseBoxProps";
 export type RenderContext = {
   theme: Theme;
   variables: Record<string, ComposableVariableEntry>;
+  // Variables flattened to primitives (entry.value), memoized once per render in
+  // Renderer. renderWhen / evaluateCondition want primitives; computing this per
+  // element rebuilt the object on every tree re-render (e.g. each autoplay
+  // ProgressIndicator step writes a variable → full re-render).
+  flatVariables: Record<string, unknown>;
   setVariable: (key: string, entry: ComposableVariableEntry) => void;
   onContinue: () => void;
   customActions: CustomActions;

--- a/packages/onboarding-ui/src/UI/Pages/Loader/Renderer.tsx
+++ b/packages/onboarding-ui/src/UI/Pages/Loader/Renderer.tsx
@@ -222,12 +222,21 @@ const StepProgress = ({ step, progress, theme }: StepProgressProps) => {
   const [barComplete, setBarComplete] = useState(false);
   const styles = createStyles(theme);
 
+  // Track the one-time transitions in refs, not the state being set, so the
+  // effect deps stay [progress] and the listener attaches exactly once. Keying
+  // on barStarted/barComplete (the very states the callback flips) re-ran the
+  // effect on each setState → listener torn down and re-added mid-animation.
+  const startedRef = useRef(false);
+  const completeRef = useRef(false);
+
   useEffect(() => {
     const listenerId = progress.addListener(({ value }) => {
-      if (value > 0 && !barStarted) {
+      if (value > 0 && !startedRef.current) {
+        startedRef.current = true;
         setBarStarted(true);
       }
-      if (value >= 1 && !barComplete) {
+      if (value >= 1 && !completeRef.current) {
+        completeRef.current = true;
         setBarComplete(true);
       }
     });
@@ -235,7 +244,7 @@ const StepProgress = ({ step, progress, theme }: StepProgressProps) => {
     return () => {
       progress.removeListener(listenerId);
     };
-  }, [progress, barStarted, barComplete]);
+  }, [progress]);
 
   const progressWidth = progress.interpolate({
     inputRange: [0, 1],

--- a/packages/onboarding/CHANGELOG.md
+++ b/packages/onboarding/CHANGELOG.md
@@ -8,6 +8,13 @@ All notable changes to `@rocapine/react-native-onboarding` are documented here.
 
 ---
 
+## [1.38.1] - 2026-06-08
+
+### Changed
+- **Version sync only** — no headless changes. Bumped in lockstep with `@rocapine/react-native-onboarding-ui` 1.38.1 (UI-side re-render fixes in the Loader animations and ComposableScreen render tree).
+
+---
+
 ## [1.38.0] - 2026-06-08
 
 ### Added

--- a/packages/onboarding/package.json
+++ b/packages/onboarding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocapine/react-native-onboarding",
-  "version": "1.38.0",
+  "version": "1.38.1",
   "description": "Headless React Native SDK for Rocapine Onboarding Studio - Data fetching, state management, and hooks",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

Fixes excessive React re-renders in the animation/transition paths.

### Loader animations
- **`CircularProgress`** — the percentage `useAnimatedReaction` rounded inside its JS callback, firing `setPercentage` **every frame (~60×/s)** and re-rendering the component continuously. It also had **no deps array**, so Reanimated rebuilt the mapper on every render (resetting `prev`). Now rounds inside the reader with a `prev` guard + `[]` deps → JS callback fires only when the displayed integer changes.
- **`StepProgress`** — the `progress.addListener` effect was keyed on `barStarted`/`barComplete`, the very states its callback flips, so each `setState` tore the listener down and re-attached it mid-animation. One-time transitions now live in refs; effect deps are `[progress]` (attaches once).

### ComposableScreen render tree
- `renderElement` rebuilt `flatVars` via `Object.fromEntries` for **every element on every tree re-render**. An autoplay `ProgressIndicator` writing a variable each step re-renders the whole tree, making this pure churn. Flatten is now memoized once in `Renderer` as `ctx.flatVariables` (added to `RenderContext`) and reused by `renderElement`, `RichTextElement`, `ButtonElement`.

### Release
- Bumped both packages + plugin 1.38.0 → 1.38.1, changelogs updated.

## Test plan
- `npm run build:ui` passes (tsc clean).
- No headless changes; headless vitest unaffected.
- Note: `StaggeredTextList` left untouched — `withTiming`-in-worklet is valid Reanimated (UI-thread, no React state/re-render).

🤖 Generated with [Claude Code](https://claude.com/claude-code)