### PR TITLE
✨ Per-item shadow on RadioGroup + CheckboxGroup — v1.42.0

### DIFF
--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-onboarding",
-  "version": "1.41.2",
+  "version": "1.42.0",
   "description": "End-to-end workflow for building and updating Rocapine Onboarding Studio flows: author step JSON, integrate the headless + UI SDKs, customize theme/components, and review onboarding quality.",
   "author": {
     "name": "Rocapine",

--- a/claude-plugin/skills/customize-onboarding-components/SKILL.md
+++ b/claude-plugin/skills/customize-onboarding-components/SKILL.md
@@ -30,6 +30,7 @@ Every styled UIElement (`Button`, `RadioGroup`, `CheckboxGroup`, `Input`, `Wheel
 - `itemColor`, `itemSelectedColor`
 - `itemFontFamily`, `itemFontSize`, `itemFontWeight`, `itemFontStyle`
 - `itemPadding`, `itemPaddingVertical`, `itemPaddingHorizontal`
+- `itemShadowColor`, `itemShadowOffset: {width,height}`, `itemShadowOpacity`, `itemShadowRadius`, `itemElevation` — per-item drop shadow (lone `itemShadowColor` defaults opacity `1` / radius `4`)
 - `showTick` — show/hide the radio circle (checkbox box) indicator. Default: `true`
 - `haptic: "none" | "light" | "medium" | "heavy" | "soft" | "rigid"` — tactile feedback on select/toggle (opt-in; needs optional `expo-haptics`)
 

--- a/example/app/example/composable-screen.tsx
+++ b/example/app/example/composable-screen.tsx
@@ -569,6 +569,13 @@ export default function ComposableScreenExample() {
                 showTick: true,
                 gap: 8,
                 marginVertical: 8,
+                itemBackgroundColor: '#FFFFFF',
+                itemBorderWidth: 0,
+                itemShadowColor: '#000000',
+                itemShadowOffset: { width: 0, height: 2 },
+                itemShadowOpacity: 0.15,
+                itemShadowRadius: 6,
+                itemElevation: 3,
                 items: [
                   { label: 'Monthly', value: 'monthly' },
                   { label: 'Yearly', value: 'yearly' },

--- a/packages/onboarding-ui/CHANGELOG.md
+++ b/packages/onboarding-ui/CHANGELOG.md
@@ -9,6 +9,13 @@ here.
 
 ---
 
+## [1.42.0] - 2026-06-10
+
+### Added
+- **RadioGroup / CheckboxGroup per-item shadow** — item rows now honor `itemShadowColor` / `itemShadowOffset` / `itemShadowOpacity` / `itemShadowRadius` / `itemElevation` via `buildShadowStyle` on each `TouchableOpacity`. Items carry no `overflow: hidden`, so the iOS shadow is not clipped; a lone `itemShadowColor` defaults opacity to `1` and radius to `4`.
+
+---
+
 ## [1.41.2] - 2026-06-10
 
 ### Fixed

--- a/packages/onboarding-ui/package.json
+++ b/packages/onboarding-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocapine/react-native-onboarding-ui",
-  "version": "1.41.2",
+  "version": "1.42.0",
   "description": "UI components and renderers for Rocapine Onboarding Studio - Built on top of the headless SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/CheckboxGroupElement.tsx
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/CheckboxGroupElement.tsx
@@ -2,9 +2,9 @@ import React, { useEffect } from "react";
 import { z } from "zod";
 import { View, Text, TouchableOpacity } from "react-native";
 import { useResolvedFontStyle } from "@rocapine/react-native-onboarding";
-import { BaseBoxProps, BaseBoxPropsSchema } from "./BaseBoxProps";
+import { BaseBoxProps, BaseBoxPropsSchema, type ShadowOffset, ShadowOffsetSchema } from "./BaseBoxProps";
 import type { UIElement } from "../types";
-import { dim, resolveInheritedFontFamily, type RenderContext } from "./shared";
+import { dim, resolveInheritedFontFamily, buildShadowStyle, type RenderContext } from "./shared";
 import { GradientBox } from "./GradientBox";
 import { triggerHaptic, type HapticStyle } from "./haptics";
 
@@ -31,6 +31,11 @@ export type CheckboxGroupElementProps = BaseBoxProps & {
   itemPadding?: number;
   itemPaddingHorizontal?: number;
   itemPaddingVertical?: number;
+  itemShadowColor?: string;
+  itemShadowOffset?: ShadowOffset;
+  itemShadowOpacity?: number;
+  itemShadowRadius?: number;
+  itemElevation?: number;
 };
 
 export const CheckboxGroupElementPropsSchema = BaseBoxPropsSchema.extend({
@@ -56,6 +61,11 @@ export const CheckboxGroupElementPropsSchema = BaseBoxPropsSchema.extend({
   itemPadding: z.number().optional(),
   itemPaddingHorizontal: z.number().optional(),
   itemPaddingVertical: z.number().optional(),
+  itemShadowColor: z.string().optional(),
+  itemShadowOffset: ShadowOffsetSchema.optional(),
+  itemShadowOpacity: z.number().min(0).max(1).optional(),
+  itemShadowRadius: z.number().min(0).optional(),
+  itemElevation: z.number().min(0).optional(),
 }).superRefine((data, ctx) => {
   const values = data.items.map((i) => i.value);
   const unique = new Set(values);
@@ -172,6 +182,13 @@ export const CheckboxGroupComponent = ({ element, ctx }: Props): React.ReactElem
               padding: element.props.itemPadding ?? (element.props.itemPaddingHorizontal === undefined && element.props.itemPaddingVertical === undefined ? 12 : undefined),
               paddingHorizontal: element.props.itemPaddingHorizontal,
               paddingVertical: element.props.itemPaddingVertical,
+              ...buildShadowStyle({
+                shadowColor: element.props.itemShadowColor,
+                shadowOffset: element.props.itemShadowOffset,
+                shadowOpacity: element.props.itemShadowOpacity,
+                shadowRadius: element.props.itemShadowRadius,
+                elevation: element.props.itemElevation,
+              }),
             }}
           >
             {element.props.showTick !== false && (

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/RadioGroupElement.tsx
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/RadioGroupElement.tsx
@@ -2,9 +2,9 @@ import React, { useEffect } from "react";
 import { z } from "zod";
 import { View, Text, TouchableOpacity } from "react-native";
 import { useResolvedFontStyle } from "@rocapine/react-native-onboarding";
-import { BaseBoxProps, BaseBoxPropsSchema } from "./BaseBoxProps";
+import { BaseBoxProps, BaseBoxPropsSchema, type ShadowOffset, ShadowOffsetSchema } from "./BaseBoxProps";
 import { UIElement } from "../types";
-import { RenderContext, dim, resolveInheritedFontFamily } from "./shared";
+import { RenderContext, dim, resolveInheritedFontFamily, buildShadowStyle } from "./shared";
 import { GradientBox } from "./GradientBox";
 import { triggerHaptic, type HapticStyle } from "./haptics";
 
@@ -31,6 +31,11 @@ export type RadioGroupElementProps = BaseBoxProps & {
   itemPadding?: number;
   itemPaddingHorizontal?: number;
   itemPaddingVertical?: number;
+  itemShadowColor?: string;
+  itemShadowOffset?: ShadowOffset;
+  itemShadowOpacity?: number;
+  itemShadowRadius?: number;
+  itemElevation?: number;
 };
 
 export const RadioGroupElementPropsSchema = BaseBoxPropsSchema.extend({
@@ -56,6 +61,11 @@ export const RadioGroupElementPropsSchema = BaseBoxPropsSchema.extend({
   itemPadding: z.number().optional(),
   itemPaddingHorizontal: z.number().optional(),
   itemPaddingVertical: z.number().optional(),
+  itemShadowColor: z.string().optional(),
+  itemShadowOffset: ShadowOffsetSchema.optional(),
+  itemShadowOpacity: z.number().min(0).max(1).optional(),
+  itemShadowRadius: z.number().min(0).optional(),
+  itemElevation: z.number().min(0).optional(),
 }).superRefine((data, ctx) => {
   const values = data.items.map((i) => i.value);
   const unique = new Set(values);
@@ -157,6 +167,13 @@ export const RadioGroupComponent = ({ element, ctx }: Props): React.ReactElement
               padding: element.props.itemPadding ?? (element.props.itemPaddingHorizontal === undefined && element.props.itemPaddingVertical === undefined ? 12 : undefined),
               paddingHorizontal: element.props.itemPaddingHorizontal,
               paddingVertical: element.props.itemPaddingVertical,
+              ...buildShadowStyle({
+                shadowColor: element.props.itemShadowColor,
+                shadowOffset: element.props.itemShadowOffset,
+                shadowOpacity: element.props.itemShadowOpacity,
+                shadowRadius: element.props.itemShadowRadius,
+                elevation: element.props.itemElevation,
+              }),
             }}
           >
             {element.props.showTick !== false && (

--- a/packages/onboarding/CHANGELOG.md
+++ b/packages/onboarding/CHANGELOG.md
@@ -8,6 +8,13 @@ All notable changes to `@rocapine/react-native-onboarding` are documented here.
 
 ---
 
+## [1.42.0] - 2026-06-10
+
+### Added
+- **RadioGroup / CheckboxGroup per-item shadow** — new optional props on both element schemas: `itemShadowColor`, `itemShadowOffset` (`{ width, height }`), `itemShadowOpacity` (0–1), `itemShadowRadius` (≥0), and `itemElevation` (≥0, Android). Applied to each item row.
+
+---
+
 ## [1.41.2] - 2026-06-10
 
 ### Changed

--- a/packages/onboarding/package.json
+++ b/packages/onboarding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocapine/react-native-onboarding",
-  "version": "1.41.2",
+  "version": "1.42.0",
   "description": "Headless React Native SDK for Rocapine Onboarding Studio - Data fetching, state management, and hooks",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/onboarding/src/onboarding-example.ts
+++ b/packages/onboarding/src/onboarding-example.ts
@@ -605,6 +605,13 @@ export const onboardingExample = {
                   showTick: true,
                   gap: 8,
                   marginVertical: 8,
+                  itemBackgroundColor: "#FFFFFF",
+                  itemBorderWidth: 0,
+                  itemShadowColor: "#000000",
+                  itemShadowOffset: { width: 0, height: 2 },
+                  itemShadowOpacity: 0.15,
+                  itemShadowRadius: 6,
+                  itemElevation: 3,
                   items: [
                     { label: "Monthly", value: "monthly" },
                     { label: "Yearly", value: "yearly" },

--- a/packages/onboarding/src/steps/ComposableScreen/elements/CheckboxGroupElement.ts
+++ b/packages/onboarding/src/steps/ComposableScreen/elements/CheckboxGroupElement.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { BaseBoxProps, BaseBoxPropsSchema } from "./BaseBoxProps";
+import { BaseBoxProps, BaseBoxPropsSchema, type ShadowOffset, ShadowOffsetSchema } from "./BaseBoxProps";
 import { type HapticStyle, HapticStyleSchema } from "../../common.types";
 
 export type CheckboxGroupElementProps = BaseBoxProps & {
@@ -26,6 +26,12 @@ export type CheckboxGroupElementProps = BaseBoxProps & {
   itemPadding?: number;
   itemPaddingHorizontal?: number;
   itemPaddingVertical?: number;
+  /** Per-item drop shadow (applied to each checkbox row). iOS uses shadow*; Android uses itemElevation. */
+  itemShadowColor?: string;
+  itemShadowOffset?: ShadowOffset;
+  itemShadowOpacity?: number;
+  itemShadowRadius?: number;
+  itemElevation?: number;
 };
 
 export const CheckboxGroupElementPropsSchema = BaseBoxPropsSchema.extend({
@@ -51,6 +57,11 @@ export const CheckboxGroupElementPropsSchema = BaseBoxPropsSchema.extend({
   itemPadding: z.number().optional(),
   itemPaddingHorizontal: z.number().optional(),
   itemPaddingVertical: z.number().optional(),
+  itemShadowColor: z.string().optional(),
+  itemShadowOffset: ShadowOffsetSchema.optional(),
+  itemShadowOpacity: z.number().min(0).max(1).optional(),
+  itemShadowRadius: z.number().min(0).optional(),
+  itemElevation: z.number().min(0).optional(),
 }).superRefine((data, ctx) => {
   const values = data.items.map((i) => i.value);
   const unique = new Set(values);

--- a/packages/onboarding/src/steps/ComposableScreen/elements/RadioGroupElement.ts
+++ b/packages/onboarding/src/steps/ComposableScreen/elements/RadioGroupElement.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { BaseBoxProps, BaseBoxPropsSchema } from "./BaseBoxProps";
+import { BaseBoxProps, BaseBoxPropsSchema, type ShadowOffset, ShadowOffsetSchema } from "./BaseBoxProps";
 import { type HapticStyle, HapticStyleSchema } from "../../common.types";
 
 export type RadioGroupElementProps = BaseBoxProps & {
@@ -26,6 +26,12 @@ export type RadioGroupElementProps = BaseBoxProps & {
   itemPadding?: number;
   itemPaddingHorizontal?: number;
   itemPaddingVertical?: number;
+  /** Per-item drop shadow (applied to each radio row). iOS uses shadow*; Android uses itemElevation. */
+  itemShadowColor?: string;
+  itemShadowOffset?: ShadowOffset;
+  itemShadowOpacity?: number;
+  itemShadowRadius?: number;
+  itemElevation?: number;
 };
 
 export const RadioGroupElementPropsSchema = BaseBoxPropsSchema.extend({
@@ -51,6 +57,11 @@ export const RadioGroupElementPropsSchema = BaseBoxPropsSchema.extend({
   itemPadding: z.number().optional(),
   itemPaddingHorizontal: z.number().optional(),
   itemPaddingVertical: z.number().optional(),
+  itemShadowColor: z.string().optional(),
+  itemShadowOffset: ShadowOffsetSchema.optional(),
+  itemShadowOpacity: z.number().min(0).max(1).optional(),
+  itemShadowRadius: z.number().min(0).optional(),
+  itemElevation: z.number().min(0).optional(),
 }).superRefine((data, ctx) => {
   const values = data.items.map((i) => i.value);
   const unique = new Set(values);

--- a/website/docs/page-types.mdx
+++ b/website/docs/page-types.mdx
@@ -750,6 +750,11 @@ Plain-text children are automatically split into **one item per word** so the ro
 | `itemFontFamily` | `string` | |
 | `itemPadding` | `number` | Defaults to `12` when no `itemPaddingHorizontal`/`Vertical` is set |
 | `itemPaddingHorizontal` / `itemPaddingVertical` | `number` | |
+| `itemShadowColor` | `string` | Per-item iOS drop shadow color. Setting only this defaults `itemShadowOpacity` to `1`, `itemShadowRadius` to `4` |
+| `itemShadowOffset` | `{ width: number; height: number }` | Per-item shadow offset |
+| `itemShadowOpacity` | `number` | `0`–`1` |
+| `itemShadowRadius` | `number` | Shadow blur radius |
+| `itemElevation` | `number` | Per-item Android elevation shadow |
 | `alignSelf` | `"auto" \| "flex-start" \| "flex-end" \| "center" \| "stretch" \| "baseline"` | |
 | `width` / `height` | `number` | Container dimensions |
 | `margin` / `marginHorizontal` / `marginVertical` | `number` | |
@@ -781,6 +786,11 @@ Plain-text children are automatically split into **one item per word** so the ro
 | `itemFontFamily` | `string` | |
 | `itemPadding` | `number` | Defaults to `12` when no `itemPaddingHorizontal`/`Vertical` is set |
 | `itemPaddingHorizontal` / `itemPaddingVertical` | `number` | |
+| `itemShadowColor` | `string` | Per-item iOS drop shadow color. Setting only this defaults `itemShadowOpacity` to `1`, `itemShadowRadius` to `4` |
+| `itemShadowOffset` | `{ width: number; height: number }` | Per-item shadow offset |
+| `itemShadowOpacity` | `number` | `0`–`1` |
+| `itemShadowRadius` | `number` | Shadow blur radius |
+| `itemElevation` | `number` | Per-item Android elevation shadow |
 | `alignSelf` | `"auto" \| "flex-start" \| "flex-end" \| "center" \| "stretch" \| "baseline"` | |
 | `width` / `height` | `number` | Container dimensions |
 | `margin` / `marginHorizontal` / `marginVertical` | `number` | |


### PR DESCRIPTION
## Summary
Adds per-item drop-shadow support to `RadioGroup` and `CheckboxGroup` ComposableScreen elements. Shadow applies to each item row (not the group container).

New optional props on both element prop schemas:
- `itemShadowColor` (string)
- `itemShadowOffset` (`{ width, height }`)
- `itemShadowOpacity` (0–1)
- `itemShadowRadius` (≥0)
- `itemElevation` (≥0, Android)

iOS uses `itemShadow*`; Android uses `itemElevation`. A lone `itemShadowColor` defaults opacity to `1` and radius to `4` (via `buildShadowStyle`). Item rows carry no `overflow: hidden`, so the iOS shadow is not clipped.

## Changes
- **Headless** `RadioGroupElement.ts` + `CheckboxGroupElement.ts` — type + Zod schema (imports `ShadowOffset` / `ShadowOffsetSchema`).
- **UI mirrors** `RadioGroupElement.tsx` + `CheckboxGroupElement.tsx` — mirrored type/schema + `...buildShadowStyle({...item* → shadow*})` on each item `TouchableOpacity`.
- **Docs** — `website/docs/page-types.mdx` (both prop tables), `customize-onboarding-components/SKILL.md`.
- **Examples** — `onboarding-example.ts` + `example/composable-screen.tsx` RadioGroup demo (white card + shadow).
- **Release** — bump both packages + plugin to `1.42.0`, changelogs.

## Verification
- `npm run build` — both packages compile clean.
- Node `safeParse`: new props accept valid payloads on both elements; `itemShadowOpacity: 12` correctly rejected (RN 0..1 bound).

## Studio mirror
The `onboarding-studio` CMS backend must mirror the 5 new props on RadioGroup/CheckboxGroup validation + editor UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)