### PR TITLE
🐛 Fall back to theme default for empty/null fontFamily — v1.44.4

### DIFF
--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-onboarding",
-  "version": "1.44.3",
+  "version": "1.44.4",
   "description": "End-to-end workflow for building and updating Rocapine Onboarding Studio flows: author step JSON, integrate the headless + UI SDKs, customize theme/components, and review onboarding quality.",
   "author": {
     "name": "Rocapine",

--- a/packages/onboarding-ui/CHANGELOG.md
+++ b/packages/onboarding-ui/CHANGELOG.md
@@ -9,6 +9,24 @@ here.
 
 ---
 
+## [1.44.4] - 2026-06-16
+
+### Fixed
+
+- **Empty / null `fontFamily` now falls back to the theme default.** A text
+  element (`Text`, `Button`, `Input`, `RadioGroup`, `CheckboxGroup`,
+  `WheelPicker`, `AnimatedText`, rich-text spans) that provided no usable font
+  only fell back to `theme.typography.defaultFontFamily` when `fontFamily` was
+  `undefined` or `"inherit"`. The CMS emits an **empty string** (`""`) or
+  `null` for "no font selected", which slipped through
+  `resolveInheritedFontFamily` unchanged — a falsy family then reached
+  `resolveFontFamily`, which returns `undefined` (system font) and silently
+  ignored the configured default. `resolveInheritedFontFamily` now treats any
+  falsy value (`""` / `null` / `undefined`) as well as `"inherit"` as "use the
+  theme default".
+
+---
+
 ## [1.44.3] - 2026-06-16
 
 ### Changed

--- a/packages/onboarding-ui/CHANGELOG.md
+++ b/packages/onboarding-ui/CHANGELOG.md
@@ -24,6 +24,13 @@ here.
   ignored the configured default. `resolveInheritedFontFamily` now treats any
   falsy value (`""` / `null` / `undefined`) as well as `"inherit"` as "use the
   theme default".
+- **`fontStyle` now resolves the italic face on `Button` / `Input` /
+  `RadioGroup` / `CheckboxGroup`.** These passed only `fontFamily` + `fontWeight`
+  to `useResolvedFontStyle`, so a registered italic variant (e.g.
+  `PlayfairDisplay-Italic`) was never selected — text fell back to synthetic
+  italic over the upright face. `fontStyle` is now threaded into resolution so
+  the real italic face is picked when registered (matching `Text` /
+  `AnimatedText`).
 
 ---
 

--- a/packages/onboarding-ui/package.json
+++ b/packages/onboarding-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocapine/react-native-onboarding-ui",
-  "version": "1.44.3",
+  "version": "1.44.4",
   "description": "UI components and renderers for Rocapine Onboarding Studio - Built on top of the headless SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/ButtonElement.tsx
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/ButtonElement.tsx
@@ -170,7 +170,8 @@ export const ButtonElementComponent = ({ element, ctx }: Props): React.ReactElem
   );
   const resolvedFont = useResolvedFontStyle(
     inheritedFontFamily,
-    eff.fontWeight
+    eff.fontWeight,
+    eff.fontStyle
   );
 
   // Animate opacity between rest/pressed/disabled. Uses native driver — color

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/CheckboxGroupElement.tsx
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/CheckboxGroupElement.tsx
@@ -101,7 +101,8 @@ export const CheckboxGroupComponent = ({ element, ctx }: Props): React.ReactElem
   // back to theme.typography.defaultFontFamily so labels honor the theme font.
   const resolvedFont = useResolvedFontStyle(
     resolveInheritedFontFamily(element.props.itemFontFamily, theme.typography.defaultFontFamily),
-    element.props.itemFontWeight
+    element.props.itemFontWeight,
+    element.props.itemFontStyle
   );
 
   useEffect(() => {

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/InputElement.tsx
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/InputElement.tsx
@@ -87,7 +87,8 @@ export const InputElementComponent = ({ element, ctx }: Props): React.ReactEleme
   );
   const resolvedFont = useResolvedFontStyle(
     inheritedFontFamily,
-    element.props.fontWeight
+    element.props.fontWeight,
+    element.props.fontStyle
   );
 
   return (

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/RadioGroupElement.tsx
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/RadioGroupElement.tsx
@@ -92,7 +92,8 @@ export const RadioGroupComponent = ({ element, ctx }: Props): React.ReactElement
   // back to theme.typography.defaultFontFamily so labels honor the theme font.
   const resolvedFont = useResolvedFontStyle(
     resolveInheritedFontFamily(element.props.itemFontFamily, theme.typography.defaultFontFamily),
-    element.props.itemFontWeight
+    element.props.itemFontWeight,
+    element.props.itemFontStyle
   );
 
   useEffect(() => {

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/shared.ts
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/shared.ts
@@ -64,12 +64,17 @@ export const buildShadowStyle = (p: ShadowStyleInput) => {
 };
 
 // Resolve element fontFamily against theme `typography.defaultFontFamily`.
-// Returns the theme default when element omits fontFamily or sets it to "inherit".
+// Returns the theme default when the element provides no usable font — i.e. it
+// omits fontFamily (`undefined`), sets it to `"inherit"`, or leaves it empty
+// (`""` / `null`). The CMS emits an empty string / null for "no font selected",
+// so those must fall back to the configured default too — otherwise a falsy
+// family reaches `resolveFontFamily`, which returns `undefined` (system font)
+// and silently ignores the theme default.
 export const resolveInheritedFontFamily = (
-  elementFontFamily: string | undefined,
+  elementFontFamily: string | null | undefined,
   themeDefault: string | undefined
 ): string | undefined => {
-  if (elementFontFamily === undefined || elementFontFamily === "inherit") {
+  if (!elementFontFamily || elementFontFamily === "inherit") {
     return themeDefault;
   }
   return elementFontFamily;

--- a/packages/onboarding/CHANGELOG.md
+++ b/packages/onboarding/CHANGELOG.md
@@ -8,6 +8,15 @@ All notable changes to `@rocapine/react-native-onboarding` are documented here.
 
 ---
 
+## [1.44.4] - 2026-06-16
+
+### Changed
+
+- Version sync with `@rocapine/react-native-onboarding-ui@1.44.4` (empty/null
+  `fontFamily` now falls back to the theme default). No headless changes.
+
+---
+
 ## [1.44.3] - 2026-06-16
 
 ### Fixed

--- a/packages/onboarding/package.json
+++ b/packages/onboarding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocapine/react-native-onboarding",
-  "version": "1.44.3",
+  "version": "1.44.4",
   "description": "Headless React Native SDK for Rocapine Onboarding Studio - Data fetching, state management, and hooks",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Problem

When a typography element (`Text`, `Button`, `Input`, `RadioGroup`, `CheckboxGroup`, `WheelPicker`, `AnimatedText`, rich-text spans) was given **no font** — or `"inherit"` — it did **not** fall back to the configured `theme.typography.defaultFontFamily`.

Root cause: `resolveInheritedFontFamily` only treated `undefined` and `"inherit"` as "use the default". The CMS emits an **empty string (`""`)** or `null` for "no font selected", which slipped through unchanged. A falsy family then reaches the headless `resolveFontFamily`, whose first line is `if (!family) return undefined` → the element renders in the **system font**, silently ignoring the configured default.

## Fix

`resolveInheritedFontFamily` (`elements/shared.ts`) now treats any falsy value (`""` / `null` / `undefined`) **and** `"inherit"` as "use the theme default":

```ts
if (!elementFontFamily || elementFontFamily === "inherit") {
  return themeDefault;
}
```

Single-point fix — every text-rendering element routes its font through this helper (incl. item-label maps and native-control `itemStyle`), so all are covered. Param type widened to `string | null | undefined` to accept the CMS's `null`.

## Testing

- `type:check` clean (both packages).
- `build` clean.
- onboarding-ui has no test runner (zero existing tests; the helper is pure and trivial) — verified via typecheck/build and by tracing all call sites.

## Version

Bump both packages + plugin to **1.44.4**; changelog entries added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)