### PR TITLE
🐛 Apply shadow* props on XStack/YStack/ZStack containers — v1.41.2

### DIFF
--- a/.claude/rules/composable-screen-runtime.md
+++ b/.claude/rules/composable-screen-runtime.md
@@ -125,6 +125,8 @@ Beyond the schema-mirror checklist in the root CLAUDE.md, a container needs its 
 
 A view with `overflow: hidden` (default for `Image`, gradient wrappers, many container styles) clips its own shadow on iOS, so the shadow renders invisible. For elements that want a shadow, build a wrapper View that carries `shadow*` + layout (no overflow clip) and let the inner content carry `borderRadius` + `overflow: hidden` for corner clipping. See `ImageElement.tsx` / `ButtonElement.tsx`. Also: when only `shadowColor` is set, default `shadowOpacity:1`, `shadowRadius:4` — iOS defaults opacity to 0 so a lone `shadowColor` does nothing.
 
+`shadow*` is a `BaseBoxProps` field, but — unlike `animation`/`transform` (wired once in `renderElement`) — it is **not** applied centrally. Each container renderer that builds its own `containerStyle` must `...buildShadowStyle(p)` (from `shared.ts`) explicitly, or shadow props parse fine and silently render nothing. Wired in: `ButtonElement`, `ImageElement`, `StackElement` (XStack/YStack), `ZStackElement`. **Still missing** (add when shadow is needed there): `ScrollViewElement`, `RichTextElement`, `TextElement`, `KeyboardAvoidingViewElement`. When adding a new container/box renderer, spread `buildShadowStyle(p)` alongside the other box props.
+
 ## RN treats `padding` and `padding{Horizontal,Vertical}` independently
 
 `style={{ padding: eff.padding, paddingHorizontal: eff.paddingHorizontal ?? 24 }}` will still apply 24 when payload sets `padding: 0`, because the axis prop's `??` fallback ignores the shorthand. Gate axis defaults on `eff.padding != null ? undefined : <default>` so explicit `padding:0` actually wins. Same gotcha for `margin`.

--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-onboarding",
-  "version": "1.41.1",
+  "version": "1.41.2",
   "description": "End-to-end workflow for building and updating Rocapine Onboarding Studio flows: author step JSON, integrate the headless + UI SDKs, customize theme/components, and review onboarding quality.",
   "author": {
     "name": "Rocapine",

--- a/example/app/example/composable-screen.tsx
+++ b/example/app/example/composable-screen.tsx
@@ -524,6 +524,40 @@ export default function ComposableScreenExample() {
                 },
               ],
             },
+            // Shadowed YStack card (verifies BaseBoxProps shadow* on containers)
+            {
+              id: 'card-shadow',
+              type: 'YStack',
+              props: {
+                padding: 16,
+                gap: 8,
+                marginVertical: 8,
+                borderRadius: 12,
+                backgroundColor: '#FFFFFF',
+                shadowColor: '#000000',
+                shadowOffset: { width: 0, height: 4 },
+                shadowOpacity: 0.2,
+                shadowRadius: 8,
+                elevation: 4,
+              },
+              children: [
+                {
+                  id: 'card-shadow-title',
+                  type: 'Text',
+                  props: { content: 'Shadow', fontSize: 13, fontWeight: '600' },
+                },
+                {
+                  id: 'card-shadow-body',
+                  type: 'Text',
+                  props: {
+                    content: 'shadowColor, shadowOffset, shadowOpacity, shadowRadius, elevation on a YStack',
+                    fontSize: 12,
+                    lineHeight: 18,
+                    opacity: 0.6,
+                  },
+                },
+              ],
+            },
             // Radio group element
             {
               id: 'hero-radio',

--- a/packages/onboarding-ui/CHANGELOG.md
+++ b/packages/onboarding-ui/CHANGELOG.md
@@ -9,6 +9,14 @@ here.
 
 ---
 
+## [1.41.2] - 2026-06-10
+
+### Fixed
+
+- **`shadow*` props now render on `XStack` / `YStack` / `ZStack` containers** — `buildShadowStyle` was only wired into `ButtonElement` and `ImageElement`, so `shadowColor` / `shadowOffset` / `shadowOpacity` / `shadowRadius` / `elevation` set on Stack containers were silently dropped. `StackElement` and `ZStackElement` now spread `buildShadowStyle(p)` into their style objects. (iOS shadows still require `overflow` ≠ `hidden` on the shadowed view.)
+
+---
+
 ## [1.41.1] - 2026-06-09
 
 ### Fixed

--- a/packages/onboarding-ui/package.json
+++ b/packages/onboarding-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocapine/react-native-onboarding-ui",
-  "version": "1.41.1",
+  "version": "1.41.2",
   "description": "UI components and renderers for Rocapine Onboarding Studio - Built on top of the headless SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/StackElement.tsx
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/StackElement.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { z } from "zod";
 import { BaseBoxProps, BaseBoxPropsSchema } from "./BaseBoxProps";
 import { UIElement } from "../types";
-import { RenderContext, dim } from "./shared";
+import { RenderContext, dim, buildShadowStyle } from "./shared";
 import { GradientBox } from "./GradientBox";
 
 export type StackElementProps = BaseBoxProps & {
@@ -60,6 +60,7 @@ export const StackElementComponent = ({ element, ctx, parentType }: Props): Reac
         borderColor: p.borderColor,
         overflow: p.overflow,
         opacity: p.opacity,
+        ...buildShadowStyle(p),
       }}
     >
       {ctx.renderChildren(element.children, element.type)}

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/ZStackElement.tsx
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/ZStackElement.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { View } from "react-native";
 import { BaseBoxProps, BaseBoxPropsSchema } from "./BaseBoxProps";
 import { UIElement } from "../types";
