### PR TITLE
🐛 Fix dropped italic faces + iOS SF Pro system-font collision — v1.44.2

### DIFF
--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-onboarding",
-  "version": "1.44.1",
+  "version": "1.44.2",
   "description": "End-to-end workflow for building and updating Rocapine Onboarding Studio flows: author step JSON, integrate the headless + UI SDKs, customize theme/components, and review onboarding quality.",
   "author": {
     "name": "Rocapine",

--- a/packages/onboarding-ui/CHANGELOG.md
+++ b/packages/onboarding-ui/CHANGELOG.md
@@ -9,6 +9,18 @@ here.
 
 ---
 
+## [1.44.2] - 2026-06-15
+
+### Fixed
+
+- **Italic text renders with the italic face.** `TextElement` (incl. rich-text
+  spans) and `AnimatedTextElement` now pass `fontStyle` into
+  `useResolvedFontStyle`, so an italic request resolves to the registered italic
+  font face instead of the upright one. Paired with
+  `@rocapine/react-native-onboarding` 1.44.2.
+
+---
+
 ## [1.44.1] - 2026-06-15
 
 ### Changed

--- a/packages/onboarding-ui/package.json
+++ b/packages/onboarding-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocapine/react-native-onboarding-ui",
-  "version": "1.44.1",
+  "version": "1.44.2",
   "description": "UI components and renderers for Rocapine Onboarding Studio - Built on top of the headless SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/AnimatedTextElement.tsx
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/AnimatedTextElement.tsx
@@ -100,7 +100,7 @@ export const AnimatedTextElementComponent = ({ element, ctx }: Props): React.Rea
     p.fontFamily ?? inherited.fontFamily,
     theme.typography.defaultFontFamily
   );
