### PR TITLE
📦 Register runtime fonts under PostScript name — v1.44.1

### DIFF
--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-onboarding",
-  "version": "1.44.0",
+  "version": "1.44.1",
   "description": "End-to-end workflow for building and updating Rocapine Onboarding Studio flows: author step JSON, integrate the headless + UI SDKs, customize theme/components, and review onboarding quality.",
   "author": {
     "name": "Rocapine",

--- a/packages/onboarding-ui/CHANGELOG.md
+++ b/packages/onboarding-ui/CHANGELOG.md
@@ -9,6 +9,15 @@ here.
 
 ---
 
+## [1.44.1] - 2026-06-15
+
+### Changed
+
+- Version bump only — paired with `@rocapine/react-native-onboarding` 1.44.1
+  (runtime fonts register under their PostScript / file name). No UI changes.
+
+---
+
 ## [1.44.0] - 2026-06-11
 
 ### Added

--- a/packages/onboarding-ui/package.json
+++ b/packages/onboarding-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocapine/react-native-onboarding-ui",
-  "version": "1.44.0",
+  "version": "1.44.1",
   "description": "UI components and renderers for Rocapine Onboarding Studio - Built on top of the headless SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/onboarding/CHANGELOG.md
+++ b/packages/onboarding/CHANGELOG.md
@@ -8,6 +8,18 @@ All notable changes to `@rocapine/react-native-onboarding` are documented here.
 
 ---
 
+## [1.44.1] - 2026-06-15
+
+### Changed
+
+- **Runtime font registration** — fonts now register under their file's
+  PostScript name (the font file's base name, e.g. `Inter-SemiBold.ttf` →
+  `Inter-SemiBold`) instead of a synthesized `<family>-<weight>` name.
+  `buildRegisteredName` now derives the name from the font URL, stripping
+  directory, query string, and extension.
+
+---
+
 ## [1.44.0] - 2026-06-11
 
 ### Changed

--- a/packages/onboarding/package.json
+++ b/packages/onboarding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocapine/react-native-onboarding",
-  "version": "1.44.0",
+  "version": "1.44.1",
   "description": "Headless React Native SDK for Rocapine Onboarding Studio - Data fetching, state management, and hooks",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/onboarding/src/infra/fonts/registry.ts
+++ b/packages/onboarding/src/infra/fonts/registry.ts
@@ -25,7 +25,14 @@ export const normalizeWeight = (key: FontWeightKey | string | number | undefined
   return Number.isFinite(parsed) ? parsed : 400;
 };
 
-const buildRegisteredName = (family: string, weight: number) => `${family}-${weight}`;
+// The registered (PostScript) name is the font file's base name, without
+// directory, query string, or extension — e.g. ".../Inter-SemiBold.ttf?v=2"
+// registers as "Inter-SemiBold".
+const buildRegisteredName = (url: string): string => {
+  const path = url.split(/[?#]/)[0];
+  const file = path.split("/").pop() ?? path;
+  return file.replace(/\.[^.]+$/, "");
+};
 
 let expoFontWarned = false;
 const loadExpoFont = (): typeof import("expo-font") | null => {
@@ -84,7 +91,7 @@ export const registerFonts = async (manifest: FontsManifest | undefined): Promis
     registry[family] = registry[family] ?? {};
 
     for (const { weight, url } of variants) {
-      const registeredName = buildRegisteredName(family, weight);
+      const registeredName = buildRegisteredName(url);
       registry[family][weight] = registeredName;
 
       loads.push(


### PR DESCRIPTION
## Summary

- `buildRegisteredName` now derives the registered (PostScript) font name from the font file URL — base name minus directory, query string, and extension (e.g. `.../Inter-SemiBold.ttf?v=2` → `Inter-SemiBold`).
- Previously fonts registered under a synthesized `<family>-<weight>` name, which did not match the font's actual PostScript name.

## Release

- Bumped both packages + plugin to **v1.44.1** (PATCH), updated both CHANGELOGs.

## Test plan

- [x] `npm run build:headless` — tsc clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)