### PR TITLE
🐛 Fix staggered autoplay ProgressIndicator loader bars resetting — v1.44.5

### DIFF
--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-onboarding",
-  "version": "1.44.4",
+  "version": "1.44.5",
   "description": "End-to-end workflow for building and updating Rocapine Onboarding Studio flows: author step JSON, integrate the headless + UI SDKs, customize theme/components, and review onboarding quality.",
   "author": {
     "name": "Rocapine",

--- a/packages/onboarding-ui/CHANGELOG.md
+++ b/packages/onboarding-ui/CHANGELOG.md
@@ -9,6 +9,33 @@ here.
 
 ---
 
+## [1.44.5] - 2026-06-16
+
+### Fixed
+
+- **Staggered autoplay `ProgressIndicator` loader bars no longer reset to
+  empty.** When several `autoplay` linear bars ran on one screen (e.g. a
+  "curating your profile…" loader), bars that finished early painted empty while
+  only the last-finishing bar stayed filled — even though every bar's bound
+  variable correctly reached its max (so `renderWhen: eq max` checkmarks stayed
+  visible, exposing the desync). Cause: each autoplay bar wrote its bound
+  variable on every animation step (~20×/s), and every `setVariable` re-rendered
+  all ComposableScreen variable consumers; on Fabric / Reanimated 4 that
+  re-render storm reverted the already-settled animated fill of sibling bars.
+  Fixes:
+  - Autoplay bars now write the bound variable only at the sweep **boundaries**
+    (start / completion) instead of on every step, eliminating the re-render
+    storm. The live numeric `%` is still rendered natively via `showLabel`.
+    (A consumer interpolating the variable mid-sweep with `{{var}}` now sees it
+    jump min→max — use `showLabel` for a live readout.)
+  - The linear fill is driven by a left-anchored `scaleX` transform instead of
+    an animated percentage `width`, which commits reliably on Fabric.
+  - Autoplay progress is seeded from the bound variable on mount, so a completed
+    bar is restored to full if the screen subtree remounts.
+  - Added dependency arrays to the animated worklets to avoid mapper churn.
+
+---
+
 ## [1.44.4] - 2026-06-16
 
 ### Fixed

--- a/packages/onboarding-ui/package.json
+++ b/packages/onboarding-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocapine/react-native-onboarding-ui",
-  "version": "1.44.4",
+  "version": "1.44.5",
   "description": "UI components and renderers for Rocapine Onboarding Studio - Built on top of the headless SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/ProgressIndicatorElement.tsx
+++ b/packages/onboarding-ui/src/UI/Pages/ComposableScreen/elements/ProgressIndicatorElement.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useRef } from "react";
 import { View, TextInput } from "react-native";
 import { z } from "zod";
 import Animated, {
@@ -109,15 +109,31 @@ export const ProgressIndicatorElementComponent = ({ element, ctx }: Props): Reac
   const boundValue = boundRaw !== undefined ? clamp(Number(boundRaw) || 0, minValue, maxValue) : undefined;
   const target = autoplay ? maxValue : clamp(boundValue ?? props.value ?? initialValue, minValue, maxValue);
 
-  const progress = useSharedValue(initialValue);
+  // (autoplay) Seed from the persisted bound variable at mount, NOT always from
+  // initialValue. The variable store lives in a provider that can sit ABOVE a
+  // Suspense boundary, so if the screen subtree remounts (e.g. a parent query
+  // re-suspends on a locale change) the variable survives but this local
+  // sharedValue would otherwise reset to 0 — desyncing a completed bar's fill
+  // from its already-at-max variable (and any `renderWhen: eq max` checkmark
+  // that stays visible). Captured once per mount in a ref so the per-step
+  // variable writes this bar makes don't feed back into the seed.
+  const autoplaySeedRef = useRef(
+    autoplay && boundValue !== undefined ? boundValue : initialValue
+  );
+  const progress = useSharedValue(autoplaySeedRef.current);
 
-  // (autoplay) Write the step-snapped value to the bound variable. The label is
-  // rendered natively (see labelAnimatedProps below), so it does NOT go through
-  // React state — this reaction's ONLY job is the variable write.
-  // Reaction input is the *step-snapped* value, so the JS callback fires only
-  // when the snapped value changes ((maxValue-minValue)/step hops/sweep) rather
-  // than every frame — avoids a per-frame context write storm (setVariable
-  // re-renders all variable consumers). Coarse `step` for large ranges.
+  // (autoplay) Write the bound variable ONLY at the sweep boundaries (start /
+  // completion) — NOT on every step. Writing each step calls setVariable ~20×/s,
+  // which re-renders every ComposableScreen variable consumer. On Fabric /
+  // Reanimated 4 that re-render storm reverts the *already-settled* animated
+  // fill of sibling bars that finished earlier: their value stays at max but the
+  // bar paints empty, and only the last-finishing bar (after which no more
+  // writes occur) stays filled — the staggered-loader bug. Boundaries are all a
+  // bound variable needs for the common `renderWhen` loader pattern
+  // (`lt max` label → `eq max` checkmark); the live numeric % is rendered
+  // natively from the shared value (labelAnimatedProps), independent of writes.
+  // Trade-off: a consumer interpolating the variable mid-sweep ({{var}}) sees it
+  // jump min→max — use `showLabel` for a live readout instead.
   const showLabel = props.showLabel ?? false;
   const variableName = props.variableName;
   const writeVariable = (v: number) => {
@@ -141,7 +157,11 @@ export const ProgressIndicatorElementComponent = ({ element, ctx }: Props): Reac
     },
     (snapped, prev) => {
       if (snapped === prev) return;
-      if (writesVariable) runOnJS(writeVariable)(snapped);
+      // Boundaries only — see the writeVariable comment above. Intermediate
+      // steps are intentionally dropped to avoid the per-step re-render storm.
+      if (writesVariable && (snapped <= minValue || snapped >= maxValue)) {
+        runOnJS(writeVariable)(snapped);
+      }
     },
     [writesVariable, variableName, minValue, maxValue, step]
   );