-  const resolvedFont = useResolvedFontStyle(inheritedFontFamily, fontWeight);
+  const resolvedFont = useResolvedFontStyle(inheritedFontFamily, fontWeight, fontStyle);
 
   // 0 -> 1 driver, lives on the UI thread.
   const progress = useSharedValue(autoplay ? 0 : 1);

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/TextElement.tsx
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/TextElement.tsx
@@ -87,7 +87,7 @@ const RichTextSpan = ({
   baseFontFamily: string | undefined;
 }): React.ReactElement => {
   const fontFamily = resolveInheritedFontFamily(span.fontFamily, baseFontFamily);
-  const resolved = useResolvedFontStyle(fontFamily, span.fontWeight);
+  const resolved = useResolvedFontStyle(fontFamily, span.fontWeight, span.fontStyle);
   return (
     <Text
       style={{
@@ -146,7 +146,7 @@ export const TextElementComponent = ({ element, ctx, parentType }: Props): React
     p.fontFamily ?? inherited.fontFamily,
     theme.typography.defaultFontFamily
   );
-  const resolvedFont = useResolvedFontStyle(inheritedFontFamily, fontWeight);
+  const resolvedFont = useResolvedFontStyle(inheritedFontFamily, fontWeight, fontStyle);
 
   const textNode = (
     <Text

--- a/packages/onboarding/CHANGELOG.md
+++ b/packages/onboarding/CHANGELOG.md
@@ -8,6 +8,35 @@ All notable changes to `@rocapine/react-native-onboarding` are documented here.
 
 ---
 
+## [1.44.2] - 2026-06-15
+
+### Fixed
+
+- **Italic font faces are no longer dropped.** The runtime font registry keyed
+  variants by weight only, so a `700-italic` face was overwritten by the
+  `700-normal` face at the same weight — any `fontStyle: "italic"` text then
+  rendered upright. Variants are now keyed by **weight + style**, both faces are
+  registered, and `resolveFontFamily` / `useResolvedFontStyle` /
+  `useResolvedFontFamily` accept an optional `fontStyle` argument and pick the
+  italic face when requested (falling back to the upright face when no italic is
+  registered at that weight).
+- **Apple SF Pro fonts now render at all weights on iOS.** A manifest family
+  whose name collides with the iOS system font (`SF Pro`, `SF Pro Display`,
+  `SF Pro Text`, `SF Pro Rounded`, `system`, … — matched case- and
+  separator-insensitively) is no longer registered as a bundled face on iOS:
+  registering under the system family name made iOS give the system font
+  precedence, so only Regular resolved (other weights rendered as tofu). On iOS
+  such families now resolve to `fontFamily: undefined` so React Native uses the
+  real system font honoring `fontWeight`. On Android (no SF Pro system font) the
+  bundled faces register and resolve normally.
+
+### Added
+
+- `isSystemFontFamily`, `normalizeStyle`, and the `FontStyleKey` /
+  `RegisteredFace` types are now exported from the package.
+
+---
+
 ## [1.44.1] - 2026-06-15
 
 ### Changed

--- a/packages/onboarding/package.json
+++ b/packages/onboarding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocapine/react-native-onboarding",
-  "version": "1.44.1",
+  "version": "1.44.2",
   "description": "Headless React Native SDK for Rocapine Onboarding Studio - Data fetching, state management, and hooks",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/onboarding/src/__tests__/resolveFontFamily.test.ts
+++ b/packages/onboarding/src/__tests__/resolveFontFamily.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mutable Platform mock — isSystemFontFamily reads Platform.OS at call time.
+const { Platform } = vi.hoisted(() => ({
+  Platform: { OS: "android" as "ios" | "android" },
+}));
+vi.mock("react-native", () => ({ Platform }));
+
+import {
+  resolveFontFamily,
+  isSystemFontFamily,
+  type FontRegistry,
+} from "../infra/fonts/registry";
+
+describe("resolveFontFamily", () => {
+  beforeEach(() => {
+    Platform.OS = "android";
+  });
+
+  // Playfair Display: bold has both upright + italic faces at weight 700.
+  const registry: FontRegistry = {
+    "playfair-display": {
+      400: { normal: "PlayfairDisplay-Regular", italic: "PlayfairDisplay-Italic" },
+      700: { normal: "PlayfairDisplay-Bold", italic: "PlayfairDisplay-BoldItalic" },
+    },
+  };
+
+  it("selects the italic face when fontStyle: italic is requested", () => {
+    expect(resolveFontFamily(registry, "playfair-display", 700, "italic")).toBe(
+      "PlayfairDisplay-BoldItalic"
+    );
+    expect(resolveFontFamily(registry, "playfair-display", 700, "normal")).toBe(
+      "PlayfairDisplay-Bold"
+    );
+  });
+
+  it("defaults to the upright face when no style is given", () => {
+    expect(resolveFontFamily(registry, "playfair-display", 700)).toBe(
+      "PlayfairDisplay-Bold"
+    );
+  });
+
+  it("falls back to the other style when the requested one is absent at that weight", () => {
+    const onlyNormal: FontRegistry = {
+      fam: { 700: { normal: "Fam-Bold" } },
+    };
+    expect(resolveFontFamily(onlyNormal, "fam", 700, "italic")).toBe("Fam-Bold");
+  });
+
+  it("matches the nearest weight when exact weight is missing", () => {
+    expect(resolveFontFamily(registry, "playfair-display", 600, "italic")).toBe(
+      "PlayfairDisplay-BoldItalic"
+    );
+  });
+
+  it("returns the raw family name for an unregistered family", () => {
+    expect(resolveFontFamily(registry, "unknown", 400)).toBe("unknown");
+  });
+});
+
+describe("system font collision (iOS)", () => {
+  beforeEach(() => {
+    Platform.OS = "android";
+  });
+
+  it("treats SF Pro family names as system fonts only on iOS", () => {
+    Platform.OS = "ios";
+    expect(isSystemFontFamily("sf-pro-display")).toBe(true);
+    expect(isSystemFontFamily("SF Pro Display")).toBe(true);
+    expect(isSystemFontFamily("system")).toBe(true);
+    expect(isSystemFontFamily("playfair-display")).toBe(false);
+
+    Platform.OS = "android";
+    expect(isSystemFontFamily("sf-pro-display")).toBe(false);
+  });
+
+  it("resolves a system family to undefined on iOS (use the real system font)", () => {
+    const registry: FontRegistry = {
+      "sf-pro-display": { 500: { normal: "SFProDisplay-Medium" } },
+    };
+    Platform.OS = "ios";
+    expect(resolveFontFamily(registry, "sf-pro-display", 500)).toBeUndefined();
+
+    Platform.OS = "android";
+    expect(resolveFontFamily(registry, "sf-pro-display", 500)).toBe(
+      "SFProDisplay-Medium"
+    );
+  });
+});

--- a/packages/onboarding/src/infra/fonts/FontRegistryContext.tsx
+++ b/packages/onboarding/src/infra/fonts/FontRegistryContext.tsx
@@ -1,5 +1,5 @@
 import { createContext, useContext, useMemo } from "react";
-import type { FontRegistry } from "./registry";
+import type { FontRegistry, FontStyleKey } from "./registry";
 import { resolveFontFamily } from "./registry";
 
 const FontRegistryContext = createContext<FontRegistry>({});
@@ -10,21 +10,27 @@ export const useFontRegistry = (): FontRegistry => useContext(FontRegistryContex
 
 export const useResolvedFontFamily = (
   family: string | null | undefined,
-  weight: string | number | null | undefined
+  weight: string | number | null | undefined,
+  fontStyle?: FontStyleKey | string | null
 ): string | undefined => {
   const registry = useFontRegistry();
-  return useMemo(() => resolveFontFamily(registry, family, weight), [registry, family, weight]);
+  return useMemo(
+    () => resolveFontFamily(registry, family, weight, fontStyle),
+    [registry, family, weight, fontStyle]
+  );
 };
 
 /**
- * Resolves a `family + weight` request to a registered font name. Returns
- * `resolvedToVariant: true` when the registry matched a concrete weighted
- * variant — callers should then suppress `fontWeight` on the rendered Text to
- * avoid synthetic emboldening on top of an already-weighted font file.
+ * Resolves a `family + weight + style` request to a registered font name.
+ * Returns `resolvedToVariant: true` when the registry matched a concrete
+ * weighted variant — callers should then suppress `fontWeight` on the rendered
+ * Text to avoid synthetic emboldening on top of an already-weighted font file.
+ * Pass `fontStyle: "italic"` to select the italic face when one is registered.
  */
 export const useResolvedFontStyle = (
   family: string | null | undefined,
-  weight: string | number | null | undefined
+  weight: string | number | null | undefined,
+  fontStyle?: FontStyleKey | string | null
 ): {
   fontFamily: string | undefined;
   fontWeight: string | number | undefined;
@@ -32,7 +38,7 @@ export const useResolvedFontStyle = (
 } => {
   const registry = useFontRegistry();
   return useMemo(() => {
-    const fontFamily = resolveFontFamily(registry, family, weight);
+    const fontFamily = resolveFontFamily(registry, family, weight, fontStyle);
     const variants = family ? registry?.[family] : undefined;
     const resolvedToVariant =
       !!variants && fontFamily !== undefined && fontFamily !== family;
@@ -41,5 +47,5 @@ export const useResolvedFontStyle = (
       fontWeight: resolvedToVariant ? undefined : (weight ?? undefined),
       resolvedToVariant,
     };
-  }, [registry, family, weight]);
+  }, [registry, family, weight, fontStyle]);
 };

--- a/packages/onboarding/src/infra/fonts/index.ts
+++ b/packages/onboarding/src/infra/fonts/index.ts
@@ -2,7 +2,11 @@ export {
   registerFonts,
   resolveFontFamily,
   normalizeWeight,
+  normalizeStyle,
+  isSystemFontFamily,
   type FontRegistry,
+  type RegisteredFace,
+  type FontStyleKey,
 } from "./registry";
 export {
   FontRegistryProvider,

--- a/packages/onboarding/src/infra/fonts/registry.ts
+++ b/packages/onboarding/src/infra/fonts/registry.ts
@@ -1,3 +1,4 @@
+import { Platform } from "react-native";
 import type {
   FontFamilyManifest,
   FontFamilyManifestInput,
@@ -6,7 +7,13 @@ import type {
   FontWeightKey,
 } from "../../types";
 
-export type FontRegistry = Record<string, Record<number, string>>;
+export type FontStyleKey = "normal" | "italic";
+
+// One weight bucket can hold both an upright and an italic face.
+export type RegisteredFace = Partial<Record<FontStyleKey, string>>;
+
+// family -> weight -> { normal?, italic? } registered (PostScript) names.
+export type FontRegistry = Record<string, Record<number, RegisteredFace>>;
 
 const WEIGHT_NAME_TO_NUM: Record<string, number> = {
   regular: 400,
@@ -23,6 +30,36 @@ export const normalizeWeight = (key: FontWeightKey | string | number | undefined
   if (named) return named;
   const parsed = parseInt(key, 10);
   return Number.isFinite(parsed) ? parsed : 400;
+};
+
+export const normalizeStyle = (style: string | undefined | null): FontStyleKey =>
+  style === "italic" ? "italic" : "normal";
+
+// Font families whose internal name collides with the iOS system font (SF Pro).
+// Registering custom faces under one of these names makes iOS give the system
+// font precedence, so only Regular resolves — every other weight renders tofu.
+// On iOS we skip registering them and resolve to `fontFamily: undefined` so RN
+// uses the real system font (which *is* SF Pro) honoring `fontWeight`. On
+// Android (no SF Pro system font) the bundled faces register normally.
+const SYSTEM_FONT_FAMILIES = new Set<string>([
+  "system",
+  "sfpro",
+  "sfprodisplay",
+  "sfprotext",
+  "sfprorounded",
+  "sfuidisplay",
+  "sfuitext",
+]);
+
+const normalizeFamilyKey = (family: string): string =>
+  family.toLowerCase().replace(/[\s_.-]+/g, "");
+
+// True when `family` names a platform system font that must NOT be registered as
+// a bundled face on iOS (see SYSTEM_FONT_FAMILIES). Always false on other
+// platforms — only iOS has the SF Pro collision.
+export const isSystemFontFamily = (family: string | null | undefined): boolean => {
+  if (!family || Platform.OS !== "ios") return false;
+  return SYSTEM_FONT_FAMILIES.has(normalizeFamilyKey(family));
 };
 
 // The registered (PostScript) name is the font file's base name, without
@@ -49,29 +86,28 @@ const loadExpoFont = (): typeof import("expo-font") | null => {
   }
 };
 
-type NormalizedVariant = { weight: number; url: string };
+type NormalizedVariant = { weight: number; style: FontStyleKey; url: string };
 
 const normalizeFamilyVariants = (input: FontFamilyManifestInput | undefined): NormalizedVariant[] => {
   if (!input) return [];
 
   if (Array.isArray(input)) {
-    const byWeight = new Map<number, NormalizedVariant>();
+    // Key by weight+style so an italic face is never overwritten by the upright
+    // face at the same weight (and vice-versa). Last entry wins on exact dup.
+    const byKey = new Map<string, NormalizedVariant>();
     for (const entry of input as FontVariantEntry[]) {
       if (!entry || typeof entry.url !== "string" || !entry.url) continue;
       const weight = normalizeWeight(entry.weight as FontWeightKey | number);
-      const existing = byWeight.get(weight);
-      const isNormalStyle = !entry.style || entry.style === "normal";
-      if (!existing || isNormalStyle) {
-        byWeight.set(weight, { weight, url: entry.url });
-      }
+      const style = normalizeStyle(entry.style);
+      byKey.set(`${weight}-${style}`, { weight, style, url: entry.url });
     }
-    return Array.from(byWeight.values());
+    return Array.from(byKey.values());
   }
 
   const out: NormalizedVariant[] = [];
   for (const [weightKey, url] of Object.entries(input as FontFamilyManifest)) {
     if (typeof url !== "string" || !url) continue;
-    out.push({ weight: normalizeWeight(weightKey as FontWeightKey), url });
+    out.push({ weight: normalizeWeight(weightKey as FontWeightKey), style: "normal", url });
   }
   return out;
 };
@@ -86,21 +122,30 @@ export const registerFonts = async (manifest: FontsManifest | undefined): Promis
   const loads: Array<Promise<void>> = [];
 
   for (const [family, variantsInput] of Object.entries(manifest)) {
+    // Don't register a system-font family's bundled faces on iOS — resolution
+    // returns `fontFamily: undefined` for it so the real system font is used.
+    if (isSystemFontFamily(family)) continue;
+
     const variants = normalizeFamilyVariants(variantsInput);
     if (variants.length === 0) continue;
     registry[family] = registry[family] ?? {};
 
-    for (const { weight, url } of variants) {
+    for (const { weight, style, url } of variants) {
       const registeredName = buildRegisteredName(url);
-      registry[family][weight] = registeredName;
+      const bucket = (registry[family][weight] = registry[family][weight] ?? {});
+      bucket[style] = registeredName;
 
       loads.push(
         Font.loadAsync({ [registeredName]: { uri: url } as any }).catch((error: unknown) => {
           console.warn(
-            `[onboarding] Failed to load font "${family}" weight ${weight} from ${url}:`,
+            `[onboarding] Failed to load font "${family}" weight ${weight} (${style}) from ${url}:`,
             error
           );
-          delete registry[family][weight];
+          const b = registry[family]?.[weight];
+          if (b) {
+            delete b[style];
+            if (Object.keys(b).length === 0) delete registry[family][weight];
+          }
         })
       );
     }
@@ -110,18 +155,30 @@ export const registerFonts = async (manifest: FontsManifest | undefined): Promis
   return registry;
 };
 
+// Picks the requested style from a weight bucket, falling back to the other
+// style when the requested one isn't available at that weight.
+const pickFace = (
+  face: RegisteredFace | undefined,
+  style: FontStyleKey
+): string | undefined => (face ? (face[style] ?? face.normal ?? face.italic) : undefined);
+
 export const resolveFontFamily = (
   registry: FontRegistry | null | undefined,
   family: string | null | undefined,
-  weight: string | number | null | undefined
+  weight: string | number | null | undefined,
+  fontStyle?: FontStyleKey | string | null
 ): string | undefined => {
   if (!family) return undefined;
+  // System font on iOS: let RN resolve the real system font from fontWeight.
+  if (isSystemFontFamily(family)) return undefined;
   if (!registry) return family;
   const variants = registry[family];
   if (!variants) return family;
 
+  const style = normalizeStyle(fontStyle);
   const requested = normalizeWeight(weight as FontWeightKey | undefined);
-  const exact = variants[requested];
+
+  const exact = pickFace(variants[requested], style);
   if (exact) return exact;
 
   const available = Object.keys(variants)
@@ -139,5 +196,5 @@ export const resolveFontFamily = (
       bestDelta = delta;
     }
   }
-  return variants[best];
+  return pickFace(variants[best], style) ?? family;
 };


### PR DESCRIPTION
## Two font bugs in ComposableScreen font handling

Found integrating into a host app using Apple SF Pro + Playfair Display (weights 400/700, normal + italic).

### Bug 1 — italic variants dropped (bold-italic rendered as bold)
The runtime registry (`packages/onboarding/src/infra/fonts/registry.ts`) keyed variants by **weight only** and preferred `normal`, so a `700-italic` face was overwritten by `700-normal`. `resolveFontFamily` / `useResolvedFontStyle` also ignored style entirely — any `fontStyle: "italic"` text at a weight that also had a normal face rendered upright.

**Fix:** thread `style` through the whole chain — variants keyed by **weight + style**, both faces registered, and `resolveFontFamily` / `useResolvedFontStyle` / `useResolvedFontFamily` accept an optional `fontStyle` arg and select the italic face (falling back to upright when no italic is registered at that weight). `TextElement`, `RichTextSpan`, and `AnimatedTextElement` now pass `fontStyle` into the hook.

### Bug 2 — Apple SF Pro only renders Regular on iOS (other weights = tofu)
The studio's `sf-pro-display` files are Apple SF Pro; their internal family name (`SF Pro Display`) **is the iOS system font family**. Registering custom faces under a name that collides with the system font makes iOS give the system font precedence — only Regular resolves; other weights render as tofu.

**Fix:** a manifest family whose name collides with the iOS system font (`SF Pro`, `SF Pro Display`, `SF Pro Text`, `SF Pro Rounded`, `system`, … — matched case- and separator-insensitively, so `sf-pro-display` matches) is **not** registered as a bundled face on iOS and resolves to `fontFamily: undefined`, so RN uses the real system font (which *is* SF Pro) honoring `fontWeight`. On Android the bundled faces register and resolve normally.

## Changes
- `registry.ts` — `FontRegistry` is now `family → weight → { normal?, italic? }`; weight+style keying; `isSystemFontFamily` / `normalizeStyle` helpers; system-font skip on iOS; `fontStyle`-aware `resolveFontFamily`.
- `FontRegistryContext.tsx` — `useResolvedFontStyle` / `useResolvedFontFamily` take optional `fontStyle`.
- UI `TextElement` / `AnimatedTextElement` — pass `fontStyle` into resolution.
- New exports: `isSystemFontFamily`, `normalizeStyle`, `FontStyleKey`, `RegisteredFace`.
- New `resolveFontFamily.test.ts` (7 cases: italic selection, style fallback, nearest-weight, iOS/Android system-font behavior).

## Verification
- `npm run build` — both packages compile clean.
- `npm test --workspace=packages/onboarding` — **112 passed** (105 existing + 7 new).

Note: `FontVariantEntry.style` already existed in the manifest schema, so no onboarding-studio schema mirror is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)