### PR TITLE
🐛 Apply static transform from frame 0 alongside entering animation — v1.41.1

### DIFF
--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-onboarding",
-  "version": "1.40.0",
+  "version": "1.41.1",
   "description": "End-to-end workflow for building and updating Rocapine Onboarding Studio flows: author step JSON, integrate the headless + UI SDKs, customize theme/components, and review onboarding quality.",
   "author": {
     "name": "Rocapine",

--- a/example/app/example/composable-screen-anim-transform.tsx
+++ b/example/app/example/composable-screen-anim-transform.tsx
@@ -1,0 +1,176 @@
+import * as OnboardingUi from '@rocapine/react-native-onboarding-ui';
+import { View, Pressable, Text, StyleSheet } from 'react-native';
+import { useRouter } from 'expo-router';
+import { useState } from 'react';
+
+export const unstable_settings = {
+  anchor: '(tabs)',
+};
+
+// A card that BOTH enters (reanimated `entering` builder) AND carries a static
+// `transform`. Each card pairs an entering preset with a persistent transform.
+// Before the fix, reanimated's entering builder owned the wrapper's transform
+// for the duration of the entry, so the static transform only snapped in after
+// the animation finished. Now AnimatedBox nests the two onto separate views, so
+// the transform is applied from frame 0 and the entry plays on top of it.
+// Hit ↻ Replay to remount and re-fire every entry — the tilt/scale must hold
+// the whole time, never snapping at the end.
+const card = (
+  id: string,
+  label: string,
+  preset: string,
+  transform: Record<string, number>,
+  delay: number,
+  color: string
+) => ({
+  id,
+  type: 'YStack' as const,
+  props: {
+    padding: 18,
+    gap: 4,
+    borderRadius: 16,
+    alignSelf: 'center' as const,
+    backgroundColor: color,
+    transform,
+    animation: {
+      entering: { preset: preset as any, duration: 600, delay, easing: 'ease-out' as const },
+    },
+  },
+  children: [
+    {
+      id: `${id}-label`,
+      type: 'Text' as const,
+      props: { content: label, fontSize: 15, fontWeight: '700' as const, color: '#fff', textAlign: 'center' as const },
+    },
+    {
+      id: `${id}-sub`,
+      type: 'Text' as const,
+      props: { content: `${preset} + ${Object.entries(transform).map(([k, v]) => `${k} ${v}`).join(', ')}`, fontSize: 12, color: '#fff', opacity: 0.8, textAlign: 'center' as const },
+    },
+  ],
+});
+
+export default function ComposableScreenAnimTransformExample() {
+  const router = useRouter();
+  // Bumping this key remounts the renderer, re-firing every `entering` animation.
+  const [replayKey, setReplayKey] = useState(0);
+
+  const step = {
+    id: 'composable-screen-anim-transform',
+    type: 'ComposableScreen',
+    name: 'Entering + Transform',
+    displayProgressHeader: true,
+    payload: {
+      elements: [
+        {
+          id: 'safe-root',
+          type: 'SafeAreaView' as const,
+          props: { flex: 1, edges: ['top', 'bottom'] as ('top' | 'right' | 'bottom' | 'left')[] },
+          children: [
+            {
+              id: 'scroll-root',
+              type: 'ScrollView' as const,
+              props: { flex: 1, showsVerticalScrollIndicator: false },
+              children: [
+                {
+                  id: 'root',
+                  type: 'YStack',
+                  props: { gap: 20, padding: 24 },
+                  children: [
+                    {
+                      id: 'title',
+                      type: 'Text' as const,
+                      props: {
+                        content: 'Entering + Transform',
+                        fontSize: 28,
+                        fontWeight: '700' as const,
+                      },
+                    },
+                    {
+                      id: 'subtitle',
+                      type: 'Text' as const,
+                      props: {
+                        content: 'Each card enters AND holds a static transform from frame 0 — the transform no longer waits for the entry to finish. Hit ↻ Replay.',
+                        fontSize: 14,
+                        lineHeight: 20,
+                        opacity: 0.6,
+                      },
+                    },
+                    card('c1', 'Fade in + tilt', 'FadeInDown', { rotate: -4 }, 150, '#1E293B'),
+                    card('c2', 'Slide in + scale', 'SlideInLeft', { scale: 1.1 }, 300, '#6C63FF'),
+                    card('c3', 'Zoom in + tilt + scale', 'ZoomIn', { rotate: 5, scale: 1.05 }, 450, '#E11D48'),
+                    card('c4', 'Bounce in + shift', 'BounceInUp', { translateY: -6 }, 600, '#10B981'),
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    customPayload: null,
+    continueButtonLabel: 'Continue',
+    figmaUrl: null,
+  } satisfies OnboardingUi.ComposableScreenStepType;
+
+  return (
+    <View style={{ flex: 1 }}>
+      {/* `key` remount re-fires every entering animation. */}
+      <OnboardingUi.ComposableScreenRenderer key={replayKey} step={step} onContinue={() => router.back()} />
+      <Pressable style={styles.replayButton} onPress={() => setReplayKey((k) => k + 1)}>
+        <Text style={styles.replayButtonText}>↻ Replay</Text>
+      </Pressable>
+      <Pressable style={styles.backButton} onPress={() => router.back()}>
+        <Text style={styles.backButtonText}>‹</Text>
+      </Pressable>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  backButton: {
+    position: 'absolute',
+    top: 50,
+    left: 20,
+    width: 32,
+    height: 32,
+    backgroundColor: 'rgba(255, 255, 255, 0.9)',
+    borderRadius: 16,
+    alignItems: 'center',
+    justifyContent: 'center',
+    zIndex: 1000,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.1,
+    shadowRadius: 4,
+    elevation: 3,
+  },
+  backButtonText: {
+    color: '#007AFF',
+    fontSize: 32,
+    fontWeight: '400',
+    lineHeight: 32,
+  },
+  replayButton: {
+    position: 'absolute',
+    top: 50,
+    right: 20,
+    paddingHorizontal: 14,
+    height: 32,
+    backgroundColor: 'rgba(255, 255, 255, 0.95)',
+    borderRadius: 16,
+    alignItems: 'center',
+    justifyContent: 'center',
+    zIndex: 1000,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.1,
+    shadowRadius: 4,
+    elevation: 3,
+  },
+  replayButtonText: {
+    color: '#007AFF',
+    fontSize: 14,
+    fontWeight: '600',
+  },
+});

--- a/example/app/example/index.tsx
+++ b/example/app/example/index.tsx
@@ -30,6 +30,7 @@ const examples: Example[] = [
       { name: "Keyboard", route: "/example/composable-screen-keyboard" },
       { name: "Runtime Fonts", route: "/example/composable-screen-fonts" },
       { name: "Animations", route: "/example/composable-screen-animations" },
+      { name: "Entering + Transform", route: "/example/composable-screen-anim-transform" },
       { name: "Re-render Isolation", route: "/example/composable-screen-rerender" },
       { name: "All", route: "/example/composable-screen" },
     ],

--- a/packages/onboarding-ui/CHANGELOG.md
+++ b/packages/onboarding-ui/CHANGELOG.md
@@ -9,6 +9,14 @@ here.
 
 ---
 
+## [1.41.1] - 2026-06-09
+
+### Fixed
+
+- **Static `transform` now applies from frame 0 when an element also has an entering animation** — reanimated's `entering`/`exiting`/`layout` builders take over the host view's transform for the duration of the transition, so a static `transform` (or continuous `effect`) placed on the same `AnimatedBox` view was suppressed until the entry finished, then snapped in. `AnimatedBox` now nests the two onto separate views when a reanimated builder is present: the outer (parent-facing) view keeps `flex`/`alignSelf` + the builder, the inner view carries the static transform/effect — so they stack instead of fighting. No-builder elements (transform/effect only) keep the single-view fast path.
+
+---
+
 ## [1.41.0] - 2026-06-09
 
 ### Added

--- a/packages/onboarding-ui/package.json
+++ b/packages/onboarding-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocapine/react-native-onboarding-ui",
-  "version": "1.41.0",
+  "version": "1.41.1",
   "description": "UI components and renderers for Rocapine Onboarding Studio - Built on top of the headless SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/AnimatedBox.tsx
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/AnimatedBox.tsx
@@ -126,14 +126,35 @@ export const AnimatedBox = ({
     }
   }, [effect, staticTransform]);
 
+  // Reanimated's entering/exiting/layout builders take over the host view's
+  // transform for the duration of the transition — so a static `transform` (or
+  // continuous `effect`) placed on the SAME view is suppressed until the entry
+  // animation finishes, then snaps in. When a builder is present, split the two
+  // onto nested views: the outer (parent-facing) view keeps flex/alignSelf +
+  // the reanimated builder, the inner view carries the static transform/effect
+  // so it applies from frame 0 and persists. They stack instead of fighting.
+  const hasBuilder = !!(animation?.entering || animation?.exiting || animation?.layout);
+
+  if (!hasBuilder) {
+    return (
+      <Animated.View style={[{ flex, alignSelf }, animatedStyle]}>
+        {children}
+      </Animated.View>
+    );
+  }
+
   return (
     <Animated.View
       entering={entering}
       exiting={exiting}
       layout={layout}
-      style={[{ flex, alignSelf }, animatedStyle]}
+      style={{ flex, alignSelf }}
     >
-      {children}
+      {/* flex:1 so the transform view fills the flexed outer wrapper; when the
+          outer is content-sized (no flex) the inner is too. */}
+      <Animated.View style={[animatedStyle, { flex: flex != null ? 1 : undefined }]}>
+        {children}
+      </Animated.View>
     </Animated.View>
   );
 };

--- a/packages/onboarding/CHANGELOG.md
+++ b/packages/onboarding/CHANGELOG.md
@@ -8,6 +8,14 @@ All notable changes to `@rocapine/react-native-onboarding` are documented here.
 
 ---
 
+## [1.41.1] - 2026-06-09
+
+### Changed
+
+- **Version sync only** — no headless changes. Bumped in lockstep with `@rocapine/react-native-onboarding-ui` 1.41.1 (fixes a static `transform` being suppressed until an element's entering animation finished).
+
+---
+
 ## [1.41.0] - 2026-06-09
 
 ### Added

--- a/packages/onboarding/package.json
+++ b/packages/onboarding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocapine/react-native-onboarding",
-  "version": "1.41.0",
+  "version": "1.41.1",
   "description": "Headless React Native SDK for Rocapine Onboarding Studio - Data fetching, state management, and hooks",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Problem

When a ComposableScreen element had **both** an entering animation and a static `transform`, the transform only applied **after** the entry animation finished — snapping into place at the end instead of holding from the first frame.

## Cause

Reanimated's `entering`/`exiting`/`layout` builders take over the host view's transform for the duration of the transition. `AnimatedBox` placed both the builder and the static `transform` (via `animatedStyle`) on the **same** `Animated.View`, so the builder owned the transform until the entry completed.

## Fix

`AnimatedBox` now nests the two onto separate views when a reanimated builder is present:
- **outer** (parent-facing) view keeps `flex`/`alignSelf` + the entering/exiting/layout builder
- **inner** view carries the static `transform` + continuous `effect`

They stack instead of fighting, so the transform applies from frame 0 and the entry plays on top of it. Elements with transform/effect only (no builder) keep the single-view fast path — zero extra view.

## Example

New **"Entering + Transform"** example screen (`example/app/example/composable-screen-anim-transform.tsx`, registered under Composable Screen) — four cards each pairing an entering preset with a persistent transform, plus a ↻ Replay button to re-fire the entries and confirm the tilt/scale holds the whole time.

## Verification

- Both packages build clean (tsc) at 1.41.1
- Example app typechecks clean
- iOS Metro bundle compiles with the fix + new screen wired in

🤖 Generated with [Claude Code](https://claude.com/claude-code)