@@ -158,15 +178,21 @@ export const ProgressIndicatorElementComponent = ({ element, ctx }: Props): Reac
     return { text: t, defaultValue: t } as object;
   }, [minValue, maxValue, step, labelSuffix]);
 
-  // Autoplay: animate initialValue -> maxValue, optionally looping, after `delay`.
+  // Autoplay: animate seed -> maxValue, optionally looping, after `delay`.
+  // `seed` is the mount-time value (persisted variable on a remount, else
+  // initialValue) — see autoplaySeedRef above. A bar already at maxValue (a
+  // completed bar restored after a remount) stays full and does NOT replay its
+  // sweep; a partially-filled bar resumes from where it was rather than from 0.
   useEffect(() => {
     if (!autoplay) return;
-    progress.value = initialValue;
+    const seed = autoplaySeedRef.current;
+    progress.value = seed;
+    if (seed >= maxValue) return () => cancelAnimation(progress);
     const anim = withTiming(maxValue, { duration, easing });
     const looped = loop ? withRepeat(anim, -1, false) : anim;
     progress.value = delay > 0 ? withDelay(delay, looped) : looped;
     return () => cancelAnimation(progress);
-  }, [autoplay, loop, duration, delay, easing, initialValue, maxValue]);
+  }, [autoplay, loop, duration, delay, easing, maxValue]);
 
   // Bound / static (non-autoplay): animate toward the current target after `delay`.
   useEffect(() => {
@@ -182,14 +208,28 @@ export const ProgressIndicatorElementComponent = ({ element, ctx }: Props): Reac
   const radius = (size - strokeWidth) / 2;
   const circumference = 2 * Math.PI * radius;
 
+  // Explicit deps arrays (same reason as the useAnimatedReaction above). An
+  // autoplay ProgressIndicator writes its variable every step → setVariable
+  // re-renders the whole tree ~20×/s; without deps these mappers are torn down
+  // and rebuilt on every one of those renders, needlessly churning the
+  // UI-thread mapper scheduler. Keying on the primitives the worklet reads keeps
+  // each mapper stable across renders.
   const animatedCircleProps = useAnimatedProps(() => {
     const frac = range > 0 ? (progress.value - minValue) / range : 0;
     return { strokeDashoffset: circumference * (1 - frac) };
-  });
+  }, [range, minValue, circumference]);
+  // Drive the linear fill with a `scaleX` transform anchored to the left edge —
+  // NOT an animated percentage `width`. On Fabric / Reanimated 4 an animated
+  // layout prop (percentage width) updates the sharedValue every frame but does
+  // not reliably commit to layout, so the bar's *static* mount value paints but
+  // the per-frame sweep does not — the value reaches 100 (the bound variable +
+  // any `eq max` checkmark update fine) while the bar stays visually empty. A
+  // transform is GPU-driven, commits every frame, and has no such limitation.
   const animatedFillStyle = useAnimatedStyle(() => {
     const frac = range > 0 ? (progress.value - minValue) / range : 0;
-    return { width: `${frac * 100}%` };
-  });
+    const clamped = frac < 0 ? 0 : frac > 1 ? 1 : frac;
+    return { transform: [{ scaleX: clamped }] };
+  }, [range, minValue]);
 
   const containerStyle = {
     alignSelf: props.alignSelf,
@@ -279,7 +319,13 @@ export const ProgressIndicatorElementComponent = ({ element, ctx }: Props): Reac
       >
         <Animated.View
           style={[
-            { height: "100%", backgroundColor: color, borderRadius: props.borderRadius ?? barHeight / 2 },
+            {
+              width: "100%",
+              height: "100%",
+              backgroundColor: color,
+              borderRadius: props.borderRadius ?? barHeight / 2,
+              transformOrigin: "left",
+            },
             animatedFillStyle,
           ]}
         />

--- a/packages/onboarding/CHANGELOG.md
+++ b/packages/onboarding/CHANGELOG.md
@@ -8,6 +8,16 @@ All notable changes to `@rocapine/react-native-onboarding` are documented here.
 
 ---
 
+## [1.44.5] - 2026-06-16
+
+### Changed
+
+- Version sync with `@rocapine/react-native-onboarding-ui@1.44.5` (staggered
+  autoplay `ProgressIndicator` loader bars no longer reset to empty). No
+  headless changes.
+
+---
+
 ## [1.44.4] - 2026-06-16
 
 ### Changed

--- a/packages/onboarding/package.json
+++ b/packages/onboarding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocapine/react-native-onboarding",
-  "version": "1.44.4",
+  "version": "1.44.5",
   "description": "Headless React Native SDK for Rocapine Onboarding Studio - Data fetching, state management, and hooks",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Problem

On a screen with several `autoplay` linear `ProgressIndicator` bars (e.g. a "Curating your profile…" loader with three staggered bars), bars that finished early rendered **empty** while only the **last-finishing** bar stayed filled — even though every bar's bound variable correctly reached its max (so `renderWhen: eq max` checkmarks stayed visible, exposing a value-vs-fill desync).

## Root cause

Each autoplay bar wrote its bound variable on **every animation step (~20×/s)**. Every `setVariable` re-renders all ComposableScreen variable consumers, so three bars produced a sustained re-render storm. On Fabric / Reanimated 4 that storm **reverts the already-settled animated fill** of sibling bars (their shared value stays at max, but the bar paints empty). The last bar survives only because no further writes happen after it completes.

Confirmed by logging the per-step variable timeline: values climbed `0→100` monotonically with **no remount and no effect re-run**, yet earlier bars emptied — and gating the writes to boundaries made all bars hold.

## Fix (`onboarding-ui` — `ProgressIndicatorElement`)

- **Write the bound variable only at sweep boundaries** (start / completion) instead of every step — eliminates the re-render storm. The live numeric `%` is still rendered natively via `showLabel`. _Trade-off:_ a consumer interpolating the variable mid-sweep with `{{var}}` now sees it jump min→max; use `showLabel` for a live readout.
- **Drive the linear fill with a left-anchored `scaleX` transform** instead of an animated percentage `width` — transforms commit reliably on Fabric.
- **Seed autoplay progress from the bound variable on mount** — a completed bar is restored to full if the screen subtree ever remounts.
- **Add dependency arrays** to the animated worklets to reduce mapper churn.

Headless package: no functional change (version sync only).

## Release

Patch bump **1.44.4 → 1.44.5** (both packages + plugin), CHANGELOGs updated.

## Test plan

- Repro the staggered three-bar loader and confirm all bars fill and stay filled with checkmarks (verified against the `harmony` app on a French-locale device, where the bug was originally reported).

🤖 Generated with [Claude Code](https://claude.com/claude-code)