### PR TITLE
✨ keyboardVerticalOffset prop on OnboardingPage — v1.44.0

### DIFF
--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-onboarding",
-  "version": "1.42.1",
+  "version": "1.44.0",
   "description": "End-to-end workflow for building and updating Rocapine Onboarding Studio flows: author step JSON, integrate the headless + UI SDKs, customize theme/components, and review onboarding quality.",
   "author": {
     "name": "Rocapine",

--- a/packages/onboarding-ui/CHANGELOG.md
+++ b/packages/onboarding-ui/CHANGELOG.md
@@ -9,6 +9,21 @@ here.
 
 ---
 
+## [1.44.0] - 2026-06-11
+
+### Added
+
+- **`OnboardingPage` `keyboardVerticalOffset`** — optional number forwarded to the
+  `ComposableScreen` renderer's `KeyboardAvoidingView` (default `0`). Hosts that
+  render `OnboardingPage` below a fixed header (e.g. a `paddingTop: HEADER_HEIGHT`
+  wrapper when `displayProgressHeader` is true) push the view's top down, so the
+  iOS `behavior="padding"` math under-compensates by exactly that offset and the
+  bottom CTA stays hidden behind the keyboard on steps containing an `Input`.
+  Pass the header height (`keyboardVerticalOffset={HEADER_HEIGHT}`) to compensate.
+  Other step renderers are unchanged.
+
+---
+
 ## [1.43.0] - 2026-06-11
 
 ### Added

--- a/packages/onboarding-ui/package.json
+++ b/packages/onboarding-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocapine/react-native-onboarding-ui",
-  "version": "1.43.0",
+  "version": "1.44.0",
   "description": "UI components and renderers for Rocapine Onboarding Studio - Built on top of the headless SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/onboarding-ui/src/UI/OnboardingPage.tsx
+++ b/packages/onboarding-ui/src/UI/OnboardingPage.tsx
@@ -10,13 +10,15 @@ interface OnboardingPageProps {
   onContinue: (args?: any) => void;
   isSandbox?: boolean;
   theme?: Theme;
+  /** Offset for ComposableScreen keyboard avoidance — pass the height of any fixed header rendered above the page. */
+  keyboardVerticalOffset?: number;
   customComponents?: {
     QuestionAnswerButton?: React.ComponentType<QuestionAnswerButtonProps>;
     QuestionAnswersList?: React.ComponentType<QuestionAnswersListProps>;
   };
 }
 
-export const OnboardingPage = ({ step, onContinue, isSandbox }: OnboardingPageProps) => {
+export const OnboardingPage = ({ step, onContinue, isSandbox, keyboardVerticalOffset }: OnboardingPageProps) => {
   const { theme } = useTheme();
 
   switch (step.type) {
@@ -35,7 +37,7 @@ export const OnboardingPage = ({ step, onContinue, isSandbox }: OnboardingPagePr
     case 'Question':
       return <QuestionRenderer step={step} onContinue={onContinue} theme={theme} />;
     case 'ComposableScreen':
-      return <ComposableScreenRenderer step={step} onContinue={onContinue} />;
+      return <ComposableScreenRenderer step={step} onContinue={onContinue} keyboardVerticalOffset={keyboardVerticalOffset} />;
     default:
       if (isSandbox) {
         // @ts-ignore

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/Renderer.tsx
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/Renderer.tsx
@@ -13,9 +13,11 @@ import { collectElementDefaults } from "./elements/collectDefaults";
 type ContentProps = {
   step: ComposableScreenStepType;
   onContinue: () => void;
+  /** Distance between the top of the screen and this page's top (e.g. a fixed host header). */
+  keyboardVerticalOffset?: number;
 };
 
-const ComposableScreenRendererBase = ({ step, onContinue }: ContentProps) => {
+const ComposableScreenRendererBase = ({ step, onContinue, keyboardVerticalOffset }: ContentProps) => {
   const { theme } = useTheme();
   const validatedData = useMemo(() => ComposableScreenStepTypeSchema.parse(step), [step]);
   const { elements } = validatedData.payload;
@@ -70,6 +72,7 @@ const ComposableScreenRendererBase = ({ step, onContinue }: ContentProps) => {
       <KeyboardAvoidingView
         style={styles.flex}
         behavior={Platform.OS === "ios" ? "padding" : "height"}
+        keyboardVerticalOffset={keyboardVerticalOffset ?? 0}
       >
         <View style={styles.flex}>
           {elements.map((element) => renderElement(element, ctx))}

--- a/packages/onboarding/CHANGELOG.md
+++ b/packages/onboarding/CHANGELOG.md
@@ -8,6 +8,15 @@ All notable changes to `@rocapine/react-native-onboarding` are documented here.
 
 ---
 
+## [1.44.0] - 2026-06-11
+
+### Changed
+
+- Version bump only — paired with `@rocapine/react-native-onboarding-ui` 1.44.0
+  (`OnboardingPage` `keyboardVerticalOffset` prop). No headless changes.
+
+---
+
 ## [1.43.0] - 2026-06-11
 
 ### Added

--- a/packages/onboarding/package.json
+++ b/packages/onboarding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocapine/react-native-onboarding",
-  "version": "1.43.0",
+  "version": "1.44.0",
   "description": "Headless React Native SDK for Rocapine Onboarding Studio - Data fetching, state management, and hooks",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Problem

On `ComposableScreen` steps containing a text `Input` (e.g. the onboarding "name" screen), the keyboard covers the bottom Continue button when the host app renders the page below a fixed header (wrapper with `paddingTop: HEADER_HEIGHT` when `displayProgressHeader` is true). The renderer's `KeyboardAvoidingView` runs with no `keyboardVerticalOffset`, so iOS `behavior="padding"` under-compensates by exactly the header height.

## Fix

Thread an optional `keyboardVerticalOffset?: number` from the host through `OnboardingPage` into the ComposableScreen `KeyboardAvoidingView` (default `0`).

- `UI/Pages/ComposableScreen/Renderer.tsx` — new optional prop, passed to the existing `KeyboardAvoidingView`.
- `UI/OnboardingPage.tsx` — new prop on `OnboardingPageProps`, forwarded only to the `ComposableScreen` case. Other step renderers unchanged.

Host usage:
```tsx
<OnboardingPage
  step={step}
  onContinue={onContinue}
  keyboardVerticalOffset={step?.displayProgressHeader ? HEADER_HEIGHT : 0}
/>
```

## Notes

- Don't author a `KeyboardAvoidingView` element inside the step payload — the renderer already provides one; nesting two causes double/under-padding.
- No headless changes; headless bumped in lockstep per release convention.

## Verify

Name screen → tap field → keyboard opens → Continue sits directly above keyboard. Re-check on notched device + Android.

🤖 Generated with [Claude Code](https://claude.com/claude-code)