-import { RenderContext, dim } from "./shared";
+import { RenderContext, dim, buildShadowStyle } from "./shared";
 import { GradientBox } from "./GradientBox";
 
 export type ZStackElementProps = BaseBoxProps;
@@ -44,6 +44,7 @@ export const ZStackElementComponent = ({ element, ctx }: Props): React.ReactElem
         borderColor: p.borderColor,
         overflow: p.overflow,
         opacity: p.opacity,
+        ...buildShadowStyle(p),
       }}
     >
       {element.children.map((child) => (

--- a/packages/onboarding/CHANGELOG.md
+++ b/packages/onboarding/CHANGELOG.md
@@ -8,6 +8,14 @@ All notable changes to `@rocapine/react-native-onboarding` are documented here.
 
 ---
 
+## [1.41.2] - 2026-06-10
+
+### Changed
+
+- **Version sync only** — no headless changes. Bumped in lockstep with `@rocapine/react-native-onboarding-ui` 1.41.2 (applies `shadow*` props on Stack/ZStack containers).
+
+---
+
 ## [1.41.1] - 2026-06-09
 
 ### Changed

--- a/packages/onboarding/package.json
+++ b/packages/onboarding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocapine/react-native-onboarding",
-  "version": "1.41.1",
+  "version": "1.41.2",
   "description": "Headless React Native SDK for Rocapine Onboarding Studio - Data fetching, state management, and hooks",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Problem

Shadow props (`shadowColor`/`shadowOffset`/`shadowOpacity`/`shadowRadius`/`elevation`) on Stack containers (XStack, YStack, ZStack) rendered nothing. `buildShadowStyle` was only wired into `ButtonElement` and `ImageElement`, so `StackElement` and `ZStackElement` built their `containerStyle` without ever applying the shadow fields — they parsed fine and were silently dropped.

## Fix

- Spread `buildShadowStyle(p)` into `StackElement.tsx` (XStack/YStack) and `ZStackElement.tsx` style objects.
- Added a shadowed `YStack` demo card to `example/app/example/composable-screen.tsx` (existing border cards use `overflow:'hidden'`, which clips iOS shadows — demo card is separate).
- Documented in the path-scoped rule that `buildShadowStyle` must be spread per container renderer (it is **not** applied centrally like `animation`/`transform`). Lists where it's wired vs still missing (`ScrollView`/`RichText`/`Text`/`KeyboardAvoidingView`).

## Release

Patch bump 1.41.1 → 1.41.2 (both packages + plugin.json), changelogs updated. Schema untouched (props already existed in `BaseBoxProps`) → no studio sync needed.

## Notes

- iOS shadows still require `overflow` ≠ `hidden` on the shadowed view.
- `build:ui` passes (tsc clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)