### PR TITLE
🐛 Fix production onboarding pinned to offline fallback — v1.44.3

### DIFF
--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-onboarding",
-  "version": "1.44.2",
+  "version": "1.44.3",
   "description": "End-to-end workflow for building and updating Rocapine Onboarding Studio flows: author step JSON, integrate the headless + UI SDKs, customize theme/components, and review onboarding quality.",
   "author": {
     "name": "Rocapine",

--- a/packages/onboarding-ui/CHANGELOG.md
+++ b/packages/onboarding-ui/CHANGELOG.md
@@ -9,6 +9,15 @@ here.
 
 ---
 
+## [1.44.3] - 2026-06-16
+
+### Changed
+
+- Version sync with `@rocapine/react-native-onboarding@1.44.3` (production
+  fallback-cache fix in the headless SDK). No UI/renderer changes.
+
+---
+
 ## [1.44.2] - 2026-06-15
 
 ### Fixed

--- a/packages/onboarding-ui/package.json
+++ b/packages/onboarding-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocapine/react-native-onboarding-ui",
-  "version": "1.44.2",
+  "version": "1.44.3",
   "description": "UI components and renderers for Rocapine Onboarding Studio - Built on top of the headless SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/onboarding/CHANGELOG.md
+++ b/packages/onboarding/CHANGELOG.md
@@ -8,6 +8,24 @@ All notable changes to `@rocapine/react-native-onboarding` are documented here.
 
 ---
 
+## [1.44.3] - 2026-06-16
+
+### Fixed
+
+- **Production no longer gets pinned to the offline fallback.** The production
+  onboarding query was cache-first with `staleTime: Infinity`: it returned the
+  AsyncStorage cache and **never called the edge function again**, and it cached
+  whatever `getSteps` returned — including the offline fallback. So a single
+  first-launch fetch failure (timeout / offline / cold-start) cached the
+  fallback and pinned every subsequent launch to it, while the device stopped
+  hitting the studio entirely. The query now (1) **never caches the fallback**
+  (detected via the `ONBS-Onboarding-Id: "fallback"` header), so a bad launch
+  self-heals on the next start, and (2) uses **stale-while-revalidate** — it
+  serves the cache for an instant first paint while refreshing from the network
+  in the background, so studio re-deploys propagate and a stale cache recovers.
+
+---
+
 ## [1.44.2] - 2026-06-15
 
 ### Fixed

--- a/packages/onboarding/package.json
+++ b/packages/onboarding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocapine/react-native-onboarding",
-  "version": "1.44.2",
+  "version": "1.44.3",
   "description": "Headless React Native SDK for Rocapine Onboarding Studio - Data fetching, state management, and hooks",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/onboarding/src/__tests__/getOnboarding.query.test.ts
+++ b/packages/onboarding/src/__tests__/getOnboarding.query.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// AsyncStorage is mocked — the query reads/writes the production cache through it.
+const { getItem, setItem } = vi.hoisted(() => ({
+  getItem: vi.fn<(key: string) => Promise<string | null>>(),
+  setItem: vi.fn<(key: string, value: string) => Promise<void>>(),
+}));
+vi.mock("@react-native-async-storage/async-storage", () => ({
+  default: { getItem, setItem },
+}));
+
+import { getOnboardingQuery } from "../infra/queries/getOnboarding.query";
+
+const CACHE_KEY = "rocapine-onboarding-studio";
+
+const realOnboarding = { metadata: { id: "real" }, steps: [], fonts: {} } as any;
+const fallbackOnboarding = { metadata: { id: "fallback" }, steps: [], fonts: {} } as any;
+
+// Builds a fake client whose `getSteps` resolves to the given payload + the
+// ONBS-Onboarding-Id header the SDK uses to flag the offline fallback.
+const makeClient = (
+  { isSandbox, onboardingId, data }: { isSandbox: boolean; onboardingId: string; data: any }
+) => {
+  const getSteps = vi.fn().mockResolvedValue({
+    data,
+    headers: {
+      "ONBS-Onboarding-Id": onboardingId,
+      "ONBS-Onboarding-Name": onboardingId,
+      "ONBS-Audience-Id": onboardingId,
+    },
+  });
+  return {
+    projectId: "p1",
+    options: { isSandbox, baseUrl: undefined },
+    getSteps,
+  } as any;
+};
+
+const run = (client: any, setOnboarding = vi.fn()) =>
+  (getOnboardingQuery(client, "en", {}, setOnboarding) as any).queryFn();
+
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+describe("getOnboardingQuery", () => {
+  beforeEach(() => {
+    getItem.mockReset();
+    setItem.mockReset();
+    setItem.mockResolvedValue(undefined);
+  });
+
+  it("sandbox: always fetches, never touches the cache", async () => {
+    const client = makeClient({ isSandbox: true, onboardingId: "real", data: realOnboarding });
+    const data = await run(client);
+
+    expect(client.getSteps).toHaveBeenCalledTimes(1);
+    expect(getItem).not.toHaveBeenCalled();
+    expect(setItem).toHaveBeenCalledWith(CACHE_KEY, JSON.stringify(realOnboarding));
+    expect(data).toBe(realOnboarding);
+  });
+
+  it("production cache miss + real payload: fetches and caches", async () => {
+    getItem.mockResolvedValue(null);
+    const client = makeClient({ isSandbox: false, onboardingId: "real", data: realOnboarding });
+    const setOnboarding = vi.fn();
+    const data = await run(client, setOnboarding);
+
+    expect(client.getSteps).toHaveBeenCalledTimes(1);
+    expect(setItem).toHaveBeenCalledWith(CACHE_KEY, JSON.stringify(realOnboarding));
+    expect(setOnboarding).toHaveBeenCalledWith(realOnboarding);
+    expect(data).toBe(realOnboarding);
+  });
+
+  it("production cache miss + fallback: returns it but does NOT cache it", async () => {
+    getItem.mockResolvedValue(null);
+    const client = makeClient({ isSandbox: false, onboardingId: "fallback", data: fallbackOnboarding });
+    const data = await run(client);
+
+    expect(client.getSteps).toHaveBeenCalledTimes(1);
+    expect(setItem).not.toHaveBeenCalled();
+    expect(data).toBe(fallbackOnboarding);
+  });
+
+  it("production cache hit: returns cache immediately and revalidates in the background", async () => {
+    const cached = { metadata: { id: "cached" }, steps: [], fonts: {} } as any;
+    getItem.mockResolvedValue(JSON.stringify(cached));
+    const client = makeClient({ isSandbox: false, onboardingId: "real", data: realOnboarding });
+    const setOnboarding = vi.fn();
+
+    const data = await run(client, setOnboarding);
+
+    // Served from cache without blocking on the network.
+    expect(data).toEqual(cached);
+    expect(setOnboarding).toHaveBeenCalledWith(cached);
+
+    // Background revalidation runs after the cache is returned.
+    await flush();
+    expect(client.getSteps).toHaveBeenCalledTimes(1);
+    expect(setItem).toHaveBeenCalledWith(CACHE_KEY, JSON.stringify(realOnboarding));
+    expect(setOnboarding).toHaveBeenCalledWith(realOnboarding);
+  });
+});

--- a/packages/onboarding/src/infra/queries/getOnboarding.query.ts
+++ b/packages/onboarding/src/infra/queries/getOnboarding.query.ts
@@ -21,37 +21,65 @@ export const getOnboardingQuery = <StepType extends BaseStepType>(
       JSON.stringify(customAudienceParams),
     ],
     queryFn: async (): Promise<Onboarding<StepType>> => {
-      // Try to get data from AsyncStorage first for production
-      if (!(client?.options?.isSandbox || false)) {
-        try {
-          const cachedData = await AsyncStorage.getItem(cacheKey);
-          if (cachedData) {
-            setOnboarding && setOnboarding(JSON.parse(cachedData));
-            return JSON.parse(cachedData);
+      const isProduction = !(client?.options?.isSandbox || false);
+
+      // Fetches the live payload, pushes it to the provider, and caches it —
+      // but NEVER caches the offline fallback. Caching the fallback (with
+      // `staleTime: Infinity` + cache-first below) would pin every future
+      // launch to the fallback even after the network recovers, and the device
+      // would stop calling the edge function entirely. Returns the payload.
+      const fetchAndCache = async (): Promise<Onboarding<StepType>> => {
+        const { data, headers } = await client!.getSteps<StepType>(
+          { locale },
+          customAudienceParams
+        );
+
+        const isFallback = headers["ONBS-Onboarding-Id"] === "fallback";
+        console.info("onbs-onboarding-name", headers["ONBS-Onboarding-Name"]);
+        console.info("onbs-onboarding-id", headers["ONBS-Onboarding-Id"]);
+        setOnboarding && setOnboarding(data);
+
+        if (!isFallback) {
+          try {
+            await AsyncStorage.setItem(cacheKey, JSON.stringify(data));
+          } catch (error) {
+            console.warn("Failed to cache onboarding questions:", error);
           }
-        } catch (error) {
-          console.warn("Failed to load cached onboarding questions:", error);
         }
+
+        return data;
+      };
+
+      // Sandbox / draft: always fetch fresh, no caching.
+      if (!isProduction) {
+        return fetchAndCache();
       }
 
-      // Fetch from API
-      const { data, headers } = await client!.getSteps<StepType>(
-        { locale },
-        customAudienceParams
-      );
-
-      console.info("onbs-onboarding-name", headers["ONBS-Onboarding-Name"]);
-      console.info("onbs-onboarding-id", headers["ONBS-Onboarding-Id"]);
-      setOnboarding && setOnboarding(data);
-
-      // Cache the steps
+      // Production: stale-while-revalidate. Serve the cached payload instantly
+      // (fast first paint, offline-resilient) AND refresh from the network in
+      // the background, so studio re-deploys propagate and a stale cache heals.
+      let cached: Onboarding<StepType> | null = null;
       try {
-        await AsyncStorage.setItem(cacheKey, JSON.stringify(data));
+        const cachedData = await AsyncStorage.getItem(cacheKey);
+        if (cachedData) cached = JSON.parse(cachedData) as Onboarding<StepType>;
       } catch (error) {
-        console.warn("Failed to cache onboarding questions:", error);
+        console.warn("Failed to load cached onboarding questions:", error);
       }
 
-      return data;
+      if (cached) {
+        setOnboarding && setOnboarding(cached);
+        // Background revalidation — updates the cache + provider state when a
+        // fresh real payload arrives. Errors are swallowed: the cache already
+        // painted, so an offline revalidation must not surface as a query error.
+        void fetchAndCache().catch((error) => {
+          console.warn("Background onboarding revalidation failed:", error);
+        });
+        return cached;
+      }
+
+      // No cache yet: await the network. A fallback result is returned but NOT
+      // cached, so the next launch retries instead of being pinned to it.
+      return fetchAndCache();
     },
     staleTime: Infinity,
   };


### PR DESCRIPTION
## Problem

In production (`isSandbox: false`), the onboarding query was **cache-first with `staleTime: Infinity`**:

- It returned the AsyncStorage cache and **never called the edge function again** — so devices stopped hitting the studio entirely (no edge-function invocations visible in Supabase).
- It cached **whatever `getSteps` returned — including the offline fallback**. So a single first-launch fetch failure (5s timeout / offline / cold-start) cached the fallback and **pinned every subsequent launch to it forever**. Studio re-deploys never reached those devices.

Downstream symptom in the Harmony app: the bundled fallback rendered with a local theme naming a concrete SF Pro face, hitting the iOS system-font collision → `fontWeight: 500` showed as **Bold** in production only.

## Fix (`getOnboarding.query.ts`)

1. **Never cache the fallback** — detected via the `ONBS-Onboarding-Id: "fallback"` header. A bad launch now self-heals on the next start instead of being pinned.
2. **Stale-while-revalidate** — serve the cache for an instant first paint, then refresh from the network in the background (updates cache + provider state). Studio re-deploys propagate and a stale/poisoned cache recovers.

Sandbox/draft behaviour unchanged (always fetch fresh, no cache).

## Changes

- `packages/onboarding/src/infra/queries/getOnboarding.query.ts` — SWR + no-fallback-cache.
- `packages/onboarding/src/__tests__/getOnboarding.query.test.ts` — new (sandbox, prod cache-miss real, prod cache-miss fallback-not-cached, prod cache-hit + background revalidation).
- Bump both packages + plugin to **1.44.3**; update both CHANGELOGs.

## Testing

- `type:check` clean.
- `vitest run` — **116 passed** (4 new).
- `build` OK.

## Consumer follow-up (Harmony)

Pairs with a one-time AsyncStorage cache-flush upgrade task in the Harmony app (separate PR) to clear already-poisoned caches on the upgrade launch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)