### PR TITLE
✨ Background asset preloader for onboarding — SDK v1.40.0

### DIFF
--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-onboarding",
-  "version": "1.39.0",
+  "version": "1.40.0",
   "description": "End-to-end workflow for building and updating Rocapine Onboarding Studio flows: author step JSON, integrate the headless + UI SDKs, customize theme/components, and review onboarding quality.",
   "author": {
     "name": "Rocapine",

--- a/packages/onboarding-ui/CHANGELOG.md
+++ b/packages/onboarding-ui/CHANGELOG.md
@@ -9,6 +9,13 @@ here.
 
 ---
 
+## [1.40.0] - 2026-06-09
+
+### Changed
+- **Version sync only** — no UI changes. Bumped in lockstep with `@rocapine/react-native-onboarding` 1.40.0 (headless background asset preloader that warms remote image/video/Lottie/Rive/SVG assets from the payload after fetch). UI renderers are unchanged; preloaded assets are served from cache when each screen mounts.
+
+---
+
 ## [1.39.0] - 2026-06-08
 
 ### Added

--- a/packages/onboarding-ui/package.json
+++ b/packages/onboarding-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocapine/react-native-onboarding-ui",
-  "version": "1.39.0",
+  "version": "1.40.0",
   "description": "UI components and renderers for Rocapine Onboarding Studio - Built on top of the headless SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/onboarding/CHANGELOG.md
+++ b/packages/onboarding/CHANGELOG.md
@@ -8,6 +8,17 @@ All notable changes to `@rocapine/react-native-onboarding` are documented here.
 
 ---
 
+## [1.40.0] - 2026-06-09
+
+### Added
+- **Background asset preloader** — once the onboarding payload is fetched, every remote image/video/Lottie/Rive/SVG asset referenced anywhere in the flow is warmed in the background so later screens render without a load flash. Fully non-blocking (never gates first render) and always on (no config). Covers ComposableScreen element trees (`Image`/`ProgressiveBlurImage`/`Video`/`Lottie`/`Rive`, recursing through container children), `MediaContent`, `Carousel`, and `Loader` `didYouKnowImages`. Bundled assets (MediaSource `localPathId`) are skipped — only remote URLs are warmed.
+- **New exports** — `extractAssetUrls(onboarding)` (pure: returns deduped `AssetRef[]` of remote assets, safe on partial/malformed payloads) and `preloadAssets(assets)` (fire-and-forget; native image prefetch via expo-image/RN Image, HTTP-cache warm for video/Lottie/Rive/SVG with bounded concurrency). `AssetRef`/`AssetKind` types exported. Hosts can call these manually for custom preloading.
+
+### Changed
+- **`expo-image` added as an optional peer dependency** — used for batched image prefetch when present; falls back to `Image.prefetch` from react-native when absent. No-op if neither warms.
+
+---
+
 ## [1.39.0] - 2026-06-08
 
 ### Added

--- a/packages/onboarding/package.json
+++ b/packages/onboarding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocapine/react-native-onboarding",
-  "version": "1.39.0",
+  "version": "1.40.0",
   "description": "Headless React Native SDK for Rocapine Onboarding Studio - Data fetching, state management, and hooks",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -36,11 +36,15 @@
   },
   "peerDependencies": {
     "expo-font": "*",
+    "expo-image": "*",
     "react": "*",
     "react-native": "*"
   },
   "peerDependenciesMeta": {
     "expo-font": {
+      "optional": true
+    },
+    "expo-image": {
       "optional": true
     }
   },

