### PR TITLE
🐛 Memoize AnimatedBox transition builders — entry animations no longer restart on re-render (v1.38.2)

### DIFF
--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-onboarding",
-  "version": "1.38.1",
+  "version": "1.38.2",
   "description": "End-to-end workflow for building and updating Rocapine Onboarding Studio flows: author step JSON, integrate the headless + UI SDKs, customize theme/components, and review onboarding quality.",
   "author": {
     "name": "Rocapine",

--- a/packages/onboarding-ui/CHANGELOG.md
+++ b/packages/onboarding-ui/CHANGELOG.md
@@ -9,6 +9,13 @@ here.
 
 ---
 
+## [1.38.2] - 2026-06-08
+
+### Fixed
+- **Entry transitions restarting on re-render** — `AnimatedBox` rebuilt its `entering`/`exiting`/`layout` reanimated builders inline on every render, handing `Animated.View` a fresh `entering` instance each time and re-firing the entry transition. With an autoplay `ProgressIndicator` on screen (writes its bound variable each step → re-renders the whole ComposableScreen tree), every sibling's entry animation visibly reloaded. The builders are now memoized on their (stable, from the memoized parsed step) spec objects.
+
+---
+
 ## [1.38.1] - 2026-06-08
 
 ### Fixed

--- a/packages/onboarding-ui/package.json
+++ b/packages/onboarding-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocapine/react-native-onboarding-ui",
-  "version": "1.38.1",
+  "version": "1.38.2",
   "description": "UI components and renderers for Rocapine Onboarding Studio - Built on top of the headless SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/AnimatedBox.tsx
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/AnimatedBox.tsx
@@ -56,9 +56,15 @@ export const AnimatedBox = ({
   alignSelf,
   children,
 }: Props): React.ReactElement => {
-  const entering = buildEntering(animation?.entering);
-  const exiting = buildExiting(animation?.exiting);
-  const layout = buildLayout(animation?.layout);
+  // Memoize the reanimated builders on their (stable) spec objects. Rebuilding
+  // them inline every render hands Animated.View a fresh `entering` instance,
+  // which re-fires the entry transition on every re-render — e.g. an autoplay
+  // ProgressIndicator writing its variable each step re-renders the whole tree,
+  // restarting every sibling's entry animation. The spec objects come from the
+  // memoized parsed step, so these references are stable across re-renders.
+  const entering = useMemo(() => buildEntering(animation?.entering), [animation?.entering]);
+  const exiting = useMemo(() => buildExiting(animation?.exiting), [animation?.exiting]);
+  const layout = useMemo(() => buildLayout(animation?.layout), [animation?.layout]);
 
   const effect = animation?.effect;
   const staticTransform = useMemo(() => buildStaticTransform(transform), [transform]);

--- a/packages/onboarding/CHANGELOG.md
+++ b/packages/onboarding/CHANGELOG.md
@@ -8,6 +8,13 @@ All notable changes to `@rocapine/react-native-onboarding` are documented here.
 
 ---
 
+## [1.38.2] - 2026-06-08
+
+### Changed
+- **Version sync only** — no headless changes. Bumped in lockstep with `@rocapine/react-native-onboarding-ui` 1.38.2 (UI-side fix: memoize `AnimatedBox` entering/exiting/layout builders so entry transitions don't restart on re-render).
+
+---
+
 ## [1.38.1] - 2026-06-08
 
 ### Changed

--- a/packages/onboarding/package.json
+++ b/packages/onboarding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocapine/react-native-onboarding",
-  "version": "1.38.1",
+  "version": "1.38.2",
   "description": "Headless React Native SDK for Rocapine Onboarding Studio - Data fetching, state management, and hooks",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

Entry transitions (`AnimatedBox` `entering`) reloaded whenever the ComposableScreen tree re-rendered — most visibly with an **autoplay `ProgressIndicator`** on screen.

**Root cause:** `AnimatedBox` rebuilt its `entering`/`exiting`/`layout` reanimated builders **inline on every render**, handing `Animated.View` a fresh `entering` instance each time → Reanimated re-fired the entry animation. An autoplay `ProgressIndicator` writes its bound variable each step → context update → whole ComposableScreen tree re-renders → every sibling's entry animation restarted.

**Fix:** memoize the three builders on their spec objects (`animation?.entering` / `exiting` / `layout`), which are stable across re-renders since they come from the memoized parsed step.

## Test plan
- `npm run build:ui` passes (tsc clean).
- No headless changes; headless version bumped in lockstep.

## Release
- 1.38.1 → 1.38.2 (both packages + plugin), changelogs updated.

> Follow-up to #78 (re-render fixes in Loader animations + ComposableScreen tree), which landed the `CircularProgress`, Loader `StepProgress`, and `ctx.flatVariables` fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)