--- a/packages/onboarding/src/__tests__/extractAssetUrls.test.ts
+++ b/packages/onboarding/src/__tests__/extractAssetUrls.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect } from "vitest";
+import { extractAssetUrls, type AssetRef } from "../infra/preload/extractAssetUrls";
+
+// Helper: wrap steps in a minimal Onboarding-shaped object.
+const onb = (steps: any[]) => ({ steps }) as any;
+
+const byUrl = (assets: AssetRef[]) =>
+  Object.fromEntries(assets.map((a) => [a.url, a.kind]));
+
+describe("extractAssetUrls — ComposableScreen element tree", () => {
+  it("pulls url/source from leaf asset elements with correct kinds", () => {
+    const step = {
+      type: "ComposableScreen",
+      payload: {
+        elements: [
+          { type: "Image", props: { url: "https://cdn/img.png" } },
+          { type: "ProgressiveBlurImage", props: { url: "https://cdn/blur.jpg" } },
+          { type: "Video", props: { url: "https://cdn/clip.mp4" } },
+          { type: "Lottie", props: { source: "https://cdn/anim.json" } },
+          { type: "Rive", props: { url: "https://cdn/anim.riv" } },
+          { type: "Text", props: { content: "no asset" } },
+        ],
+      },
+    };
+    expect(byUrl(extractAssetUrls(onb([step])))).toEqual({
+      "https://cdn/img.png": "image",
+      "https://cdn/blur.jpg": "image",
+      "https://cdn/clip.mp4": "video",
+      "https://cdn/anim.json": "lottie",
+      "https://cdn/anim.riv": "rive",
+    });
+  });
+
+  it("recurses into nested container children", () => {
+    const step = {
+      type: "ComposableScreen",
+      payload: {
+        elements: [
+          {
+            type: "YStack",
+            props: {
+              children: [
+                { type: "Image", props: { url: "https://cdn/a.png" } },
+                {
+                  type: "ScrollView",
+                  props: {
+                    children: [{ type: "Video", props: { url: "https://cdn/deep.mp4" } }],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    };
+    const assets = extractAssetUrls(onb([step]));
+    expect(assets.map((a) => a.url).sort()).toEqual([
+      "https://cdn/a.png",
+      "https://cdn/deep.mp4",
+    ]);
+  });
+
+  it("tags .svg image urls as image-svg (query/hash tolerant)", () => {
+    const step = {
+      type: "ComposableScreen",
+      payload: {
+        elements: [
+          { type: "Image", props: { url: "https://cdn/icon.svg" } },
+          { type: "Image", props: { url: "https://cdn/icon2.svg?v=2#frag" } },
+        ],
+      },
+    };
+    const kinds = extractAssetUrls(onb([step])).map((a) => a.kind);
+    expect(kinds).toEqual(["image-svg", "image-svg"]);
+  });
+});
+
+describe("extractAssetUrls — other step types", () => {
+  it("MediaContent: uses MediaSource.type as kind, skips localPathId", () => {
+    const steps = [
+      { type: "MediaContent", payload: { mediaSource: { type: "video", url: "https://cdn/m.mp4" } } },
+      { type: "MediaContent", payload: { mediaSource: { type: "image", localPathId: "bundled-1" } } },
+      { type: "MediaContent", payload: { mediaSource: { type: "lottie", url: "https://cdn/m.json" } } },
+    ];
+    expect(byUrl(extractAssetUrls(onb(steps)))).toEqual({
+      "https://cdn/m.mp4": "video",
+      "https://cdn/m.json": "lottie",
+    });
+  });
+
+  it("Carousel: screens[].mediaUrl as images", () => {
+    const step = {
+      type: "Carousel",
+      payload: {
+        screens: [
+          { mediaUrl: "https://cdn/c1.png", title: "a" },
+          { mediaUrl: "https://cdn/c2.png", title: "b" },
+        ],
+      },
+    };
+    expect(byUrl(extractAssetUrls(onb([step])))).toEqual({
+      "https://cdn/c1.png": "image",
+      "https://cdn/c2.png": "image",
+    });
+  });
+
+  it("Loader: didYouKnowImages MediaSource array, skips localPathId", () => {
+    const step = {
+      type: "Loader",
+      payload: {
+        title: "t",
+        steps: [],
+        didYouKnowImages: [
+          { type: "image", url: "https://cdn/dyk.png" },
+          { type: "image", localPathId: "bundled-2" },
+        ],
+      },
+    };
+    expect(byUrl(extractAssetUrls(onb([step])))).toEqual({
+      "https://cdn/dyk.png": "image",
+    });
+  });
+});
+
+describe("extractAssetUrls — robustness", () => {
+  it("dedupes repeated urls (first kind wins)", () => {
+    const step = {
+      type: "ComposableScreen",
+      payload: {
+        elements: [
+          { type: "Image", props: { url: "https://cdn/dup.png" } },
+          { type: "Image", props: { url: "https://cdn/dup.png" } },
+        ],
+      },
+    };
+    expect(extractAssetUrls(onb([step]))).toEqual([
+      { url: "https://cdn/dup.png", kind: "image" },
+    ]);
+  });
+
+  it("skips empty/missing urls", () => {
+    const step = {
+      type: "ComposableScreen",
+      payload: {
+        elements: [
+          { type: "Image", props: { url: "" } },
+          { type: "Image", props: {} },
+          { type: "Lottie", props: { source: null } },
+        ],
+      },
+    };
+    expect(extractAssetUrls(onb([step]))).toEqual([]);
+  });
+
+  it("returns [] for null/empty/malformed onboarding", () => {
+    expect(extractAssetUrls(null)).toEqual([]);
+    expect(extractAssetUrls(undefined)).toEqual([]);
+    expect(extractAssetUrls(onb([]))).toEqual([]);
+    expect(extractAssetUrls({ steps: "not-array" } as any)).toEqual([]);
+  });
+
+  it("one malformed step does not abort extraction of the rest", () => {
+    const steps = [
+      { type: "ComposableScreen", get payload(): any { throw new Error("boom"); } },
+      { type: "Image", payload: undefined },
+      { type: "MediaContent", payload: { mediaSource: { type: "image", url: "https://cdn/ok.png" } } },
+    ];
+    expect(byUrl(extractAssetUrls(onb(steps)))).toEqual({
+      "https://cdn/ok.png": "image",
+    });
+  });
+});

--- a/packages/onboarding/src/infra/index.ts
+++ b/packages/onboarding/src/infra/index.ts
@@ -1,3 +1,4 @@
 export * from "./provider";
 export * from "./hooks";
 export * from "./fonts";
+export * from "./preload";

--- a/packages/onboarding/src/infra/preload/extractAssetUrls.ts
+++ b/packages/onboarding/src/infra/preload/extractAssetUrls.ts
@@ -1,0 +1,148 @@
+import type { BaseStepType, Onboarding } from "../../types";
+
+/**
+ * A remote asset referenced somewhere in an onboarding payload.
+ *
+ * `kind` selects how {@link preloadAssets} warms it:
+ * - `image`     → native image prefetch (expo-image / RN Image)
+ * - `image-svg` → HTTP-cache warm (SvgUri fetches the XML itself; native image
+ *                 prefetch can't decode SVG)
+ * - `video` / `lottie` / `rive` → HTTP-cache warm
+ */
+export type AssetKind = "image" | "image-svg" | "video" | "lottie" | "rive";
+
+export interface AssetRef {
+  url: string;
+  kind: AssetKind;
+}
+
+// `.svg` path-extension detection, query/hash tolerant. Mirrors the local
+// `isSvgUrl` in onboarding-ui's ImageElement.tsx (not exported from UI).
+const isSvgUrl = (url: string): boolean =>
+  url.split(/[?#]/)[0].toLowerCase().endsWith(".svg");
+
+// MediaSource.type → AssetKind. Images get re-tagged to `image-svg` by the
+// caller when the url is an SVG.
+const mediaTypeToKind = (type: unknown): AssetKind => {
+  switch (type) {
+    case "video":
+      return "video";
+    case "lottie":
+      return "lottie";
+    case "rive":
+      return "rive";
+    default:
+      return "image";
+  }
+};
+
+// Push a url with kind, re-tagging SVG images so the runner HTTP-warms them.
+const pushAsset = (out: AssetRef[], url: unknown, kind: AssetKind): void => {
+  if (typeof url !== "string" || url.length === 0) return;
+  const finalKind: AssetKind = kind === "image" && isSvgUrl(url) ? "image-svg" : kind;
+  out.push({ url, kind: finalKind });
+};
+
+// A `{ type, url }` MediaSource is remote (prefetchable); a `{ type, localPathId }`
+// MediaSource is a bundled asset — skip it.
+const pushMediaSource = (out: AssetRef[], media: any): void => {
+  if (!media || typeof media !== "object") return;
+  if (typeof media.url !== "string") return; // localPathId variant or malformed
+  pushAsset(out, media.url, mediaTypeToKind(media.type));
+};
+
+// Walk a ComposableScreen UIElement tree. Asset-bearing element types pull their
+// url/source prop; container types recurse into `props.children`.
+const walkElement = (out: AssetRef[], element: any): void => {
+  if (!element || typeof element !== "object") return;
+  const props = element.props ?? {};
+
+  switch (element.type) {
+    case "Image":
+    case "ProgressiveBlurImage":
+      pushAsset(out, props.url, "image");
+      break;
+    case "Video":
+      pushAsset(out, props.url, "video");
+      break;
+    case "Lottie":
+      pushAsset(out, props.source, "lottie");
+      break;
+    case "Rive":
+      pushAsset(out, props.url, "rive");
+      break;
+    default:
+      break;
+  }
+
+  if (Array.isArray(props.children)) {
+    for (const child of props.children) walkElement(out, child);
+  }
+};
+
+// Collect every remote asset from one step. Defensive: a malformed step throws
+// here and is swallowed by the per-step guard in extractAssetUrls.
+const extractFromStep = (out: AssetRef[], step: BaseStepType): void => {
+  const payload: any = step.payload;
+  if (!payload) return;
+
+  switch (step.type) {
+    case "ComposableScreen":
+      if (Array.isArray(payload.elements)) {
+        for (const el of payload.elements) walkElement(out, el);
+      }
+      break;
+    case "MediaContent":
+      pushMediaSource(out, payload.mediaSource);
+      break;
+    case "Carousel":
+      if (Array.isArray(payload.screens)) {
+        for (const screen of payload.screens) pushAsset(out, screen?.mediaUrl, "image");
+      }
+      break;
+    case "Loader":
+      if (Array.isArray(payload.didYouKnowImages)) {
+        for (const media of payload.didYouKnowImages) pushMediaSource(out, media);
+      }
+      break;
+    default:
+      break;
+  }
+};
+
+/**
+ * Extract every remote asset referenced by an onboarding payload, deduped by url.
+ *
+ * Covers ComposableScreen element trees (Image / ProgressiveBlurImage / Video /
+ * Lottie / Rive, recursing through container children), MediaContent, Carousel,
+ * and Loader. Bundled assets (MediaSource `localPathId`) are skipped — only
+ * remote `url`s are returned.
+ *
+ * Pure and side-effect free; safe to call on partial/malformed payloads (each
+ * step is guarded independently).
+ */
+export const extractAssetUrls = <StepType extends BaseStepType>(
+  onboarding: Onboarding<StepType> | null | undefined
+): AssetRef[] => {
+  const steps = onboarding?.steps;
+  if (!Array.isArray(steps)) return [];
+
+  const collected: AssetRef[] = [];
+  for (const step of steps) {
+    try {
+      extractFromStep(collected, step);
+    } catch {
+      // One malformed step must not abort preloading the rest.
+    }
+  }
+
+  // Dedupe by url (first kind seen wins).
+  const seen = new Set<string>();
+  const deduped: AssetRef[] = [];
+  for (const asset of collected) {
+    if (seen.has(asset.url)) continue;
+    seen.add(asset.url);
+    deduped.push(asset);
+  }
+  return deduped;
+};

--- a/packages/onboarding/src/infra/preload/index.ts
+++ b/packages/onboarding/src/infra/preload/index.ts
@@ -1,0 +1,3 @@
+export { extractAssetUrls } from "./extractAssetUrls";
+export type { AssetRef, AssetKind } from "./extractAssetUrls";
+export { preloadAssets } from "./preloadAssets";

--- a/packages/onboarding/src/infra/preload/preloadAssets.ts
+++ b/packages/onboarding/src/infra/preload/preloadAssets.ts
@@ -1,0 +1,95 @@
+import { Image as RNImage } from "react-native";
+import type { AssetRef } from "./extractAssetUrls";
+
+declare const __DEV__: boolean;
+
+// expo-image (optional peer dep) gives reliable cross-platform image caching.
+// Require-guarded exactly like onboarding-ui's ImageElement — fall back to RN
+// Image.prefetch when absent.
+let ExpoImage: { prefetch?: (urls: string | string[]) => Promise<unknown> } | null = null;
+try {
+  ExpoImage = require("expo-image").Image;
+} catch {
+  // expo-image not installed — RN Image.prefetch fallback below.
+}
+
+// Cap concurrent HTTP-warm fetches so we don't saturate the connection while the
+// user is interacting with the first screen.
+const FETCH_CONCURRENCY = 4;
+
+// Warm the OS/CDN HTTP cache for a non-image asset. expo-video /
+// lottie-react-native / rive-react-native / SvgUri all load from the URL at
+// mount, so a cached response makes them appear instantly. For video we abort
+// after the first chunk to avoid pulling the whole file into memory.
+const warmHttpCache = async (ref: AssetRef): Promise<void> => {
+  const controller = typeof AbortController !== "undefined" ? new AbortController() : undefined;
+  try {
+    const res = await fetch(ref.url, controller ? { signal: controller.signal } : undefined);
+    if (ref.kind === "video") {
+      // Touch the body so the request is real, then abort — establishes the
+      // connection and warms the CDN edge without downloading the full video.
+      controller?.abort();
+      return;
+    }
+    // Drain small JSON/binary/SVG bodies fully so they land in the cache.
+    if (typeof res.arrayBuffer === "function") await res.arrayBuffer();
+  } catch {
+    // Best-effort: aborted reads and network errors are expected and silent.
+  }
+};
+
+// Run thunks with bounded concurrency.
+const runPool = (thunks: Array<() => Promise<void>>, limit: number): void => {
+  let i = 0;
+  const next = (): void => {
+    if (i >= thunks.length) return;
+    const thunk = thunks[i++];
+    thunk().finally(next);
+  };
+  for (let n = 0; n < Math.min(limit, thunks.length); n++) next();
+};
+
+/**
+ * Fire-and-forget background prefetch of onboarding assets. Returns immediately;
+ * all work is async and best-effort (failures are swallowed). Safe to call with
+ * an empty list.
+ *
+ * - `image`   → native prefetch via expo-image (batched) or RN Image.prefetch.
+ * - everything else → HTTP-cache warm via `fetch`, concurrency-capped.
+ */
+export const preloadAssets = (assets: AssetRef[]): void => {
+  if (!assets || assets.length === 0) return;
+
+  const imageUrls: string[] = [];
+  const warmThunks: Array<() => Promise<void>> = [];
+
+  for (const asset of assets) {
+    if (asset.kind === "image") imageUrls.push(asset.url);
+    else warmThunks.push(() => warmHttpCache(asset));
+  }
+
+  // Images: prefer expo-image's batch prefetch; otherwise RN per-url.
+  if (imageUrls.length > 0) {
+    try {
+      if (ExpoImage?.prefetch) {
+        Promise.resolve(ExpoImage.prefetch(imageUrls)).catch(() => {});
+      } else {
+        for (const url of imageUrls) {
+          Promise.resolve(RNImage.prefetch(url)).catch(() => {});
+        }
+      }
+    } catch {
+      // Prefetch unavailable — silent no-op.
+    }
+  }
+
+  // Non-image assets: bounded HTTP-cache warming.
+  if (warmThunks.length > 0) runPool(warmThunks, FETCH_CONCURRENCY);
+
+  if (typeof __DEV__ !== "undefined" && __DEV__) {
+    // eslint-disable-next-line no-console
+    console.info(
+      `[onboarding] preloading ${imageUrls.length} image(s) + ${warmThunks.length} other asset(s)`
+    );
+  }
+};

--- a/packages/onboarding/src/infra/provider/OnboardingProvider.tsx
+++ b/packages/onboarding/src/infra/provider/OnboardingProvider.tsx
@@ -1,4 +1,4 @@
-import { createContext, useCallback, useRef, useState } from "react";
+import { createContext, useCallback, useEffect, useRef, useState } from "react";
 import { QueryClient, QueryClientProvider, useQuery } from "@tanstack/react-query";
 import { OnboardingStudioClient } from "../../OnboardingStudioClient";
 import { getOnboardingQuery } from "../queries/getOnboarding.query";
@@ -6,6 +6,8 @@ import { Onboarding } from "../../types";
 import { OnboardingStepType } from "../../steps/types";
 import { ComposableVariableEntry } from "../../steps/ComposableScreen/types";
 import { FontLoaderGate } from "./FontLoader";
+import { extractAssetUrls } from "../preload/extractAssetUrls";
+import { preloadAssets } from "../preload/preloadAssets";
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -61,6 +63,18 @@ const OnboardingDataGate = ({
   const { data, error } = useQuery<Onboarding<OnboardingStepType>>(
     getOnboardingQuery<OnboardingStepType>(client, locale, customAudienceParams, setOnboarding)
   );
+
+  // Background asset preload: once the payload is available, warm every remote
+  // image/video/Lottie/Rive asset so later screens render without a load flash.
+  // Fire-and-forget and non-blocking — does NOT gate the FontLoaderGate render.
+  // Runs once per payload (the query reference is stable thanks to staleTime:
+  // Infinity, whether `data` came from cache or the network).
+  const preloadedRef = useRef<Onboarding<OnboardingStepType> | null>(null);
+  useEffect(() => {
+    if (!data || preloadedRef.current === data) return;
+    preloadedRef.current = data;
+    preloadAssets(extractAssetUrls(data));
+  }, [data]);
 
   if (error) throw error;
   if (!data) return <>{fontsFallback ?? null}</>;


### PR DESCRIPTION
## What

Warm every remote **image / video / Lottie / Rive / SVG** asset referenced anywhere in an onboarding right after the payload is fetched, so later screens render without a load flash.

- **Fully background** — never gates first render (TTI unchanged).
- **All asset types** — images, videos, Lottie, Rive, SVG.
- **Always on** — no config surface.

## How

- **`extractAssetUrls(onboarding)`** (headless, pure + tested) — walks `Onboarding.steps`: ComposableScreen element tree (recursing `props.children`) + `MediaContent` / `Carousel` / `Loader.didYouKnowImages`. Dedupes by url, skips bundled `localPathId` assets, tags `.svg` as `image-svg`.
- **`preloadAssets(assets)`** (fire-and-forget) — expo-image batch `prefetch` (RN `Image.prefetch` fallback) for images; bounded-concurrency (4) `fetch` HTTP-cache warm for video/Lottie/Rive/SVG. All silent best-effort.
- Hooked into `OnboardingDataGate` via a once-per-payload `useEffect` — runs for cache or network data, does **not** gate `FontLoaderGate`.
- `expo-image` added as **optional** peer dep of the headless package.
- New exports: `extractAssetUrls`, `preloadAssets`, `AssetRef` / `AssetKind`.

No UIElement schema change → no studio-sync / schema-mirror needed.

## Release

`1.39.0 → 1.40.0` (minor) across both packages + plugin.json; both CHANGELOGs updated. Not published.

## Verification

- `npm test --workspace=packages/onboarding` — 105 pass (new extraction tests: kinds, recursion, dedupe, localPathId-skip, malformed-step robustness).
- `npm run build` — both packages compile clean.
- ⚠️ Live example-app network/cache check not run (needs sim/device).

🤖 Generated with [Claude Code](https://claude.com/claude-code)